### PR TITLE
chore: add devcontainer for isolated development

### DIFF
--- a/.devcontainer/default/devcontainer.json
+++ b/.devcontainer/default/devcontainer.json
@@ -1,0 +1,17 @@
+{
+  "name": "ha-legacy-gsm-sms (Build)",
+  "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+  "features": {
+    "ghcr.io/devcontainers/features/docker-in-docker:2": {},
+    "ghcr.io/devcontainers/features/github-cli:1": {}
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "timonwong.shellcheck",
+        "ms-azuretools.vscode-docker"
+      ]
+    }
+  },
+  "mounts": []
+}

--- a/.devcontainer/default/devcontainer.json
+++ b/.devcontainer/default/devcontainer.json
@@ -2,7 +2,7 @@
   "name": "ha-legacy-gsm-sms (Build)",
   "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
   "features": {
-    "ghcr.io/devcontainers/features/docker-in-docker:2": {},
+    "ghcr.io/devcontainers/features/docker-in-docker:2": { "moby": false },
     "ghcr.io/devcontainers/features/github-cli:1": {}
   },
   "customizations": {

--- a/.devcontainer/ha/devcontainer.json
+++ b/.devcontainer/ha/devcontainer.json
@@ -1,0 +1,25 @@
+{
+  "name": "ha-legacy-gsm-sms (Home Assistant)",
+  "image": "ghcr.io/home-assistant/devcontainer:addons",
+  "features": {
+    "ghcr.io/devcontainers/features/github-cli:1": {}
+  },
+  "forwardPorts": [
+    8123
+  ],
+  "portsAttributes": {
+    "8123": {
+      "label": "Home Assistant",
+      "onAutoForward": "notify"
+    }
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "timonwong.shellcheck",
+        "ms-azuretools.vscode-docker"
+      ]
+    }
+  },
+  "mounts": []
+}

--- a/renovate.json
+++ b/renovate.json
@@ -16,7 +16,8 @@
   "pip_requirements": {
     "managerFilePatterns": [
       "/(^|/)requirements[\\w-]*\\.txt$/"
-    ]
+    ],
+    "rangeStrategy": "bump"
   },
   "packageRules": [
     {

--- a/renovate.json
+++ b/renovate.json
@@ -9,6 +9,10 @@
   ],
   "prConcurrentLimit": 0,
   "prHourlyLimit": 0,
+  "ignorePaths": [
+    "z-addon-old-test/",
+    "temp-pavelve/"
+  ],
   "pip_requirements": {
     "managerFilePatterns": [
       "/(^|/)requirements[\\w-]*\\.txt$/"
@@ -54,6 +58,11 @@
       "matchManagers": [
         "dockerfile"
       ],
+      "addLabels": [
+        "dockerfile"
+      ]
+    },
+    {
       "matchPackageNames": [
         "/dockerfile/"
       ],


### PR DESCRIPTION
Add multi-config devcontainer: default (build-only with Docker-in-Docker) and HA (full Home Assistant addon dev). No host filesystem mounts.