### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,5 +1,8 @@
 name: Validate
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/BigThunderSR/ha-legacy-gsm-sms/security/code-scanning/2](https://github.com/BigThunderSR/ha-legacy-gsm-sms/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will define the least privileges required for the workflow. Based on the provided workflow, it appears that the jobs only need to read repository contents. Therefore, we will set `contents: read` as the permission. This ensures that the workflow does not inadvertently inherit write permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
