### PR TITLE
ci: add code style enforcement (black + isort + flake8)

### DIFF
--- a/.github/scripts/update_network_codes.py
+++ b/.github/scripts/update_network_codes.py
@@ -1,15 +1,15 @@
 #!/usr/bin/env python3
 """Update network operator codes from public sources."""
 
-import json
-import re
-import sys
 from datetime import datetime
 from email.utils import parsedate_to_datetime
+import json
 from pathlib import Path
+import re
+import sys
 
-import requests
 from bs4 import BeautifulSoup
+import requests
 
 # Public data sources - multiple fallback options
 # Each source will be checked for availability and last update time
@@ -50,7 +50,7 @@ SOURCES = [
 # Wikipedia MVNO list pages (for reference - not currently used due to lack of MCC-MNC codes)
 # When adding new MVNOs to MANUAL_OVERRIDES, check these pages for updates:
 # - USA: https://en.wikipedia.org/wiki/List_of_United_States_mobile_virtual_network_operators
-# - Canada: https://en.wikipedia.org/wiki/List_of_Canadian_mobile_virtual_network_operators  
+# - Canada: https://en.wikipedia.org/wiki/List_of_Canadian_mobile_virtual_network_operators
 # - Mexico: https://en.wikipedia.org/wiki/List_of_mobile_network_operators_of_the_Americas#Mexico
 #
 # To find MCC-MNC codes for MVNOs:
@@ -112,14 +112,12 @@ MANUAL_OVERRIDES = {
     "314720": "OXIO",  # MVNO
     "314730": "TextNow",  # MVNO
     "314790": "Neuner Mobile Technologies",  # MVNO
-    
     # Canada MVNOs (MCC 302)
     "302100": "dotmobile",  # Data on Tap MVNO
     "302160": "Sugar Mobile",  # Iristel MVNO
     "302340": "Execulink",  # MVNO
     "302370": "Fido",  # Rogers MVNO (former Microcell)
     "302760": "Public Mobile",  # Telus MVNO
-    
     # Mexico MVNOs (MCC 334)
     "334030": "Movistar",  # MVNO on AT&T
     "334110": "Maxcom Telecomunicaciones",  # MVNO
@@ -129,123 +127,118 @@ MANUAL_OVERRIDES = {
     "334200": "Virgin Mobile",  # MVNO
     "334210": "YO Mobile",  # Yonder Media Mobile MVNO
     "334220": "Megamóvil",  # Mega Cable MVNO
-    
     # Fix syntax errors from unescaped quotes in source data
     "24706": "SIA UNISTARS",  # Latvia - Source has broken quotes
-    "24707": "SIA MEGATEL",   # Latvia - Source has broken quotes
+    "24707": "SIA MEGATEL",  # Latvia - Source has broken quotes
     "25509": "PRJSC Farlep-Invest",  # Ukraine - Source has broken quotes
 }
 
 
 def get_source_last_update(source, response):
     """Get the last update time for a source.
-    
+
     First tries the Last-Modified header from the raw file response,
     then falls back to GitHub API if needed.
-    
+
     Args:
         source: Dictionary containing 'repo' and 'file' keys for GitHub API lookup
         response: requests.Response object from fetching the raw file
-    
+
     Returns:
         datetime object representing last update time, or None if unavailable
     """
     # Try to get Last-Modified header from the response
-    last_modified = response.headers.get('Last-Modified')
+    last_modified = response.headers.get("Last-Modified")
     if last_modified:
         try:
             # Parse HTTP date format (RFC 2822)
             return parsedate_to_datetime(last_modified)
         except (ValueError, TypeError):
             pass
-    
+
     # Fallback: Try GitHub API (may hit rate limits, only for GitHub sources)
-    if source.get('repo') and source.get('file'):
+    if source.get("repo") and source.get("file"):
         try:
             url = f"https://api.github.com/repos/{source['repo']}/commits"
             params = {"path": source["file"], "per_page": 1}
-            
+
             api_response = requests.get(url, params=params, timeout=10)
             if api_response.status_code == 200:
                 commits = api_response.json()
                 if commits:
                     commit_date_str = commits[0]["commit"]["committer"]["date"]
                     # Parse ISO 8601 date
-                    commit_date = datetime.fromisoformat(commit_date_str.replace('Z', '+00:00'))
+                    commit_date = datetime.fromisoformat(
+                        commit_date_str.replace("Z", "+00:00")
+                    )
                     return commit_date
         except (requests.exceptions.RequestException, ValueError, KeyError, IndexError):
             pass
-    
+
     return None
 
 
 def scrape_wikipedia_mvnos():
     """Scrape MVNO information from Wikipedia pages.
-    
+
     Returns:
         Dictionary mapping MCC-MNC codes to MVNO operator names
     """
     mvno_overrides = {}
-    
+
     print("\nScraping MVNO data from Wikipedia...")
-    
+
     # Use a proper User-Agent header to avoid 403 errors
     headers = {
-        'User-Agent': (
-            'Mozilla/5.0 (compatible; MCC-MNC-Updater/1.0; '
-            '+https://github.com/BigThunderSR/ha-legacy-gsm-sms)'
+        "User-Agent": (
+            "Mozilla/5.0 (compatible; MCC-MNC-Updater/1.0; "
+            "+https://github.com/BigThunderSR/ha-legacy-gsm-sms)"
         )
     }
-    
+
     for wiki_source in WIKIPEDIA_MVNO_SOURCES:
         try:
-            country = wiki_source['country']
+            country = wiki_source["country"]
             print(f"  Fetching {country} MVNOs from Wikipedia...")
-            response = requests.get(
-                wiki_source['url'], headers=headers, timeout=15
-            )
+            response = requests.get(wiki_source["url"], headers=headers, timeout=15)
             response.raise_for_status()
-            
-            soup = BeautifulSoup(response.text, 'html.parser')
-            
+
+            soup = BeautifulSoup(response.text, "html.parser")
+
             # Find all tables in the page
-            tables = soup.find_all('table', class_='wikitable')
-            
+            tables = soup.find_all("table", class_="wikitable")
+
             for table in tables:
-                rows = table.find_all('tr')
-                
+                rows = table.find_all("tr")
+
                 # Try to identify header columns
                 headers = []
                 if rows:
                     header_row = rows[0]
-                    header_cells = header_row.find_all(['th', 'td'])
-                    headers = [
-                        th.get_text(strip=True).lower()
-                        for th in header_cells
-                    ]
-                
+                    header_cells = header_row.find_all(["th", "td"])
+                    headers = [th.get_text(strip=True).lower() for th in header_cells]
+
                 # Look for columns containing MCC, MNC, and operator name
                 mcc_col = mnc_col = name_col = None
                 for idx, header in enumerate(headers):
-                    if 'mcc' in header:
+                    if "mcc" in header:
                         mcc_col = idx
-                    elif 'mnc' in header:
+                    elif "mnc" in header:
                         mnc_col = idx
                     elif any(
-                        term in header
-                        for term in ['operator', 'brand', 'name', 'mvno']
+                        term in header for term in ["operator", "brand", "name", "mvno"]
                     ):
                         if name_col is None:  # Use first name-like column
                             name_col = idx
-                
+
                 # Process data rows
                 for row in rows[1:]:  # Skip header row
-                    cells = row.find_all(['td', 'th'])
+                    cells = row.find_all(["td", "th"])
                     if len(cells) < 2:
                         continue
-                    
+
                     mcc = mnc = name = None
-                    
+
                     # Extract values based on identified columns
                     if mcc_col is not None and mcc_col < len(cells):
                         mcc = cells[mcc_col].get_text(strip=True)
@@ -253,20 +246,16 @@ def scrape_wikipedia_mvnos():
                         mnc = cells[mnc_col].get_text(strip=True)
                     if name_col is not None and name_col < len(cells):
                         name = cells[name_col].get_text(strip=True)
-                    
+
                     # If we didn't find columns by header, try pattern matching
                     if not mcc or not mnc or not name:
                         for cell in cells:
                             text = cell.get_text(strip=True)
                             # Look for MCC pattern
-                            if re.match(r'^\d{3}$', text) and not mcc:
+                            if re.match(r"^\d{3}$", text) and not mcc:
                                 mcc = text
                             # Look for MNC pattern (after finding MCC)
-                            elif (
-                                re.match(r'^\d{2,3}$', text)
-                                and mcc
-                                and not mnc
-                            ):
+                            elif re.match(r"^\d{2,3}$", text) and mcc and not mnc:
                                 mnc = text
                             # Look for operator name
                             elif (
@@ -276,51 +265,49 @@ def scrape_wikipedia_mvnos():
                                 and not name
                             ):
                                 name = text
-                    
+
                     # Clean up and validate
                     if mcc and mnc and name:
                         mcc = mcc.strip()
                         mnc = mnc.strip().zfill(2)  # Pad MNC to 2 digits
                         name = name.strip()
-                        
+
                         # Validate MCC matches expected prefixes
-                        if mcc in wiki_source['mcc_prefixes']:
+                        if mcc in wiki_source["mcc_prefixes"]:
                             code = f"{mcc}{mnc}"
                             # Only add if it's a valid 5-6 digit code
                             if 5 <= len(code) <= 6 and code.isdigit():
                                 # Clean up common Wikipedia formatting
                                 # Remove reference markers [1]
-                                name = re.sub(r'\[\d+\]', '', name)
+                                name = re.sub(r"\[\d+\]", "", name)
                                 # Normalize whitespace
-                                name = re.sub(r'\s+', ' ', name)
+                                name = re.sub(r"\s+", " ", name)
                                 mvno_overrides[code] = name
-            
+
             # Count codes found for this country
-            prefixes = tuple(wiki_source['mcc_prefixes'])
+            prefixes = tuple(wiki_source["mcc_prefixes"])
             found = sum(
-                1
-                for code in mvno_overrides.keys()
-                if code.startswith(prefixes)
+                1 for code in mvno_overrides.keys() if code.startswith(prefixes)
             )
             if found > 0:
                 print(f"    ✓ Found {found} {country} MVNO codes")
             else:
                 print(f"    ⚠ No MVNOs found (table format may have changed)")
-                
+
         except requests.exceptions.RequestException as e:
             print(f"    ✗ Failed to fetch {country} MVNOs: {e}")
         except Exception as e:
             print(f"    ✗ Error parsing {country} MVNOs: {e}")
-    
+
     return mvno_overrides
 
 
 def fetch_from_source(source):
     """Fetch MCC-MNC data from a specific source.
-    
+
     Args:
         source: Dictionary containing 'name', 'url', 'repo', and 'file' keys
-    
+
     Returns:
         Tuple of (data, last_update) where data is the JSON response or None,
         and last_update is a datetime object or None
@@ -328,142 +315,155 @@ def fetch_from_source(source):
     try:
         print(f"  Trying source: {source['name']}")
         print(f"    URL: {source['url']}")
-        
+
         response = requests.get(source["url"], timeout=30)
         response.raise_for_status()
-        
+
         data = response.json()
-        
+
         # Validate that we got data
         if not data:
             print(f"    Warning: Source returned empty data")
             return None, None
-        
+
         entry_count = len(data) if isinstance(data, (list, dict)) else 0
         print(f"    ✓ Success: Retrieved {entry_count} entries")
-        
+
         # Get last update time for this source (pass the response for headers)
         last_update = get_source_last_update(source, response)
         if last_update:
             print(f"    Last updated: {last_update.strftime('%Y-%m-%d %H:%M:%S UTC')}")
         else:
             print(f"    Last updated: Unable to determine")
-        
+
         return data, last_update
-        
+
     except requests.exceptions.HTTPError as e:
         status = e.response.status_code if e.response is not None else "Unknown"
         print(f"    ✗ HTTP Error {status}: {e}")
         return None, None
-    except (requests.exceptions.RequestException, json.JSONDecodeError, ValueError, KeyError) as e:
+    except (
+        requests.exceptions.RequestException,
+        json.JSONDecodeError,
+        ValueError,
+        KeyError,
+    ) as e:
         print(f"    ✗ Failed: {e}")
         return None, None
 
 
 def parse_data_to_codes(data, source_format):
     """Parse data from various source formats into our standard format.
-    
+
     Args:
         data: Raw JSON data from the source (list or dict)
         source_format: Format type, currently supports "list"
-    
+
     Returns:
         Dictionary mapping MCCMNC codes to operator names
     """
     codes = {}
-    
+
     if not data:
         return codes
-    
+
     if source_format == "list":
         # Handle list-based formats (most sources)
         for entry in data:
             # Get values, ensuring they're not None
-            mcc = entry.get('mcc')
-            mnc = entry.get('mnc')
-            
+            mcc = entry.get("mcc")
+            mnc = entry.get("mnc")
+
             # Skip if mcc or mnc is None or not convertible to string
             if mcc is None or mnc is None:
                 continue
-            
+
             # Convert to string
             mcc = str(mcc).strip()
             mnc = str(mnc).strip()
-            
+
             # Try different field names for operator name
-            operator = (entry.get('network') or 
-                       entry.get('brand') or 
-                       entry.get('operator') or '')
-            
+            operator = (
+                entry.get("network")
+                or entry.get("brand")
+                or entry.get("operator")
+                or ""
+            )
+
             # Ensure we have valid numeric MCC/MNC and operator name
             if mcc and mnc and operator and mcc.isdigit() and mnc.isdigit():
                 # Pad MNC to 2-3 digits as needed
                 code = f"{mcc}{mnc.zfill(2)}"
                 codes[code] = operator
-    
+
     return codes
 
 
 def fetch_mcc_mnc_data():
     """Fetch MCC-MNC data from the most recently updated available source.
-    
+
     Returns:
         Dictionary mapping MCCMNC codes to operator names, or empty dict if no sources available
     """
     print("\nChecking all available sources...")
-    print("="*70)
-    
+    print("=" * 70)
+
     available_sources = []
-    
+
     # Try each source and collect successful ones
     for source in SOURCES:
         data, last_update = fetch_from_source(source)
-        
+
         if data:
             parsed_codes = parse_data_to_codes(data, source["format"])
             if parsed_codes:
-                available_sources.append({
-                    "source": source,
-                    "data": parsed_codes,
-                    "last_update": last_update,
-                    "count": len(parsed_codes)
-                })
-    
-    print("="*70)
-    
+                available_sources.append(
+                    {
+                        "source": source,
+                        "data": parsed_codes,
+                        "last_update": last_update,
+                        "count": len(parsed_codes),
+                    }
+                )
+
+    print("=" * 70)
+
     if not available_sources:
         print("\n✗ ERROR: No sources were available!")
         return {}
-    
+
     # Separate sources with known update times from those without
     sources_with_dates = [s for s in available_sources if s["last_update"]]
     sources_without_dates = [s for s in available_sources if not s["last_update"]]
-    
+
     # Sort sources with dates by most recent first, then by count
-    sources_with_dates.sort(
-        key=lambda x: (x["last_update"], x["count"]),
-        reverse=True
-    )
-    
+    sources_with_dates.sort(key=lambda x: (x["last_update"], x["count"]), reverse=True)
+
     # Sort sources without dates by count only
     sources_without_dates.sort(key=lambda x: x["count"], reverse=True)
-    
+
     # Combine: prefer sources with known update dates
     sorted_sources = sources_with_dates + sources_without_dates
-    
+
     # Display all available sources
     print(f"\n✓ Found {len(available_sources)} working source(s):")
     for i, src in enumerate(sorted_sources, 1):
-        update_info = src["last_update"].strftime('%Y-%m-%d') if src["last_update"] else "unknown"
+        update_info = (
+            src["last_update"].strftime("%Y-%m-%d") if src["last_update"] else "unknown"
+        )
         marker = "➜ SELECTED" if i == 1 else ""
-        print(f"  {i}. {src['source']['name']} - {src['count']} codes (updated: {update_info}) {marker}")
-    
+        print(
+            f"  {i}. {src['source']['name']} - {src['count']} codes (updated: {update_info}) {marker}"
+        )
+
     # Use the most recently updated source (or most entries if no dates available)
     selected = sorted_sources[0]
-    selection_reason = "most recently updated" if selected["last_update"] else "most entries"
+    selection_reason = (
+        "most recently updated" if selected["last_update"] else "most entries"
+    )
     print(f"\n✓ Using {selection_reason} source: {selected['source']['name']}")
     print(f"  Total network codes: {selected['count']}")
-    
+
     return selected["data"]
 
 
@@ -477,34 +477,32 @@ def get_mcc_prefix(code):
 def parse_existing_file(existing_file):
     """Parse existing file preserving all structure, comments, and docstrings."""
     content = existing_file.read_text()
-    
+
     # Extract the docstring
     docstring_match = re.match(r'^(""".*?""")', content, re.DOTALL)
-    docstring = docstring_match.group(1) if docstring_match else ''
-    
+    docstring = docstring_match.group(1) if docstring_match else ""
+
     # Find the NETWORK_OPERATORS dictionary
     dict_match = re.search(
-        r'(NETWORK_OPERATORS\s*=\s*\{)(.*?)(\n\})',
-        content,
-        re.DOTALL
+        r"(NETWORK_OPERATORS\s*=\s*\{)(.*?)(\n\})", content, re.DOTALL
     )
-    
+
     if not dict_match:
         print("Error: Could not find NETWORK_OPERATORS in existing file")
         return None, None, None, None
-    
+
     dict_content = dict_match.group(2)
-    
+
     # Parse entries while preserving comments and structure
     entries = {}
     lines_with_comments = []
     sections = {}  # Track which MCC prefixes appear in which sections
     current_section_comment = None
     current_section_codes = set()
-    
-    for line in dict_content.split('\n'):
+
+    for line in dict_content.split("\n"):
         # Preserve comment lines
-        if line.strip().startswith('#'):
+        if line.strip().startswith("#"):
             # Save previous section if it exists
             if current_section_comment and current_section_codes:
                 for code in current_section_codes:
@@ -512,10 +510,10 @@ def parse_existing_file(existing_file):
                     if mcc:
                         if mcc not in sections:
                             sections[mcc] = current_section_comment
-            
+
             current_section_comment = line
             current_section_codes = set()
-            lines_with_comments.append(('comment', line))
+            lines_with_comments.append(("comment", line))
         # Parse code entries
         else:
             match = re.match(r'\s*"(\d+)":\s*"([^"]+)",?', line)
@@ -523,10 +521,10 @@ def parse_existing_file(existing_file):
                 code, name = match.group(1), match.group(2)
                 entries[code] = name
                 current_section_codes.add(code)
-                lines_with_comments.append(('entry', code, name))
-            elif line.strip() == '':
-                lines_with_comments.append(('blank', line))
-    
+                lines_with_comments.append(("entry", code, name))
+            elif line.strip() == "":
+                lines_with_comments.append(("blank", line))
+
     # Don't forget the last section
     if current_section_comment and current_section_codes:
         for code in current_section_codes:
@@ -534,27 +532,27 @@ def parse_existing_file(existing_file):
             if mcc:
                 if mcc not in sections:
                     sections[mcc] = current_section_comment
-    
+
     # Extract function definitions after the dict
-    func_match = re.search(r'(\n\ndef get_network_name.*)', content, re.DOTALL)
-    functions = func_match.group(1) if func_match else ''
-    
+    func_match = re.search(r"(\n\ndef get_network_name.*)", content, re.DOTALL)
+    functions = func_match.group(1) if func_match else ""
+
     return docstring, entries, lines_with_comments, functions, sections
 
 
 def update_file_preserving_structure(existing_file, new_codes):
     """Update file while preserving docstrings, comments, and structure."""
-    
+
     result = parse_existing_file(existing_file)
     if result[0] is None:
         return False
-    
+
     docstring, existing_entries, structure, functions, sections = result
-    
+
     # Separate new codes into truly new ones and updates to existing ones
     updated_entries = existing_entries.copy()
     new_entries = {}
-    
+
     for code, name in new_codes.items():
         if code in existing_entries:
             # Code exists - check if name changed
@@ -565,22 +563,24 @@ def update_file_preserving_structure(existing_file, new_codes):
             # Code doesn't exist - it's a new entry
             updated_entries[code] = name
             new_entries[code] = name
-    
+
     if not new_entries:
         print(f"  No new entries to add to {existing_file.name}")
         return False
-    
+
     # Count truly new codes vs updates
     truly_new = [c for c in new_entries.keys() if c not in existing_entries]
     updates = [c for c in new_entries.keys() if c in existing_entries]
-    
-    print(f"  Processing {len(truly_new)} new codes and {len(updates)} updates for "
-          f"{existing_file.name}")
-    
+
+    print(
+        f"  Processing {len(truly_new)} new codes and {len(updates)} updates for "
+        f"{existing_file.name}"
+    )
+
     # Group new entries by MCC prefix for insertion into correct sections
     new_by_mcc = {}
     orphaned_codes = []
-    
+
     for code, name in new_entries.items():
         mcc = get_mcc_prefix(code)
         if mcc:
@@ -595,11 +595,11 @@ def update_file_preserving_structure(existing_file, new_codes):
         else:
             # No valid MCC prefix
             orphaned_codes.append((code, name))
-    
+
     # Sort entries within each MCC group
     for mcc in new_by_mcc:
         new_by_mcc[mcc].sort(key=lambda x: x[0])
-    
+
     # Group orphaned codes by MCC for better organization
     orphaned_by_mcc = {}
     for code, name in orphaned_codes:
@@ -610,39 +610,39 @@ def update_file_preserving_structure(existing_file, new_codes):
             orphaned_by_mcc[mcc].append((code, name))
         else:
             # Truly orphaned (no valid MCC)
-            if 'unknown' not in orphaned_by_mcc:
-                orphaned_by_mcc['unknown'] = []
-            orphaned_by_mcc['unknown'].append((code, name))
-    
+            if "unknown" not in orphaned_by_mcc:
+                orphaned_by_mcc["unknown"] = []
+            orphaned_by_mcc["unknown"].append((code, name))
+
     # Sort orphaned codes
     for mcc in orphaned_by_mcc:
         orphaned_by_mcc[mcc].sort(key=lambda x: x[0])
-    
+
     # Rebuild the file with updated entries but preserving structure
-    new_content_parts = [docstring, '\n\n']
-    
+    new_content_parts = [docstring, "\n\n"]
+
     # Add comment about the database
     new_content_parts.append(
-        '# Comprehensive database of mobile network operators by MCC+MNC\n'
+        "# Comprehensive database of mobile network operators by MCC+MNC\n"
     )
     new_content_parts.append('# Format: "MCCMNC": "Operator Name"\n')
-    new_content_parts.append('NETWORK_OPERATORS = {\n')
-    
+    new_content_parts.append("NETWORK_OPERATORS = {\n")
+
     # Reconstruct with preserved comments and insert new entries
     # in correct numerical order within their sections
     current_section_mcc = None
     section_entries_added = set()
     pending_new_codes = []  # Track new codes to insert in this section
-    
+
     for i, item in enumerate(structure):
-        if item[0] == 'comment':
+        if item[0] == "comment":
             # Before writing this comment, finalize any pending section
             if current_section_mcc and current_section_mcc in new_by_mcc:
                 section_entries_added.add(current_section_mcc)
-            
+
             # Write the comment
-            new_content_parts.append(item[1] + '\n')
-            
+            new_content_parts.append(item[1] + "\n")
+
             # Determine which MCC section this comment represents
             # For multi-MCC sections (e.g., "United States (MCC 310-316)"),
             # we need to load codes for ALL MCCs that map to this section
@@ -656,139 +656,137 @@ def update_file_preserving_structure(existing_file, new_codes):
                     # Add codes from this MCC to pending_new_codes
                     if mcc in new_by_mcc:
                         pending_new_codes.extend(new_by_mcc[mcc])
-            
+
             # Sort pending codes by code number for correct insertion order
             if pending_new_codes:
                 pending_new_codes.sort(key=lambda x: x[0])
-            
-        elif item[0] == 'entry':
+
+        elif item[0] == "entry":
             code = item[1]
             mcc = get_mcc_prefix(code)
-            
+
             # Check if this code's MCC belongs to the current section
             code_section = sections.get(mcc)
-            in_current_section = (code_section and current_section_mcc and
-                                  code_section == sections.get(current_section_mcc))
-            
+            in_current_section = (
+                code_section
+                and current_section_mcc
+                and code_section == sections.get(current_section_mcc)
+            )
+
             # Insert any pending new codes that come before this code
             # in numerical order (only if in the same section)
             if pending_new_codes and in_current_section:
                 codes_to_insert = []
                 remaining_codes = []
-                
+
                 for new_code, new_name in pending_new_codes:
                     if new_code < code:
                         codes_to_insert.append((new_code, new_name))
                     else:
                         remaining_codes.append((new_code, new_name))
-                
+
                 # Insert codes that come before current code
                 for new_code, new_name in codes_to_insert:
-                    new_content_parts.append(
-                        f'    "{new_code}": "{new_name}",\n'
-                    )
-                
+                    new_content_parts.append(f'    "{new_code}": "{new_name}",\n')
+
                 # Update pending list with remaining codes
                 pending_new_codes = remaining_codes
-            
+
             # Write the current entry
             name = updated_entries.get(code, item[2])
             new_content_parts.append(f'    "{code}": "{name}",\n')
-            
+
             # Check if this is the last entry in this section
             is_last_in_section = False
             if i + 1 < len(structure):
                 next_item = structure[i + 1]
-                if next_item[0] == 'comment':
+                if next_item[0] == "comment":
                     is_last_in_section = True
-                elif next_item[0] == 'blank':
-                    if (i + 2 < len(structure) and
-                            structure[i + 2][0] == 'comment'):
+                elif next_item[0] == "blank":
+                    if i + 2 < len(structure) and structure[i + 2][0] == "comment":
                         is_last_in_section = True
             else:
                 is_last_in_section = True
-            
+
             # If last entry in section, add any remaining pending codes
-            if (is_last_in_section and pending_new_codes and in_current_section):
+            if is_last_in_section and pending_new_codes and in_current_section:
                 for new_code, new_name in pending_new_codes:
-                    new_content_parts.append(
-                        f'    "{new_code}": "{new_name}",\n'
-                    )
+                    new_content_parts.append(f'    "{new_code}": "{new_name}",\n')
                 pending_new_codes = []
                 if current_section_mcc:
                     section_entries_added.add(current_section_mcc)
-                
-        elif item[0] == 'blank':
-            new_content_parts.append('\n')
-    
+
+        elif item[0] == "blank":
+            new_content_parts.append("\n")
+
     # Add orphaned codes (codes without existing MCC sections) organized by MCC
     if orphaned_by_mcc:
         total_orphaned = sum(len(codes) for codes in orphaned_by_mcc.values())
         print(f"    Adding {total_orphaned} codes in new MCC sections")
-        new_content_parts.append('\n    # Additional network codes (new MCC regions)\n')
-        
+        new_content_parts.append("\n    # Additional network codes (new MCC regions)\n")
+
         # Sort MCCs for consistent ordering
-        sorted_mccs = sorted([m for m in orphaned_by_mcc.keys() if m != 'unknown'])
-        if 'unknown' in orphaned_by_mcc:
-            sorted_mccs.append('unknown')
-        
+        sorted_mccs = sorted([m for m in orphaned_by_mcc.keys() if m != "unknown"])
+        if "unknown" in orphaned_by_mcc:
+            sorted_mccs.append("unknown")
+
         for mcc in sorted_mccs:
             codes = orphaned_by_mcc[mcc]
-            if mcc == 'unknown':
-                new_content_parts.append('\n    # Unclassified codes\n')
+            if mcc == "unknown":
+                new_content_parts.append("\n    # Unclassified codes\n")
             else:
                 # Add a basic comment for the new MCC section
-                new_content_parts.append(f'\n    # MCC {mcc}\n')
-            
+                new_content_parts.append(f"\n    # MCC {mcc}\n")
+
             for code, name in codes:
                 new_content_parts.append(f'    "{code}": "{name}",\n')
-    
-    new_content_parts.append('}\n')
-    
+
+    new_content_parts.append("}\n")
+
     # Add function definitions if they exist
     if functions:
         new_content_parts.append(functions)
-    
-    existing_file.write_text(''.join(new_content_parts))
+
+    existing_file.write_text("".join(new_content_parts))
     return True
 
 
 def main():
     """Main update process."""
     print("Fetching network operator data from public sources...")
-    
+
     # Fetch data from the most recently updated available source
     new_codes = fetch_mcc_mnc_data()
-    
+
     if not new_codes:
         print("\n✗ ERROR: Could not fetch data from any source!")
         sys.exit(1)
-    
+
     # Wikipedia scraping is currently disabled because Wikipedia MVNO pages
     # don't include MCC-MNC codes in a machine-readable format.
     # MVNOs must be maintained manually in the MANUAL_OVERRIDES dictionary.
     # See comments above WIKIPEDIA_MVNO_SOURCES for resources to find new MVNOs.
     wikipedia_mvnos = {}
-    
+
     # Uncomment to enable Wikipedia scraping (experimental):
     # try:
     #     wikipedia_mvnos = scrape_wikipedia_mvnos()
     # except Exception as e:
     #     print(f"\n⚠ Wikipedia scraping failed: {e}")
     #     print("  Continuing with manual overrides only...")
-    
+
     # Merge Wikipedia MVNOs with manual overrides
     # Manual overrides take precedence over Wikipedia data
     all_overrides = {}
     if wikipedia_mvnos:
         all_overrides.update(wikipedia_mvnos)  # Add Wikipedia data first
     all_overrides.update(MANUAL_OVERRIDES)  # Manual overrides win
-    
+
     # Apply all overrides to correct known issues in source data
     wiki_count = len(wikipedia_mvnos)
     manual_count = len(MANUAL_OVERRIDES)
     total_corrections = len(all_overrides)
-    
+
     if wiki_count > 0:
         print(
             f"\nApplying {total_corrections} corrections "
@@ -796,7 +794,7 @@ def main():
         )
     else:
         print(f"\nApplying {manual_count} manual corrections...")
-    
+
     for code, corrected_name in all_overrides.items():
         if code in new_codes:
             old_name = new_codes[code]
@@ -807,26 +805,26 @@ def main():
             # Code doesn't exist in source data, add it
             new_codes[code] = corrected_name
             print(f"  {code}: Added '{corrected_name}' (missing from source)")
-    
+
     # Update all network_codes.py files
     repo_root = Path(__file__).parent.parent.parent
-    
+
     files_updated = False
     for target in [
         repo_root / "custom_components" / "legacy_gsm_sms" / "network_codes.py",
         repo_root / "addon-gsm-gateway" / "network_codes.py",
         repo_root / "addon-test-current" / "network_codes.py",
         repo_root / "addon-test-pavelve" / "network_codes.py",
-        repo_root / "network_codes.py"
+        repo_root / "network_codes.py",
     ]:
         if not target.exists():
             print(f"Warning: {target} does not exist, skipping")
             continue
-        
+
         print(f"\nProcessing {target}...")
         if update_file_preserving_structure(target, new_codes):
             files_updated = True
-    
+
     if files_updated:
         print("\n✓ Update complete! New network codes added.")
     else:

--- a/.github/workflows/code-style.yml
+++ b/.github/workflows/code-style.yml
@@ -33,7 +33,6 @@ jobs:
   flake8:
     name: Flake8 (informational)
     runs-on: ubuntu-latest
-    continue-on-error: true
     steps:
       - uses: actions/checkout@v6
 
@@ -45,4 +44,6 @@ jobs:
         run: pip install flake8
 
       - name: Run flake8
-        run: flake8 --count --statistics
+        run: |
+          # --exit-zero so the job passes; issues show as warnings in the log
+          flake8 --count --statistics --exit-zero --format='%(path)s:%(row)d:%(col)d: %(code)s %(text)s'

--- a/.github/workflows/code-style.yml
+++ b/.github/workflows/code-style.yml
@@ -1,0 +1,48 @@
+name: Code Style
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  format-check:
+    name: Black + isort
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: Install formatters
+        run: pip install black isort
+
+      - name: Check black formatting
+        run: black --check --exclude '.venv*|temp-pavelve|z-addon-old-test' .
+
+      - name: Check import order
+        run: isort --check --skip .venv-ci-test --skip temp-pavelve --skip z-addon-old-test --profile black .
+
+  flake8:
+    name: Flake8 (informational)
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: Install flake8
+        run: pip install flake8
+
+      - name: Run flake8
+        run: flake8 --count --statistics

--- a/__init__.py
+++ b/__init__.py
@@ -3,14 +3,13 @@
 import logging
 
 import gammu
-import voluptuous as vol
-
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_DEVICE, CONF_NAME, Platform
 from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import config_validation as cv, discovery
 from homeassistant.helpers.typing import ConfigType
+import voluptuous as vol
 
 from .const import (
     ATTR_FLASH,

--- a/addon-gsm-gateway/mqtt_publisher.py
+++ b/addon-gsm-gateway/mqtt_publisher.py
@@ -10,25 +10,27 @@ Credits:
 Licensed under Apache License 2.0
 """
 
+import concurrent.futures
 import json
-import time
 import logging
-import threading
 import os
 import sys
-import requests
-from typing import Optional, Dict, Any
+import threading
+import time
+from typing import Any, Dict, Optional
+
 import paho.mqtt.client as mqtt
-import concurrent.futures
+import requests
+
 from network_codes import get_network_name
 
 logger = logging.getLogger(__name__)
 
 # SMS counter persistence file
-SMS_COUNTER_FILE = '/data/sms_counter.json'
+SMS_COUNTER_FILE = "/data/sms_counter.json"
 
 # Pending SMS queue persistence file
-SMS_QUEUE_FILE = '/data/pending_sms.json'
+SMS_QUEUE_FILE = "/data/pending_sms.json"
 
 # Default queue expiry time (1 hour)
 SMS_QUEUE_EXPIRY_SECONDS = 3600
@@ -37,7 +39,11 @@ SMS_QUEUE_EXPIRY_SECONDS = 3600
 class SMSQueue:
     """Manages pending SMS queue with persistence for retry after modem recovery"""
 
-    def __init__(self, queue_file: str = SMS_QUEUE_FILE, expiry_seconds: int = SMS_QUEUE_EXPIRY_SECONDS):
+    def __init__(
+        self,
+        queue_file: str = SMS_QUEUE_FILE,
+        expiry_seconds: int = SMS_QUEUE_EXPIRY_SECONDS,
+    ):
         self.queue_file = queue_file
         self.expiry_seconds = expiry_seconds
         self.pending = []
@@ -48,13 +54,15 @@ class SMSQueue:
         """Load pending SMS queue from JSON file"""
         try:
             if os.path.exists(self.queue_file):
-                with open(self.queue_file, 'r') as f:
+                with open(self.queue_file, "r") as f:
                     data = json.load(f)
-                    self.pending = data.get('pending', [])
+                    self.pending = data.get("pending", [])
                     # Clear expired messages on load
                     self._clear_expired()
                     if self.pending:
-                        logger.info(f"📥 Loaded {len(self.pending)} pending SMS from queue")
+                        logger.info(
+                            f"📥 Loaded {len(self.pending)} pending SMS from queue"
+                        )
                     else:
                         logger.info("📥 SMS queue is empty")
             else:
@@ -69,8 +77,8 @@ class SMSQueue:
             # Ensure /data directory exists
             os.makedirs(os.path.dirname(self.queue_file), exist_ok=True)
 
-            data = {'pending': self.pending}
-            with open(self.queue_file, 'w') as f:
+            data = {"pending": self.pending}
+            with open(self.queue_file, "w") as f:
                 json.dump(data, f, indent=2)
             logger.debug(f"📥 Saved SMS queue: {len(self.pending)} pending")
         except Exception as e:
@@ -80,12 +88,13 @@ class SMSQueue:
         """Remove expired messages from queue"""
         if not self.pending:
             return
-        
+
         current_time = time.time()
         before_count = len(self.pending)
         self.pending = [
-            msg for msg in self.pending
-            if current_time - msg.get('queued_at', 0) < self.expiry_seconds
+            msg
+            for msg in self.pending
+            if current_time - msg.get("queued_at", 0) < self.expiry_seconds
         ]
         expired_count = before_count - len(self.pending)
         if expired_count > 0:
@@ -97,32 +106,38 @@ class SMSQueue:
         with self._lock:
             # Check if same message already queued (prevent duplicates)
             for msg in self.pending:
-                if msg.get('number') == number and msg.get('text') == text:
-                    logger.debug(f"📥 SMS already queued for {number}, skipping duplicate")
+                if msg.get("number") == number and msg.get("text") == text:
+                    logger.debug(
+                        f"📥 SMS already queued for {number}, skipping duplicate"
+                    )
                     return False
-            
+
             message = {
-                'number': number,
-                'text': text,
-                'smsc': smsc,
-                'queued_at': time.time(),
-                'attempts': 0
+                "number": number,
+                "text": text,
+                "smsc": smsc,
+                "queued_at": time.time(),
+                "attempts": 0,
             }
             self.pending.append(message)
             self._save()
-            logger.info(f"📥 SMS queued for retry: {number} "
-                       f"({len(self.pending)} total in queue)")
+            logger.info(
+                f"📥 SMS queued for retry: {number} "
+                f"({len(self.pending)} total in queue)"
+            )
             return True
 
     def remove(self, number: str, text: str) -> bool:
         """Remove SMS from queue (after successful send) (thread-safe)"""
         with self._lock:
             for i, msg in enumerate(self.pending):
-                if msg.get('number') == number and msg.get('text') == text:
+                if msg.get("number") == number and msg.get("text") == text:
                     self.pending.pop(i)
                     self._save()
-                    logger.info(f"📥 SMS removed from queue: {number} "
-                               f"({len(self.pending)} remaining)")
+                    logger.info(
+                        f"📥 SMS removed from queue: {number} "
+                        f"({len(self.pending)} remaining)"
+                    )
                     return True
             return False
 
@@ -130,10 +145,10 @@ class SMSQueue:
         """Increment attempt counter for a message (thread-safe)"""
         with self._lock:
             for msg in self.pending:
-                if msg.get('number') == number and msg.get('text') == text:
-                    msg['attempts'] = msg.get('attempts', 0) + 1
+                if msg.get("number") == number and msg.get("text") == text:
+                    msg["attempts"] = msg.get("attempts", 0) + 1
                     self._save()
-                    return msg['attempts']
+                    return msg["attempts"]
             return 0
 
     def get_pending(self) -> list:
@@ -158,10 +173,11 @@ class SMSQueue:
 def detect_unicode_needed(text: str) -> bool:
     """Detect if text contains non-ASCII characters requiring Unicode encoding"""
     try:
-        text.encode('ascii')
+        text.encode("ascii")
         return False
     except UnicodeEncodeError:
         return True
+
 
 class SMSCounter:
     """Tracks sent and received SMS counts with persistent storage (thread-safe)"""
@@ -177,11 +193,13 @@ class SMSCounter:
         """Load counter from JSON file"""
         try:
             if os.path.exists(self.counter_file):
-                with open(self.counter_file, 'r') as f:
+                with open(self.counter_file, "r") as f:
                     data = json.load(f)
-                    self.sent_count = data.get('sent_count', 0)
-                    self.received_count = data.get('received_count', 0)
-                    logger.info(f"📊 Loaded SMS counters from file: sent={self.sent_count}, received={self.received_count}")
+                    self.sent_count = data.get("sent_count", 0)
+                    self.received_count = data.get("received_count", 0)
+                    logger.info(
+                        f"📊 Loaded SMS counters from file: sent={self.sent_count}, received={self.received_count}"
+                    )
             else:
                 logger.info("📊 SMS counter file not found, starting from 0")
         except Exception as e:
@@ -196,12 +214,14 @@ class SMSCounter:
             os.makedirs(os.path.dirname(self.counter_file), exist_ok=True)
 
             data = {
-                'sent_count': self.sent_count,
-                'received_count': self.received_count
+                "sent_count": self.sent_count,
+                "received_count": self.received_count,
             }
-            with open(self.counter_file, 'w') as f:
+            with open(self.counter_file, "w") as f:
                 json.dump(data, f)
-            logger.debug(f"📊 Saved SMS counters to file: sent={self.sent_count}, received={self.received_count}")
+            logger.debug(
+                f"📊 Saved SMS counters to file: sent={self.sent_count}, received={self.received_count}"
+            )
         except Exception as e:
             logger.error(f"Error saving SMS counter: {e}")
 
@@ -258,10 +278,11 @@ class SMSCounter:
         with self._lock:
             return self.sent_count
 
+
 class SMSHistory:
     """Tracks received SMS history with persistent storage (thread-safe)"""
 
-    def __init__(self, history_file='/data/sms_history.json', max_messages=10):
+    def __init__(self, history_file="/data/sms_history.json", max_messages=10):
         self.history_file = history_file
         self.max_messages = max_messages
         self.messages = []
@@ -272,11 +293,11 @@ class SMSHistory:
         """Load history from JSON file"""
         try:
             if os.path.exists(self.history_file):
-                with open(self.history_file, 'r') as f:
+                with open(self.history_file, "r") as f:
                     data = json.load(f)
-                    self.messages = data.get('messages', [])
+                    self.messages = data.get("messages", [])
                     # Keep only max_messages
-                    self.messages = self.messages[-self.max_messages:]
+                    self.messages = self.messages[-self.max_messages :]
                     logger.info(f"📜 Loaded SMS history: {len(self.messages)} messages")
             else:
                 logger.info("📜 SMS history file not found, starting fresh")
@@ -290,8 +311,8 @@ class SMSHistory:
             # Ensure /data directory exists
             os.makedirs(os.path.dirname(self.history_file), exist_ok=True)
 
-            data = {'messages': self.messages}
-            with open(self.history_file, 'w') as f:
+            data = {"messages": self.messages}
+            with open(self.history_file, "w") as f:
                 json.dump(data, f, indent=2)
             logger.debug(f"📜 Saved SMS history: {len(self.messages)} messages")
         except Exception as e:
@@ -302,19 +323,19 @@ class SMSHistory:
         with self._lock:
             if timestamp is None:
                 timestamp = time.strftime("%Y-%m-%d %H:%M:%S")
-            
+
             message = {
                 "number": number,
                 "text": text,  # Store full message text
-                "timestamp": timestamp
+                "timestamp": timestamp,
             }
-            
+
             self.messages.append(message)
-            
+
             # Keep only last max_messages
             if len(self.messages) > self.max_messages:
-                self.messages = self.messages[-self.max_messages:]
-            
+                self.messages = self.messages[-self.max_messages :]
+
             self._save()
             logger.debug(f"📜 Added message to history from {number}")
             return self.messages.copy()
@@ -331,10 +352,11 @@ class SMSHistory:
             self._save()
             logger.info("📜 SMS history cleared")
 
+
 class SMSDeliveryTracker:
     """Tracks SMS delivery status and reports (thread-safe)"""
 
-    def __init__(self, delivery_file='/data/sms_delivery.json', max_tracked=50):
+    def __init__(self, delivery_file="/data/sms_delivery.json", max_tracked=50):
         self.delivery_file = delivery_file
         self.max_tracked = max_tracked
         self.pending_deliveries = {}  # message_ref -> delivery info
@@ -345,10 +367,12 @@ class SMSDeliveryTracker:
         """Load delivery tracking from JSON file"""
         try:
             if os.path.exists(self.delivery_file):
-                with open(self.delivery_file, 'r') as f:
+                with open(self.delivery_file, "r") as f:
                     data = json.load(f)
-                    self.pending_deliveries = data.get('pending', {})
-                    logger.info(f"📬 Loaded delivery tracking: {len(self.pending_deliveries)} pending")
+                    self.pending_deliveries = data.get("pending", {})
+                    logger.info(
+                        f"📬 Loaded delivery tracking: {len(self.pending_deliveries)} pending"
+                    )
             else:
                 logger.info("📬 Delivery tracking file not found, starting fresh")
         except Exception as e:
@@ -359,20 +383,22 @@ class SMSDeliveryTracker:
         """Save delivery tracking to JSON file"""
         try:
             os.makedirs(os.path.dirname(self.delivery_file), exist_ok=True)
-            
+
             # Keep only max_tracked most recent entries
             if len(self.pending_deliveries) > self.max_tracked:
                 sorted_items = sorted(
                     self.pending_deliveries.items(),
-                    key=lambda x: x[1].get('sent_timestamp', ''),
-                    reverse=True
+                    key=lambda x: x[1].get("sent_timestamp", ""),
+                    reverse=True,
                 )
-                self.pending_deliveries = dict(sorted_items[:self.max_tracked])
-            
-            data = {'pending': self.pending_deliveries}
-            with open(self.delivery_file, 'w') as f:
+                self.pending_deliveries = dict(sorted_items[: self.max_tracked])
+
+            data = {"pending": self.pending_deliveries}
+            with open(self.delivery_file, "w") as f:
                 json.dump(data, f, indent=2)
-            logger.debug(f"📬 Saved delivery tracking: {len(self.pending_deliveries)} pending")
+            logger.debug(
+                f"📬 Saved delivery tracking: {len(self.pending_deliveries)} pending"
+            )
         except Exception as e:
             logger.error(f"Error saving delivery tracking: {e}")
 
@@ -384,12 +410,10 @@ class SMSDeliveryTracker:
                     "number": number,
                     "text_preview": text_preview[:50],
                     "sent_timestamp": time.strftime("%Y-%m-%d %H:%M:%S"),
-                    "status": "sent"
+                    "status": "sent",
                 }
                 self._save()
-                logger.info(
-                    f"📬 Tracking delivery for ref {message_ref} to {number}"
-                )
+                logger.info(f"📬 Tracking delivery for ref {message_ref} to {number}")
 
     def update_delivery_status(self, message_ref, status, timestamp=None):
         """Update delivery status for a message"""
@@ -409,10 +433,13 @@ class SMSDeliveryTracker:
     def get_pending_count(self):
         """Get count of messages awaiting delivery report"""
         with self._lock:
-            return len([
-                d for d in self.pending_deliveries.values()
-                if d.get('status') == 'sent'
-            ])
+            return len(
+                [
+                    d
+                    for d in self.pending_deliveries.values()
+                    if d.get("status") == "sent"
+                ]
+            )
 
     def get_all_deliveries(self):
         """Get all tracked deliveries"""
@@ -425,13 +452,13 @@ class SMSDeliveryTracker:
             count = len(self.pending_deliveries)
             self.pending_deliveries = {}
             self._save()
-            
+
             # Verify the file was actually cleared
             try:
                 if os.path.exists(self.delivery_file):
-                    with open(self.delivery_file, 'r') as f:
+                    with open(self.delivery_file, "r") as f:
                         data = json.load(f)
-                        remaining = len(data.get('pending', {}))
+                        remaining = len(data.get("pending", {}))
                         if remaining > 0:
                             logger.error(
                                 f"📬 WARNING: File still contains {remaining} "
@@ -444,13 +471,14 @@ class SMSDeliveryTracker:
                             )
             except Exception as e:
                 logger.error(f"📬 Error verifying clear operation: {e}")
-            
+
             return count
+
 
 class MissedCallTracker:
     """Tracks missed call history with persistent storage (thread-safe)"""
 
-    def __init__(self, calls_file='/data/missed_calls.json', max_calls=10):
+    def __init__(self, calls_file="/data/missed_calls.json", max_calls=10):
         self.calls_file = calls_file
         self.max_calls = max_calls
         self.calls = []
@@ -462,13 +490,15 @@ class MissedCallTracker:
         """Load missed calls from JSON file"""
         try:
             if os.path.exists(self.calls_file):
-                with open(self.calls_file, 'r') as f:
+                with open(self.calls_file, "r") as f:
                     data = json.load(f)
-                    self.calls = data.get('calls', [])
-                    self.last_call = data.get('last_call', None)
+                    self.calls = data.get("calls", [])
+                    self.last_call = data.get("last_call", None)
                     # Keep only max_calls
-                    self.calls = self.calls[-self.max_calls:]
-                    logger.info(f"📞 Loaded missed call history: {len(self.calls)} calls")
+                    self.calls = self.calls[-self.max_calls :]
+                    logger.info(
+                        f"📞 Loaded missed call history: {len(self.calls)} calls"
+                    )
             else:
                 logger.info("📞 Missed call history file not found, starting fresh")
         except Exception as e:
@@ -482,11 +512,8 @@ class MissedCallTracker:
             # Ensure /data directory exists
             os.makedirs(os.path.dirname(self.calls_file), exist_ok=True)
 
-            data = {
-                'calls': self.calls,
-                'last_call': self.last_call
-            }
-            with open(self.calls_file, 'w') as f:
+            data = {"calls": self.calls, "last_call": self.last_call}
+            with open(self.calls_file, "w") as f:
                 json.dump(data, f, indent=2)
             logger.debug(f"📞 Saved missed call history: {len(self.calls)} calls")
         except Exception as e:
@@ -498,13 +525,15 @@ class MissedCallTracker:
             # Store the call
             self.calls.append(call_data)
             self.last_call = call_data
-            
+
             # Keep only last max_calls
             if len(self.calls) > self.max_calls:
-                self.calls = self.calls[-self.max_calls:]
-            
+                self.calls = self.calls[-self.max_calls :]
+
             self._save()
-            logger.debug(f"📞 Added missed call to history from {call_data.get('Number', 'Unknown')}")
+            logger.debug(
+                f"📞 Added missed call to history from {call_data.get('Number', 'Unknown')}"
+            )
             return call_data
 
     def get_last_call(self):
@@ -528,8 +557,8 @@ class MissedCallTracker:
 
 class BalanceSMSParser:
     """Parses SMS messages from network providers to extract account balance information"""
-    
-    def __init__(self, balance_file='/data/balance_data.json', currency='USD'):
+
+    def __init__(self, balance_file="/data/balance_data.json", currency="USD"):
         self.balance_file = balance_file
         self.currency = currency
         self.balance_data = {
@@ -541,49 +570,53 @@ class BalanceSMSParser:
             "messages_remaining": None,
             "plan_expiry": None,
             "last_updated": None,
-            "raw_message": None
+            "raw_message": None,
         }
         self._load()
-    
+
     def _migrate_old_format(self, data: Dict[str, Any]) -> Dict[str, Any]:
         """Migrate old string-based format to new numeric format"""
         migrated = False
-        
+
         # Migrate data_remaining from "200.00 MB" to 200.0
-        if isinstance(data.get('data_remaining'), str):
+        if isinstance(data.get("data_remaining"), str):
             import re
-            match = re.match(r'([\d.]+)\s*(MB|GB)?', data['data_remaining'])
+
+            match = re.match(r"([\d.]+)\s*(MB|GB)?", data["data_remaining"])
             if match:
                 value = float(match.group(1))
-                unit = match.group(2) or 'MB'
-                if unit.upper() == 'GB':
+                unit = match.group(2) or "MB"
+                if unit.upper() == "GB":
                     value *= 1024
-                data['data_remaining'] = value
-                data['data_remaining_unit'] = 'MB'
+                data["data_remaining"] = value
+                data["data_remaining_unit"] = "MB"
                 migrated = True
                 logger.info(f"💰 Migrated data_remaining to numeric: {value}")
-        
+
         # Migrate account_balance from "$3.00" to 3.0
-        if isinstance(data.get('account_balance'), str):
+        if isinstance(data.get("account_balance"), str):
             import re
-            match = re.match(r'[\$€£]?([\d.]+)', data['account_balance'])
+
+            match = re.match(r"[\$€£]?([\d.]+)", data["account_balance"])
             if match:
                 value = float(match.group(1))
-                data['account_balance'] = value
-                data['account_balance_currency'] = self.currency
+                data["account_balance"] = value
+                data["account_balance_currency"] = self.currency
                 migrated = True
                 logger.info(f"💰 Migrated account_balance to numeric: {value}")
-        
+
         if migrated:
-            logger.info("💰 Migrated balance data from old format to new numeric format")
-        
+            logger.info(
+                "💰 Migrated balance data from old format to new numeric format"
+            )
+
         return data
-    
+
     def _load(self):
         """Load saved balance data from JSON file"""
         try:
             if os.path.exists(self.balance_file):
-                with open(self.balance_file, 'r') as f:
+                with open(self.balance_file, "r") as f:
                     data = json.load(f)
                     # Migrate old format if needed
                     original_data = data.copy()
@@ -596,37 +629,38 @@ class BalanceSMSParser:
                     logger.info(f"💰 Loaded balance data from {self.balance_file}")
         except Exception as e:
             logger.error(f"Error loading balance data: {e}")
-    
+
     def _save(self):
         """Save balance data to JSON file"""
         try:
-            with open(self.balance_file, 'w') as f:
+            with open(self.balance_file, "w") as f:
                 json.dump(self.balance_data, f, indent=2)
             logger.debug(f"💰 Saved balance data")
         except Exception as e:
             logger.error(f"Error saving balance data: {e}")
-    
+
     def parse_balance_sms(self, message_text: str) -> Dict[str, Any]:
         """Parse balance information from SMS text
-        
+
         Example messages:
         - "You have 200.00 MB of High Speed Data Remaining 200 Minutes & 934 Messages."
         - "Your plan expires on 2025-12-20. You have balance of $3.00"
-        
+
         Values are stored as numeric types for proper Home Assistant device classes:
         - data_remaining: float (in MB)
         - account_balance: float
         """
         import re
-        
+
         updated = False
-        self.balance_data["last_updated"] = time.strftime('%Y-%m-%d %H:%M:%S')
+        self.balance_data["last_updated"] = time.strftime("%Y-%m-%d %H:%M:%S")
         self.balance_data["raw_message"] = message_text
-        
+
         # Parse data remaining (MB or GB) - store as numeric MB
         data_match = re.search(
-            r'([\d.]+)\s*(MB|GB)\s*(?:of\s*)?(?:High\s*Speed\s*)?Data',
-            message_text, re.IGNORECASE
+            r"([\d.]+)\s*(MB|GB)\s*(?:of\s*)?(?:High\s*Speed\s*)?Data",
+            message_text,
+            re.IGNORECASE,
         )
         if data_match:
             amount = float(data_match.group(1))
@@ -638,26 +672,26 @@ class BalanceSMSParser:
             self.balance_data["data_remaining_unit"] = "MB"
             updated = True
             logger.info(f"💰 Parsed data: {amount} MB")
-        
+
         # Parse minutes remaining
-        minutes_match = re.search(r'([\d,]+)\s*Minutes', message_text, re.IGNORECASE)
+        minutes_match = re.search(r"([\d,]+)\s*Minutes", message_text, re.IGNORECASE)
         if minutes_match:
-            minutes = int(minutes_match.group(1).replace(',', ''))
+            minutes = int(minutes_match.group(1).replace(",", ""))
             self.balance_data["minutes_remaining"] = minutes
             updated = True
             logger.info(f"💰 Parsed minutes: {minutes}")
-        
+
         # Parse messages remaining
-        messages_match = re.search(r'([\d,]+)\s*Messages', message_text, re.IGNORECASE)
+        messages_match = re.search(r"([\d,]+)\s*Messages", message_text, re.IGNORECASE)
         if messages_match:
-            messages = int(messages_match.group(1).replace(',', ''))
+            messages = int(messages_match.group(1).replace(",", ""))
             self.balance_data["messages_remaining"] = messages
             updated = True
             logger.info(f"💰 Parsed messages: {messages}")
-        
+
         # Parse account balance (dollar amount) - store as numeric
         balance_match = re.search(
-            r'balance\s*of\s*\$?([\d.]+)', message_text, re.IGNORECASE
+            r"balance\s*of\s*\$?([\d.]+)", message_text, re.IGNORECASE
         )
         if balance_match:
             balance = float(balance_match.group(1))
@@ -665,26 +699,27 @@ class BalanceSMSParser:
             self.balance_data["account_balance_currency"] = self.currency
             updated = True
             logger.info(f"💰 Parsed account balance: {balance} {self.currency}")
-        
+
         # Parse plan expiry date
         expiry_match = re.search(
-            r'expires?\s*on\s*([\d-]+)', message_text, re.IGNORECASE
+            r"expires?\s*on\s*([\d-]+)", message_text, re.IGNORECASE
         )
         if expiry_match:
             expiry_date = expiry_match.group(1)
             self.balance_data["plan_expiry"] = expiry_date
             updated = True
             logger.info(f"💰 Parsed expiry: {expiry_date}")
-        
+
         if updated:
             self._save()
             logger.info("💰 Balance data updated from SMS")
-        
+
         return self.balance_data
-    
+
     def get_balance_data(self) -> Dict[str, Any]:
         """Get current balance data"""
         return self.balance_data
+
 
 class DeviceConnectivityTracker:
     """Tracks USB GSM device connectivity status (thread-safe)"""
@@ -713,9 +748,11 @@ class DeviceConnectivityTracker:
             # 2. An SMS operation succeeds (critical path)
             # This prevents GetSignalQuality from clearing offline state when retrieveAllSms is failing
             if self.hard_offline:
-                is_sms_operation = operation_name and 'sms' in operation_name.lower()
-                is_same_operation = operation_name and operation_name == self.hard_offline_operation
-                
+                is_sms_operation = operation_name and "sms" in operation_name.lower()
+                is_same_operation = (
+                    operation_name and operation_name == self.hard_offline_operation
+                )
+
                 if is_sms_operation or is_same_operation:
                     logger.info(
                         f"✅ Device recovery from hard offline: {operation_name} succeeded "
@@ -744,6 +781,7 @@ class DeviceConnectivityTracker:
 
                 try:
                     from support import invalidate_network_type_cache
+
                     invalidate_network_type_cache()
                 except:
                     pass
@@ -761,7 +799,7 @@ class DeviceConnectivityTracker:
                 str(error_message) if error_message else "Communication failed"
             )
             self.total_operations += 1
-            
+
             # Timeout errors are critical - mark hard offline immediately
             # This ensures status polling can't incorrectly clear the offline state
             if is_timeout:
@@ -783,7 +821,7 @@ class DeviceConnectivityTracker:
 
             if self.consecutive_failures >= 2:
                 return "offline"
-            
+
             # Hard offline takes precedence (timeout occurred)
             if self.hard_offline:
                 return "offline"
@@ -805,9 +843,9 @@ class DeviceConnectivityTracker:
                 "total_operations": self.total_operations,
                 "successful_operations": self.successful_operations,
                 "last_error": self.last_error,
-                "hard_offline": self.hard_offline
+                "hard_offline": self.hard_offline,
             }
-            
+
             # Include which operation caused hard offline
             if self.hard_offline and self.hard_offline_operation:
                 data["hard_offline_operation"] = self.hard_offline_operation
@@ -835,7 +873,7 @@ class DeviceConnectivityTracker:
 
         if self.consecutive_failures >= 2:
             return "offline"
-        
+
         # Hard offline takes precedence (timeout occurred)
         if self.hard_offline:
             return "offline"
@@ -858,42 +896,56 @@ class MQTTPublisher:
         self.client: Optional[mqtt.Client] = None
         self.connected = False
         self.disconnecting = False  # Flag to prevent multiple disconnect calls
-        self.topic_prefix = config.get('mqtt_topic_prefix', 'homeassistant/sensor/sms_gateway')
-        self.availability_topic = f"{self.topic_prefix}/availability"  # Shared availability for all entities
+        self.topic_prefix = config.get(
+            "mqtt_topic_prefix", "homeassistant/sensor/sms_gateway"
+        )
+        self.availability_topic = (
+            f"{self.topic_prefix}/availability"  # Shared availability for all entities
+        )
         self.gammu_machine = None  # Will be set externally
-        self.gammu_lock = threading.Lock()  # Serialize all Gammu operations to prevent race conditions
+        self.gammu_lock = (
+            threading.Lock()
+        )  # Serialize all Gammu operations to prevent race conditions
         self.current_phone_number = ""  # Current phone number from text input
         self.current_message_text = ""  # Current message text from text input
         self.current_ussd_code = ""  # Current USSD code from text input
-        self.device_tracker = DeviceConnectivityTracker()  # USB device connectivity tracking
+        self.device_tracker = (
+            DeviceConnectivityTracker()
+        )  # USB device connectivity tracking
         self.sms_counter = SMSCounter()  # SMS counter with persistence
-        self.log_level = config.get('log_level', 'normal')  # Store log level for conditional logging
-        
+        self.log_level = config.get(
+            "log_level", "normal"
+        )  # Store log level for conditional logging
+
         # Reconnection settings
-        self.auto_recovery = config.get('auto_recovery', True)
+        self.auto_recovery = config.get("auto_recovery", True)
         self.consecutive_failures = 0
         self.reconnect_threshold = 5  # Try to reconnect after 5 consecutive failures
         self.last_reconnect_attempt = 0
         self.reconnect_cooldown = 60  # Wait 60 seconds between reconnect attempts
-        
+
         # Initialize SMS history with configurable max messages (default: 10)
-        max_history = config.get('sms_history_max_messages', 10)
-        self.sms_history = SMSHistory(max_messages=max_history)  # SMS history with persistence
-        
+        max_history = config.get("sms_history_max_messages", 10)
+        self.sms_history = SMSHistory(
+            max_messages=max_history
+        )  # SMS history with persistence
+
         # Initialize delivery tracking
         self.delivery_tracker = SMSDeliveryTracker()  # SMS delivery report tracking
-        
+
         # Initialize missed call tracking
-        max_missed_calls = config.get('missed_calls_max_history', 10)
+        max_missed_calls = config.get("missed_calls_max_history", 10)
         self.missed_call_tracker = MissedCallTracker(max_calls=max_missed_calls)
-        
+
         # Initialize balance SMS parser if enabled
         self.balance_parser = None
-        if config.get('balance_sms_enabled', False):
-            balance_currency = config.get('balance_currency', 'USD')
+        if config.get("balance_sms_enabled", False):
+            balance_currency = config.get("balance_currency", "USD")
             self.balance_parser = BalanceSMSParser(currency=balance_currency)
-            logger.info(f"💰 Balance SMS parsing enabled (currency: {balance_currency})")
-        
+            logger.info(
+                f"💰 Balance SMS parsing enabled (currency: {balance_currency})"
+            )
+
         # SMSC caching for reliable SMS sending
         self.cached_smsc = None
         self.smsc_cache_time = None
@@ -901,69 +953,82 @@ class MQTTPublisher:
 
         # SMS queue for retry after modem recovery
         self.sms_queue = SMSQueue()
-        
+
         # Auto-restart settings for persistent modem failures
-        self.auto_restart_on_failure = config.get('auto_restart_on_failure', True)
+        self.auto_restart_on_failure = config.get("auto_restart_on_failure", True)
         self.failure_start_time = None  # When continuous failures started
         self.restart_timeout = 120  # Restart after 2 min of continuous failure
         # Shorter timeout for hard offline (modem timed out completely)
         self.hard_offline_restart_timeout = config.get(
-            'hard_offline_restart_timeout', 30
+            "hard_offline_restart_timeout", 30
         )
-        
+
         # Modem operation delay - helps prevent buffer overflows and crashes
         # Configurable: 0.1 to 5.0 seconds (default 0.3s)
-        self.modem_operation_delay = config.get('modem_operation_delay', 0.3)
+        self.modem_operation_delay = config.get("modem_operation_delay", 0.3)
         logger.info(f"⏱️ Modem operation delay: {self.modem_operation_delay}s")
 
         # Call monitoring (real-time via Gammu callbacks)
         self.call_monitoring_enabled = False
-        self.call_queue = []  # [{'number': str, 'ring_start': datetime, 'ring_count': int}, ...]
+        self.call_queue = (
+            []
+        )  # [{'number': str, 'ring_start': datetime, 'ring_count': int}, ...]
         self.MAX_CALL_QUEUE_SIZE = 5  # Maximum number of concurrent calls in queue
         self._read_device_thread = None
-        self._call_auto_reset_timer = None  # Timer for auto-resetting stuck incoming call state
+        self._call_auto_reset_timer = (
+            None  # Timer for auto-resetting stuck incoming call state
+        )
         self._call_ended_at = None  # Timestamp when call ended (for cooldown)
-        self.CALL_COOLDOWN_SECONDS = 10  # Wait this long after call before resuming polls
+        self.CALL_COOLDOWN_SECONDS = (
+            10  # Wait this long after call before resuming polls
+        )
         self._post_call_reinit_needed = False  # Request modem reinit after cooldown
-        self._reinit_in_progress = False  # Lock to prevent concurrent modem access during reinit
+        self._reinit_in_progress = (
+            False  # Lock to prevent concurrent modem access during reinit
+        )
 
         # SMS callback (faster delivery, polling as fallback)
         self.sms_callback_enabled = False
         self._sms_callback_pending = False  # Flag that SMS arrived
-        self._sms_callback_timer = None     # Debounce timer
+        self._sms_callback_timer = None  # Debounce timer
 
-        if config.get('mqtt_enabled', False):
+        if config.get("mqtt_enabled", False):
             self._setup_client()
-    
+
     def set_gammu_machine(self, machine):
         """Set gammu machine for SMS sending"""
         self.gammu_machine = machine
         logger.info("Gammu machine set for MQTT SMS sending")
-    
+
     def _setup_client(self):
         """Setup MQTT client with configuration"""
         try:
             # Create client with unique ID for better connection tracking
             import socket
+
             client_id = f"sms_gateway_{socket.gethostname()}"
             self.client = mqtt.Client(client_id=client_id, clean_session=True)
 
             # Set credentials ONLY if username is provided and not empty
-            username = self.config.get('mqtt_username', '')
-            password = self.config.get('mqtt_password', '')
+            username = self.config.get("mqtt_username", "")
+            password = self.config.get("mqtt_password", "")
 
             # Ensure username is a string and strip whitespace
             if username is None:
-                username = ''
+                username = ""
             username = str(username).strip()
 
             # Only set credentials if username has actual content
-            if username and username != '':
+            if username and username != "":
                 self.client.username_pw_set(username, password)
-                logger.info(f"MQTT: Client ID: {client_id}, Using authentication with username: '{username}'")
+                logger.info(
+                    f"MQTT: Client ID: {client_id}, Using authentication with username: '{username}'"
+                )
             else:
-                logger.info(f"MQTT: Client ID: {client_id}, Connecting without authentication (local broker mode)")
-            
+                logger.info(
+                    f"MQTT: Client ID: {client_id}, Connecting without authentication (local broker mode)"
+                )
+
             # Set callbacks
             self.client.on_connect = self._on_connect
             self.client.on_disconnect = self._on_disconnect
@@ -973,19 +1038,21 @@ class MQTTPublisher:
             # Set Last Will and Testament - published if connection lost unexpectedly
             # This makes ALL entities unavailable in HA when addon crashes/stops
             self.client.will_set(self.availability_topic, "offline", qos=1, retain=True)
-            logger.info("📡 MQTT Last Will set: all entities will be unavailable if connection lost")
+            logger.info(
+                "📡 MQTT Last Will set: all entities will be unavailable if connection lost"
+            )
 
             # Connect to broker
-            host = self.config.get('mqtt_host', 'core-mosquitto')
-            port = self.config.get('mqtt_port', 1883)
+            host = self.config.get("mqtt_host", "core-mosquitto")
+            port = self.config.get("mqtt_port", 1883)
 
             logger.info(f"Connecting to MQTT broker: {host}:{port}")
             self.client.connect(host, port, 60)
             self.client.loop_start()
-            
+
         except Exception as e:
             logger.error(f"Failed to setup MQTT client: {e}")
-    
+
     def _on_connect(self, client, userdata, flags, rc):
         """Callback for MQTT connection"""
         if rc == 0:
@@ -1021,12 +1088,18 @@ class MQTTPublisher:
             # Subscribe to reset sent counter button
             reset_counter_topic = f"{self.topic_prefix}/reset_counter_button"
             client.subscribe(reset_counter_topic)
-            logger.info(f"Subscribed to reset sent counter topic: {reset_counter_topic}")
+            logger.info(
+                f"Subscribed to reset sent counter topic: {reset_counter_topic}"
+            )
 
             # Subscribe to reset received counter button
-            reset_received_counter_topic = f"{self.topic_prefix}/reset_received_counter_button"
+            reset_received_counter_topic = (
+                f"{self.topic_prefix}/reset_received_counter_button"
+            )
             client.subscribe(reset_received_counter_topic)
-            logger.info(f"Subscribed to reset received counter topic: {reset_received_counter_topic}")
+            logger.info(
+                f"Subscribed to reset received counter topic: {reset_received_counter_topic}"
+            )
 
             # Subscribe to delete all SMS button
             delete_all_sms_topic = f"{self.topic_prefix}/delete_all_sms_button"
@@ -1034,9 +1107,13 @@ class MQTTPublisher:
             logger.info(f"Subscribed to delete all SMS topic: {delete_all_sms_topic}")
 
             # Subscribe to clear delivery reports button
-            clear_delivery_reports_topic = f"{self.topic_prefix}/clear_delivery_reports_button"
+            clear_delivery_reports_topic = (
+                f"{self.topic_prefix}/clear_delivery_reports_button"
+            )
             client.subscribe(clear_delivery_reports_topic)
-            logger.info(f"Subscribed to clear delivery reports topic: {clear_delivery_reports_topic}")
+            logger.info(
+                f"Subscribed to clear delivery reports topic: {clear_delivery_reports_topic}"
+            )
 
             # Subscribe to text input topics
             phone_topic = f"{self.topic_prefix}/phone_number/set"
@@ -1048,7 +1125,9 @@ class MQTTPublisher:
             client.subscribe(message_topic)
             client.subscribe(phone_state_topic)  # Subscribe to state topics too
             client.subscribe(message_state_topic)
-            logger.info(f"Subscribed to text input topics: {phone_topic}, {message_topic}, {phone_state_topic}, {message_state_topic}")
+            logger.info(
+                f"Subscribed to text input topics: {phone_topic}, {message_topic}, {phone_state_topic}, {message_state_topic}"
+            )
 
             # Subscribe to USSD topics
             ussd_code_topic = f"{self.topic_prefix}/ussd_code/set"
@@ -1058,24 +1137,26 @@ class MQTTPublisher:
             client.subscribe(ussd_code_topic)
             client.subscribe(ussd_code_state_topic)
             client.subscribe(ussd_button_topic)
-            logger.info(f"Subscribed to USSD topics: {ussd_code_topic}, {ussd_code_state_topic}, {ussd_button_topic}")
+            logger.info(
+                f"Subscribed to USSD topics: {ussd_code_topic}, {ussd_code_state_topic}, {ussd_button_topic}"
+            )
         else:
             logger.error(f"Failed to connect to MQTT broker: {rc}")
-    
+
     def _on_disconnect(self, client, userdata, rc):
         """Callback for MQTT disconnection"""
         self.connected = False
         logger.warning("Disconnected from MQTT broker")
-    
+
     def _on_publish(self, client, userdata, mid):
         """Callback for published messages"""
         pass
-    
+
     def _on_message(self, client, userdata, msg):
         """Callback for received MQTT messages"""
         try:
             topic = msg.topic
-            payload = msg.payload.decode('utf-8')
+            payload = msg.payload.decode("utf-8")
             logger.info(f"Received MQTT message on topic {topic}: {payload}")
 
             # Check message topic and handle accordingly
@@ -1084,9 +1165,13 @@ class MQTTPublisher:
             button_topic = f"{self.topic_prefix}/send_button"
             flash_button_topic = f"{self.topic_prefix}/send_flash_button"
             reset_counter_topic = f"{self.topic_prefix}/reset_counter_button"
-            reset_received_counter_topic = f"{self.topic_prefix}/reset_received_counter_button"
+            reset_received_counter_topic = (
+                f"{self.topic_prefix}/reset_received_counter_button"
+            )
             delete_all_sms_topic = f"{self.topic_prefix}/delete_all_sms_button"
-            clear_delivery_reports_topic = f"{self.topic_prefix}/clear_delivery_reports_button"
+            clear_delivery_reports_topic = (
+                f"{self.topic_prefix}/clear_delivery_reports_button"
+            )
             phone_topic = f"{self.topic_prefix}/phone_number/set"
             message_topic = f"{self.topic_prefix}/message_text/set"
             phone_state_topic = f"{self.topic_prefix}/phone_number/state"
@@ -1159,35 +1244,39 @@ class MQTTPublisher:
                         "status": "error",
                         "message": f"Command processing failed: {str(e)}",
                         "topic": msg.topic,
-                        "timestamp": time.strftime("%Y-%m-%d %H:%M:%S")
+                        "timestamp": time.strftime("%Y-%m-%d %H:%M:%S"),
                     }
-                    self.client.publish(status_topic, json.dumps(status_data), retain=False)
+                    self.client.publish(
+                        status_topic, json.dumps(status_data), retain=False
+                    )
                 except Exception as pub_err:
                     logger.error(f"Failed to publish error status: {pub_err}")
-    
+
     def _handle_sms_send_command(self, payload):
         """Handle SMS send command from MQTT"""
         try:
             # Parse JSON payload
             data = json.loads(payload)
-            number = data.get('number')
-            text = data.get('text')
+            number = data.get("number")
+            text = data.get("text")
             # If 'unicode' is explicitly provided, use it; otherwise use None for auto-detection
-            unicode_mode = data.get('unicode') if 'unicode' in data else None
-            flash_mode = data.get('flash', False)
+            unicode_mode = data.get("unicode") if "unicode" in data else None
+            flash_mode = data.get("flash", False)
 
             if not number or not text:
                 logger.error("SMS send command missing required fields: number or text")
                 return
 
-            logger.info(f"Processing SMS send command: {number} -> {text} (unicode: {unicode_mode if unicode_mode is not None else 'auto'}, flash: {flash_mode})")
+            logger.info(
+                f"Processing SMS send command: {number} -> {text} (unicode: {unicode_mode if unicode_mode is not None else 'auto'}, flash: {flash_mode})"
+            )
 
             # Send SMS via gammu machine (will be set externally)
-            if hasattr(self, 'gammu_machine') and self.gammu_machine:
+            if hasattr(self, "gammu_machine") and self.gammu_machine:
                 self._send_sms_via_gammu(number, text, unicode_mode, flash_mode)
             else:
                 logger.error("Gammu machine not available for SMS sending")
-                
+
         except json.JSONDecodeError as e:
             logger.error(f"Invalid JSON in SMS send command: {e}")
         except Exception as e:
@@ -1195,60 +1284,60 @@ class MQTTPublisher:
 
     def _handle_queued_sms_from_mqtt(self, payload, topic):
         """Handle SMS from persistent MQTT queue topic (survives addon restarts)
-        
+
         This topic uses retained messages so SMS requests persist in the MQTT broker
         even when the addon is down. When the addon starts, it receives the retained
         message and adds it to the local queue for processing.
-        
+
         Args:
             payload: JSON payload with 'number' and 'text' fields
             topic: The MQTT topic to clear after processing
         """
         try:
             # Skip empty payloads (cleared retained messages)
-            if not payload or payload.strip() == '':
+            if not payload or payload.strip() == "":
                 logger.debug("Empty queue_sms payload received, skipping")
                 return
-            
+
             # Parse JSON payload
             data = json.loads(payload)
-            number = data.get('number')
-            text = data.get('text')
-            smsc = data.get('smsc')  # Optional SMSC
-            
+            number = data.get("number")
+            text = data.get("text")
+            smsc = data.get("smsc")  # Optional SMSC
+
             if not number or not text:
                 logger.error("Queued SMS missing required fields: number or text")
                 # Clear the invalid retained message
-                self.client.publish(topic, '', retain=True)
+                self.client.publish(topic, "", retain=True)
                 return
-            
+
             logger.info(f"📥 Received SMS from MQTT queue: {number}")
-            
+
             # Clear the retained message immediately to prevent re-processing
-            self.client.publish(topic, '', retain=True)
+            self.client.publish(topic, "", retain=True)
             logger.info(f"📤 Cleared retained message from {topic}")
-            
+
             # Add to local queue for processing
             added = self.sms_queue.add(number, text, smsc)
             if added:
                 logger.info(f"📥 SMS added to local queue from MQTT: {number}")
             else:
                 logger.info(f"📥 SMS already in queue (duplicate): {number}")
-            
+
             # If gammu machine is ready, trigger immediate processing
-            if hasattr(self, 'gammu_machine') and self.gammu_machine:
+            if hasattr(self, "gammu_machine") and self.gammu_machine:
                 logger.info("📤 Triggering immediate queue processing...")
                 self.process_pending_sms()
             else:
                 logger.info("⏳ Gammu not ready, SMS will be sent when modem connects")
-                
+
         except json.JSONDecodeError as e:
             logger.error(f"Invalid JSON in queued SMS: {e}")
             # Clear invalid retained message
-            self.client.publish(topic, '', retain=True)
+            self.client.publish(topic, "", retain=True)
         except Exception as e:
             logger.error(f"Error handling queued SMS from MQTT: {e}")
-    
+
     def _send_ussd_via_gammu(self, ussd_code):
         """Send USSD code using gammu machine and return response
 
@@ -1260,46 +1349,50 @@ class MQTTPublisher:
         """
         try:
             logger.info(f"📱 Sending USSD code: {ussd_code}")
-            
+
             # Use DialService to send USSD and get response
             # DialService returns the USSD response as text (or dict with Text key)
-            response = self.track_gammu_operation("DialService", self.gammu_machine.DialService, ussd_code)
-            
+            response = self.track_gammu_operation(
+                "DialService", self.gammu_machine.DialService, ussd_code
+            )
+
             # Handle response - may be string or dict depending on Gammu version
             if isinstance(response, dict):
-                response_text = response.get('Text', str(response))
+                response_text = response.get("Text", str(response))
             else:
                 response_text = str(response) if response else "No response"
-            
+
             logger.info(f"✅ USSD Response received: {response_text}")
-            
+
             # Publish USSD response to MQTT
             if self.connected:
                 response_topic = f"{self.topic_prefix}/ussd_response/state"
                 response_data = {
                     "response": response_text,
                     "code": ussd_code,
-                    "timestamp": time.strftime("%Y-%m-%d %H:%M:%S")
+                    "timestamp": time.strftime("%Y-%m-%d %H:%M:%S"),
                 }
-                self.client.publish(response_topic, json.dumps(response_data), retain=True)
+                self.client.publish(
+                    response_topic, json.dumps(response_data), retain=True
+                )
                 logger.info(f"📤 Published USSD response to {response_topic}")
-            
+
             return response_text
 
         except Exception as e:
             error_msg = f"Failed to send USSD code: {str(e)}"
             logger.error(f"❌ {error_msg}")
-            
+
             # Publish error to USSD response sensor
             if self.connected:
                 response_topic = f"{self.topic_prefix}/ussd_response/state"
                 error_data = {
                     "response": f"ERROR: {str(e)}",
                     "code": ussd_code,
-                    "timestamp": time.strftime("%Y-%m-%d %H:%M:%S")
+                    "timestamp": time.strftime("%Y-%m-%d %H:%M:%S"),
                 }
                 self.client.publish(response_topic, json.dumps(error_data), retain=True)
-            
+
             raise
 
     def _send_sms_via_gammu(self, number, text, unicode_mode=None, flash_mode=False):
@@ -1319,12 +1412,16 @@ class MQTTPublisher:
             if unicode_mode is None:
                 unicode_mode = detect_unicode_needed(text)
                 if unicode_mode:
-                    logger.info(f"🔤 Auto-detected non-ASCII characters, using Unicode mode")
+                    logger.info(
+                        f"🔤 Auto-detected non-ASCII characters, using Unicode mode"
+                    )
 
             # Determine SMS class based on flash_mode
             sms_class = 0 if flash_mode else -1
             if flash_mode:
-                logger.info("⚡ Sending Flash SMS (will display on screen without saving)")
+                logger.info(
+                    "⚡ Sending Flash SMS (will display on screen without saving)"
+                )
 
             # Prepare SMS info
             smsinfo = {
@@ -1339,7 +1436,7 @@ class MQTTPublisher:
             }
 
             # Support multiple recipients (comma-separated)
-            recipients = [r.strip() for r in number.split(',')]
+            recipients = [r.strip() for r in number.split(",")]
             all_message_refs = []
             sent_count = 0
 
@@ -1352,29 +1449,33 @@ class MQTTPublisher:
                 message_refs = []
                 for message in messages:
                     # Use same SMSC logic as REST API
-                    config_smsc = self.config.get('smsc_number', '').strip()
+                    config_smsc = self.config.get("smsc_number", "").strip()
                     if config_smsc:
-                        message["SMSC"] = {'Number': config_smsc}
+                        message["SMSC"] = {"Number": config_smsc}
                         logger.info(f"Using configured SMSC: {config_smsc}")
                     else:
                         # Use Location 1 (same as REST API when no SMSC provided)
-                        message["SMSC"] = {'Location': 1}
+                        message["SMSC"] = {"Location": 1}
                         logger.info("Using SMSC from Location 1 (same as REST API)")
 
                     message["Number"] = recipient
-                    
+
                     # Request delivery report if enabled in config
-                    if self.config.get('sms_delivery_reports', False):
+                    if self.config.get("sms_delivery_reports", False):
                         message["DeliveryReport"] = "yes"
-                    
-                    result = self.track_gammu_operation("SendSMS", self.gammu_machine.SendSMS, message)
+
+                    result = self.track_gammu_operation(
+                        "SendSMS", self.gammu_machine.SendSMS, message
+                    )
                     logger.info(f"SMS sent successfully to {recipient}: {result}")
-                    
+
                     # Track delivery - result is the message reference
-                    if result and self.config.get('sms_delivery_reports', False):
+                    if result and self.config.get("sms_delivery_reports", False):
                         message_refs.append(result)
                         self.delivery_tracker.track_sent_sms(result, recipient, text)
-                        logger.info(f"📬 Delivery report requested for message ref: {result}")
+                        logger.info(
+                            f"📬 Delivery report requested for message ref: {result}"
+                        )
 
                 all_message_refs.extend(message_refs)
                 sent_count += 1
@@ -1383,7 +1484,9 @@ class MQTTPublisher:
             for _ in range(sent_count):
                 self.sms_counter.increment()
             self.publish_sms_counter()
-            logger.info(f"📊 SMS counter incremented by {sent_count} to: {self.sms_counter.get_count()}")
+            logger.info(
+                f"📊 SMS counter incremented by {sent_count} to: {self.sms_counter.get_count()}"
+            )
 
             # Publish confirmation with message references
             if self.connected:
@@ -1394,14 +1497,14 @@ class MQTTPublisher:
                     "text": text,
                     "message_refs": all_message_refs,
                     "pending_delivery_reports": len(all_message_refs),
-                    "timestamp": time.strftime("%Y-%m-%d %H:%M:%S")
+                    "timestamp": time.strftime("%Y-%m-%d %H:%M:%S"),
                 }
                 self.client.publish(status_topic, json.dumps(status_data), retain=False)
-                
+
                 # Publish initial delivery status if enabled
-                if self.config.get('sms_delivery_reports', False) and all_message_refs:
+                if self.config.get("sms_delivery_reports", False) and all_message_refs:
                     self.publish_delivery_pending(all_message_refs, number)
-                
+
         except Exception as e:
             error_msg = str(e)
             # Try to extract useful error message from gammu error
@@ -1413,7 +1516,7 @@ class MQTTPublisher:
                 user_error = "SMSC number not found - configure SMS center number in SIM settings"
             else:
                 user_error = f"SMS sending error: {error_msg}"
-            
+
             logger.error(f"Failed to send SMS via gammu: {error_msg}")
             # Publish error status with user-friendly message
             if self.connected:
@@ -1423,33 +1526,44 @@ class MQTTPublisher:
                     "error": user_error,
                     "number": number,
                     "text": text,
-                    "timestamp": time.strftime("%Y-%m-%d %H:%M:%S")
+                    "timestamp": time.strftime("%Y-%m-%d %H:%M:%S"),
                 }
                 self.client.publish(status_topic, json.dumps(status_data), retain=False)
-    
+
     def _handle_button_sms_send(self):
         """Handle SMS send when button is pressed using current text inputs"""
         # Log current state for debugging
-        logger.info(f"Button pressed - current state: phone='{self.current_phone_number}', message='{self.current_message_text}'")
+        logger.info(
+            f"Button pressed - current state: phone='{self.current_phone_number}', message='{self.current_message_text}'"
+        )
 
-        if not self.current_phone_number.strip() or not self.current_message_text.strip():
+        if (
+            not self.current_phone_number.strip()
+            or not self.current_message_text.strip()
+        ):
             # If fields are empty, show instruction
             if self.connected:
                 status_topic = f"{self.topic_prefix}/send_status"
                 status_data = {
                     "status": "missing_fields",
                     "message": f"Please fill in phone number and message text first. Current: phone='{self.current_phone_number}', message='{self.current_message_text}'",
-                    "timestamp": time.strftime("%Y-%m-%d %H:%M:%S")
+                    "timestamp": time.strftime("%Y-%m-%d %H:%M:%S"),
                 }
                 self.client.publish(status_topic, json.dumps(status_data), retain=False)
-            logger.warning(f"Button pressed but fields empty: phone='{self.current_phone_number}', message='{self.current_message_text}'")
+            logger.warning(
+                f"Button pressed but fields empty: phone='{self.current_phone_number}', message='{self.current_message_text}'"
+            )
             return
 
         # Send SMS using current values
-        logger.info(f"Button SMS send: {self.current_phone_number} -> {self.current_message_text}")
-        if hasattr(self, 'gammu_machine') and self.gammu_machine:
+        logger.info(
+            f"Button SMS send: {self.current_phone_number} -> {self.current_message_text}"
+        )
+        if hasattr(self, "gammu_machine") and self.gammu_machine:
             # Use unicode_mode=None for auto-detection
-            self._send_sms_via_gammu(self.current_phone_number, self.current_message_text, unicode_mode=None)
+            self._send_sms_via_gammu(
+                self.current_phone_number, self.current_message_text, unicode_mode=None
+            )
             # Always clear fields after send attempt (success or failure)
             self._clear_text_fields()
         else:
@@ -1459,23 +1573,35 @@ class MQTTPublisher:
 
     def _handle_flash_button_sms_send(self):
         """Handle Flash SMS send when button is pressed using current text inputs"""
-        logger.info(f"Flash button pressed - phone='{self.current_phone_number}', message='{self.current_message_text}'")
+        logger.info(
+            f"Flash button pressed - phone='{self.current_phone_number}', message='{self.current_message_text}'"
+        )
 
-        if not self.current_phone_number.strip() or not self.current_message_text.strip():
+        if (
+            not self.current_phone_number.strip()
+            or not self.current_message_text.strip()
+        ):
             if self.connected:
                 status_topic = f"{self.topic_prefix}/send_status"
                 status_data = {
                     "status": "missing_fields",
                     "message": "Please fill in phone number and message text first",
-                    "timestamp": time.strftime("%Y-%m-%d %H:%M:%S")
+                    "timestamp": time.strftime("%Y-%m-%d %H:%M:%S"),
                 }
                 self.client.publish(status_topic, json.dumps(status_data), retain=False)
             logger.warning("Flash button pressed but fields empty")
             return
 
-        logger.info(f"Flash SMS send: {self.current_phone_number} -> {self.current_message_text}")
-        if hasattr(self, 'gammu_machine') and self.gammu_machine:
-            self._send_sms_via_gammu(self.current_phone_number, self.current_message_text, unicode_mode=None, flash_mode=True)
+        logger.info(
+            f"Flash SMS send: {self.current_phone_number} -> {self.current_message_text}"
+        )
+        if hasattr(self, "gammu_machine") and self.gammu_machine:
+            self._send_sms_via_gammu(
+                self.current_phone_number,
+                self.current_message_text,
+                unicode_mode=None,
+                flash_mode=True,
+            )
             self._clear_text_fields()
         else:
             logger.error("Gammu machine not available for SMS sending")
@@ -1492,15 +1618,17 @@ class MQTTPublisher:
                 response_data = {
                     "response": "ERROR: Please enter a USSD code first (e.g., *#100#)",
                     "code": "",
-                    "timestamp": time.strftime("%Y-%m-%d %H:%M:%S")
+                    "timestamp": time.strftime("%Y-%m-%d %H:%M:%S"),
                 }
-                self.client.publish(response_topic, json.dumps(response_data), retain=True)
+                self.client.publish(
+                    response_topic, json.dumps(response_data), retain=True
+                )
             logger.warning(f"USSD button pressed but code field is empty")
             return
 
         # Send USSD using current value
         logger.info(f"Sending USSD code: {self.current_ussd_code}")
-        if hasattr(self, 'gammu_machine') and self.gammu_machine:
+        if hasattr(self, "gammu_machine") and self.gammu_machine:
             try:
                 response = self._send_ussd_via_gammu(self.current_ussd_code)
                 logger.info(f"✅ USSD sent successfully, response: {response}")
@@ -1511,7 +1639,7 @@ class MQTTPublisher:
                 logger.error(f"❌ USSD send failed: {e}")
         else:
             logger.error("Gammu machine not available for USSD sending")
-    
+
     def _handle_reset_counter(self):
         """Handle reset sent counter button press"""
         logger.info("🔄 Reset sent counter button pressed")
@@ -1531,7 +1659,7 @@ class MQTTPublisher:
         logger.info("📬 Clear delivery reports button pressed")
         try:
             count = self.delivery_tracker.clear_pending_deliveries()
-            
+
             # Publish updated status
             if self.connected:
                 status_topic = f"{self.topic_prefix}/delivery_status"
@@ -1539,7 +1667,7 @@ class MQTTPublisher:
                     "status": "cleared",
                     "message": f"Cleared {count} pending delivery reports",
                     "pending_count": 0,
-                    "timestamp": time.strftime("%Y-%m-%d %H:%M:%S")
+                    "timestamp": time.strftime("%Y-%m-%d %H:%M:%S"),
                 }
                 self.client.publish(status_topic, json.dumps(status_data), retain=False)
                 logger.info(f"✅ Cleared {count} pending delivery reports")
@@ -1550,7 +1678,7 @@ class MQTTPublisher:
                 status_data = {
                     "status": "error",
                     "message": f"Failed to clear delivery reports: {str(e)}",
-                    "timestamp": time.strftime("%Y-%m-%d %H:%M:%S")
+                    "timestamp": time.strftime("%Y-%m-%d %H:%M:%S"),
                 }
                 self.client.publish(status_topic, json.dumps(status_data), retain=False)
 
@@ -1558,14 +1686,16 @@ class MQTTPublisher:
         """Handle delete all SMS button press - with fallback for corrupted SMS"""
         logger.info("🗑️ Delete all SMS button pressed")
         try:
-            if hasattr(self, 'gammu_machine') and self.gammu_machine:
-                from support import retrieveAllSms, deleteSms
+            if hasattr(self, "gammu_machine") and self.gammu_machine:
+                from support import deleteSms, retrieveAllSms
 
                 deleted_count = 0
 
                 # Try method 1: Retrieve and delete SMS one by one
                 try:
-                    all_sms = self.track_gammu_operation("retrieveAllSms", retrieveAllSms, self.gammu_machine)
+                    all_sms = self.track_gammu_operation(
+                        "retrieveAllSms", retrieveAllSms, self.gammu_machine
+                    )
                     count = len(all_sms)
 
                     logger.info(f"📋 Found {count} SMS to delete")
@@ -1573,12 +1703,18 @@ class MQTTPublisher:
                     # Delete each SMS
                     for sms in all_sms:
                         try:
-                            self.track_gammu_operation("deleteSms", deleteSms, self.gammu_machine, sms)
+                            self.track_gammu_operation(
+                                "deleteSms", deleteSms, self.gammu_machine, sms
+                            )
                             deleted_count += 1
                         except Exception as e:
-                            logger.warning(f"Could not delete SMS at location {sms.get('Location', 'unknown')}: {e}")
+                            logger.warning(
+                                f"Could not delete SMS at location {sms.get('Location', 'unknown')}: {e}"
+                            )
 
-                    logger.info(f"✅ Method 1: Deleted {deleted_count}/{count} SMS messages")
+                    logger.info(
+                        f"✅ Method 1: Deleted {deleted_count}/{count} SMS messages"
+                    )
 
                 except Exception as e:
                     # Method 1 failed (likely corrupted SMS) - try method 2
@@ -1587,10 +1723,14 @@ class MQTTPublisher:
 
                     # Method 2: Get SMS capacity and delete by location
                     try:
-                        capacity = self.track_gammu_operation("GetSMSStatus", self.gammu_machine.GetSMSStatus)
-                        sim_size = capacity.get('SIMSize', 50)  # Default 50 if unknown
+                        capacity = self.track_gammu_operation(
+                            "GetSMSStatus", self.gammu_machine.GetSMSStatus
+                        )
+                        sim_size = capacity.get("SIMSize", 50)  # Default 50 if unknown
 
-                        logger.info(f"📋 Attempting to delete SMS from {sim_size} locations")
+                        logger.info(
+                            f"📋 Attempting to delete SMS from {sim_size} locations"
+                        )
 
                         # Try to delete each location (even corrupted ones)
                         # Use multiple folder IDs to catch SMS in different folders
@@ -1603,33 +1743,52 @@ class MQTTPublisher:
                                     self.gammu_machine.DeleteSMS(folder, location)
                                     deleted_count += 1
                                     deleted_this_location = True
-                                    logger.info(f"✅ Deleted SMS at folder={folder}, location={location}")
+                                    logger.info(
+                                        f"✅ Deleted SMS at folder={folder}, location={location}"
+                                    )
                                     break  # Success - don't try other folders for this location
                                 except Exception as loc_err:
                                     error_msg = str(loc_err)
                                     # Only log if it's not just "empty location"
-                                    if "Empty" not in error_msg and "InvalidLocation" not in error_msg:
-                                        logger.debug(f"Folder {folder}, Location {location}: {error_msg}")
+                                    if (
+                                        "Empty" not in error_msg
+                                        and "InvalidLocation" not in error_msg
+                                    ):
+                                        logger.debug(
+                                            f"Folder {folder}, Location {location}: {error_msg}"
+                                        )
 
                             if not deleted_this_location:
-                                logger.debug(f"Location {location}: no SMS found in any folder")
+                                logger.debug(
+                                    f"Location {location}: no SMS found in any folder"
+                                )
 
-                        logger.info(f"✅ Method 2: Processed {sim_size} locations, deleted {deleted_count} SMS")
+                        logger.info(
+                            f"✅ Method 2: Processed {sim_size} locations, deleted {deleted_count} SMS"
+                        )
 
                     except Exception as capacity_err:
                         logger.error(f"Method 2 also failed: {capacity_err}")
-                        raise Exception(f"Both deletion methods failed. Last error: {capacity_err}")
+                        raise Exception(
+                            f"Both deletion methods failed. Last error: {capacity_err}"
+                        )
 
                 # Give modem time to process bulk deletion (prevents Code 27 errors)
                 if deleted_count > 0:
-                    logger.info("⏳ Waiting for modem to stabilize after bulk deletion...")
+                    logger.info(
+                        "⏳ Waiting for modem to stabilize after bulk deletion..."
+                    )
                     time.sleep(3)  # 3 second pause
 
                 # Update SMS capacity after deletion
                 try:
-                    capacity = self.track_gammu_operation("GetSMSStatus", self.gammu_machine.GetSMSStatus)
+                    capacity = self.track_gammu_operation(
+                        "GetSMSStatus", self.gammu_machine.GetSMSStatus
+                    )
                     self.publish_sms_capacity(capacity)
-                    logger.info(f"📊 Updated SMS capacity: {capacity.get('SIMUsed', 0)}/{capacity.get('SIMSize', 0)}")
+                    logger.info(
+                        f"📊 Updated SMS capacity: {capacity.get('SIMUsed', 0)}/{capacity.get('SIMSize', 0)}"
+                    )
                 except Exception as e:
                     logger.warning(f"Could not update SMS capacity: {e}")
 
@@ -1640,9 +1799,11 @@ class MQTTPublisher:
                         "status": "success",
                         "deleted_count": deleted_count,
                         "message": f"Deleted {deleted_count} SMS messages from SIM",
-                        "timestamp": time.strftime("%Y-%m-%d %H:%M:%S")
+                        "timestamp": time.strftime("%Y-%m-%d %H:%M:%S"),
                     }
-                    self.client.publish(status_topic, json.dumps(status_data), retain=False)
+                    self.client.publish(
+                        status_topic, json.dumps(status_data), retain=False
+                    )
             else:
                 logger.error("Gammu machine not available for deleting SMS")
         except Exception as e:
@@ -1652,7 +1813,7 @@ class MQTTPublisher:
                 status_data = {
                     "status": "error",
                     "error": str(e),
-                    "timestamp": time.strftime("%Y-%m-%d %H:%M:%S")
+                    "timestamp": time.strftime("%Y-%m-%d %H:%M:%S"),
                 }
                 self.client.publish(status_topic, json.dumps(status_data), retain=False)
 
@@ -1672,12 +1833,14 @@ class MQTTPublisher:
                 self.client.publish(phone_state_topic, "", retain=True, qos=1)
                 self.client.publish(message_state_topic, "", retain=True, qos=1)
 
-                logger.info("🧹 Cleared both phone and message text fields after sending SMS")
+                logger.info(
+                    "🧹 Cleared both phone and message text fields after sending SMS"
+                )
             except Exception as e:
                 logger.warning(f"Could not clear text fields in UI: {e}")
         else:
             logger.info("🧹 Cleared both text fields (internal state only)")
-    
+
     def _publish_phone_state(self, value):
         """Publish phone number state"""
         if self.connected:
@@ -1695,7 +1858,7 @@ class MQTTPublisher:
         if self.connected:
             state_topic = f"{self.topic_prefix}/ussd_code/state"
             self.client.publish(state_topic, value, retain=True, qos=1)
-    
+
     def _publish_discovery_configs(self):
         """Publish Home Assistant auto-discovery configurations"""
         if not self.connected:
@@ -1706,14 +1869,14 @@ class MQTTPublisher:
             "identifiers": ["sms_gateway"],
             "name": "SMS Gateway",
             "model": "GSM Modem",
-            "manufacturer": "Gammu Gateway"
+            "manufacturer": "Gammu Gateway",
         }
 
         # Common availability config - all entities share same availability topic
         AVAILABILITY_CONFIG = {
             "availability_topic": self.availability_topic,
             "payload_available": "online",
-            "payload_not_available": "offline"
+            "payload_not_available": "offline",
         }
 
         # Signal strength sensor (original from PavelVe)
@@ -1726,9 +1889,9 @@ class MQTTPublisher:
             "icon": "mdi:signal-cellular-3",
             "state_class": "measurement",
             "device": DEVICE_CONFIG,
-            **AVAILABILITY_CONFIG
+            **AVAILABILITY_CONFIG,
         }
-        
+
         # Signal strength dBm sensor (diagnostic - shows actual dBm value, not percent)
         signal_dbm_config = {
             "name": "GSM Signal Strength (dBm)",
@@ -1741,9 +1904,9 @@ class MQTTPublisher:
             "icon": "mdi:signal",
             "state_class": "measurement",
             "device": DEVICE_CONFIG,
-            **AVAILABILITY_CONFIG
+            **AVAILABILITY_CONFIG,
         }
-        
+
         # Bit Error Rate sensor (diagnostic)
         ber_config = {
             "name": "GSM Bit Error Rate",
@@ -1755,9 +1918,9 @@ class MQTTPublisher:
             "icon": "mdi:gauge",
             "state_class": "measurement",
             "device": DEVICE_CONFIG,
-            **AVAILABILITY_CONFIG
+            **AVAILABILITY_CONFIG,
         }
-        
+
         # Network info sensor (original from PavelVe)
         network_config = {
             "name": "GSM Network",
@@ -1766,9 +1929,9 @@ class MQTTPublisher:
             "value_template": "{{ value_json.NetworkName }}",
             "icon": "mdi:network",
             "device": DEVICE_CONFIG,
-            **AVAILABILITY_CONFIG
+            **AVAILABILITY_CONFIG,
         }
-        
+
         # Network registration state sensor (main display)
         network_state_config = {
             "name": "GSM Network State",
@@ -1777,9 +1940,9 @@ class MQTTPublisher:
             "value_template": "{{ value_json.State }}",
             "icon": "mdi:signal-variant",
             "device": DEVICE_CONFIG,
-            **AVAILABILITY_CONFIG
+            **AVAILABILITY_CONFIG,
         }
-        
+
         # Network code (MCC+MNC) sensor (diagnostic)
         network_code_config = {
             "name": "GSM Network Code",
@@ -1789,9 +1952,9 @@ class MQTTPublisher:
             "icon": "mdi:network",
             "entity_category": "diagnostic",
             "device": DEVICE_CONFIG,
-            **AVAILABILITY_CONFIG
+            **AVAILABILITY_CONFIG,
         }
-        
+
         # Cell ID sensor
         cid_config = {
             "name": "GSM Cell ID",
@@ -1801,9 +1964,9 @@ class MQTTPublisher:
             "icon": "mdi:radio-tower",
             "entity_category": "diagnostic",
             "device": DEVICE_CONFIG,
-            **AVAILABILITY_CONFIG
+            **AVAILABILITY_CONFIG,
         }
-        
+
         # Location Area Code sensor
         lac_config = {
             "name": "GSM Location Area Code",
@@ -1813,9 +1976,9 @@ class MQTTPublisher:
             "icon": "mdi:map-marker-radius",
             "entity_category": "diagnostic",
             "device": DEVICE_CONFIG,
-            **AVAILABILITY_CONFIG
+            **AVAILABILITY_CONFIG,
         }
-        
+
         # Packet Location Area Code sensor
         packet_lac_config = {
             "name": "GSM Packet Location Area Code",
@@ -1825,9 +1988,9 @@ class MQTTPublisher:
             "icon": "mdi:map-marker-radius",
             "entity_category": "diagnostic",
             "device": DEVICE_CONFIG,
-            **AVAILABILITY_CONFIG
+            **AVAILABILITY_CONFIG,
         }
-        
+
         # Network Type sensor (2G/3G/4G/LTE)
         network_type_config = {
             "name": "GSM Network Type",
@@ -1837,7 +2000,7 @@ class MQTTPublisher:
             "icon": "mdi:network",
             "entity_category": "diagnostic",
             "device": DEVICE_CONFIG,
-            **AVAILABILITY_CONFIG
+            **AVAILABILITY_CONFIG,
         }
 
         # Last SMS sensor
@@ -1850,7 +2013,7 @@ class MQTTPublisher:
             "json_attributes_template": "{{ {'Number': value_json.Number, 'timestamp': value_json.timestamp, 'history': value_json.history} | tojson }}",
             "icon": "mdi:message-text",
             "device": DEVICE_CONFIG,
-            **AVAILABILITY_CONFIG
+            **AVAILABILITY_CONFIG,
         }
 
         # Last SMS sender number sensor
@@ -1861,7 +2024,7 @@ class MQTTPublisher:
             "value_template": "{{ value_json.Number }}",
             "icon": "mdi:phone",
             "device": DEVICE_CONFIG,
-            **AVAILABILITY_CONFIG
+            **AVAILABILITY_CONFIG,
         }
 
         # SMS send status sensor
@@ -1873,7 +2036,7 @@ class MQTTPublisher:
             "json_attributes_topic": f"{self.topic_prefix}/send_status",
             "icon": "mdi:send",
             "device": DEVICE_CONFIG,
-            **AVAILABILITY_CONFIG
+            **AVAILABILITY_CONFIG,
         }
 
         # SMS delete status sensor
@@ -1885,7 +2048,7 @@ class MQTTPublisher:
             "json_attributes_topic": f"{self.topic_prefix}/delete_sms_status",
             "icon": "mdi:delete-sweep",
             "device": DEVICE_CONFIG,
-            **AVAILABILITY_CONFIG
+            **AVAILABILITY_CONFIG,
         }
 
         # SMS delivery report sensor (🆕 v2.1.0)
@@ -1897,7 +2060,7 @@ class MQTTPublisher:
             "json_attributes_topic": f"{self.topic_prefix}/delivery_status",
             "icon": "mdi:email-check",
             "device": DEVICE_CONFIG,
-            **AVAILABILITY_CONFIG
+            **AVAILABILITY_CONFIG,
         }
 
         # SMS send button
@@ -1908,7 +2071,7 @@ class MQTTPublisher:
             "payload_press": "PRESS",
             "icon": "mdi:message-plus",
             "device": DEVICE_CONFIG,
-            **AVAILABILITY_CONFIG
+            **AVAILABILITY_CONFIG,
         }
 
         # Flash SMS send button
@@ -1919,7 +2082,7 @@ class MQTTPublisher:
             "payload_press": "PRESS",
             "icon": "mdi:message-flash",
             "device": DEVICE_CONFIG,
-            **AVAILABILITY_CONFIG
+            **AVAILABILITY_CONFIG,
         }
 
         # Phone number input text
@@ -1932,7 +2095,7 @@ class MQTTPublisher:
             "mode": "text",
             "pattern": r"^[\+\d\s\-\(\),]*$",  # Allow + anywhere for multiple international numbers
             "device": DEVICE_CONFIG,
-            **AVAILABILITY_CONFIG
+            **AVAILABILITY_CONFIG,
         }
 
         # Message input text
@@ -1945,7 +2108,7 @@ class MQTTPublisher:
             "mode": "text",
             "max": 255,  # HA text entity max length (Gammu will still split long messages into multiple SMS)
             "device": DEVICE_CONFIG,
-            **AVAILABILITY_CONFIG
+            **AVAILABILITY_CONFIG,
         }
 
         # USSD code input text
@@ -1958,7 +2121,7 @@ class MQTTPublisher:
             "mode": "text",
             "pattern": r"^\*[0-9#\*]+#?$",  # USSD codes start with * followed by digits/# (e.g., *225#, *#100#)
             "device": DEVICE_CONFIG,
-            **AVAILABILITY_CONFIG
+            **AVAILABILITY_CONFIG,
         }
 
         # USSD send button
@@ -1969,7 +2132,7 @@ class MQTTPublisher:
             "payload_press": "PRESS",
             "icon": "mdi:dialpad",
             "device": DEVICE_CONFIG,
-            **AVAILABILITY_CONFIG
+            **AVAILABILITY_CONFIG,
         }
 
         # USSD response sensor
@@ -1981,7 +2144,7 @@ class MQTTPublisher:
             "json_attributes_topic": f"{self.topic_prefix}/ussd_response/state",
             "icon": "mdi:message-reply-text",
             "device": DEVICE_CONFIG,
-            **AVAILABILITY_CONFIG
+            **AVAILABILITY_CONFIG,
         }
 
         # Modem Status sensor
@@ -2000,7 +2163,7 @@ class MQTTPublisher:
             "json_attributes_template": "{{ {'consecutive_failures': value_json.consecutive_failures, 'last_error': value_json.last_error, 'hard_offline': value_json.hard_offline, 'hard_offline_operation': value_json.hard_offline_operation | default(None), 'last_seen': value_json.last_seen} | tojson }}",
             "icon": "mdi:connection",
             "device": DEVICE_CONFIG,
-            **AVAILABILITY_CONFIG
+            **AVAILABILITY_CONFIG,
         }
 
         # SMS Sent Counter sensor
@@ -2013,7 +2176,7 @@ class MQTTPublisher:
             "state_class": "total_increasing",
             "unit_of_measurement": "messages",
             "device": DEVICE_CONFIG,
-            **AVAILABILITY_CONFIG
+            **AVAILABILITY_CONFIG,
         }
 
         # SMS Received Counter sensor
@@ -2026,11 +2189,11 @@ class MQTTPublisher:
             "state_class": "total_increasing",
             "unit_of_measurement": "messages",
             "device": DEVICE_CONFIG,
-            **AVAILABILITY_CONFIG
+            **AVAILABILITY_CONFIG,
         }
 
         # SMS Cost sensor (only if cost > 0)
-        sms_cost_per_message = self.config.get('sms_cost_per_message', 0.0)
+        sms_cost_per_message = self.config.get("sms_cost_per_message", 0.0)
 
         # Reset sent counter button
         reset_counter_button_config = {
@@ -2040,7 +2203,7 @@ class MQTTPublisher:
             "payload_press": "PRESS",
             "icon": "mdi:restart",
             "device": DEVICE_CONFIG,
-            **AVAILABILITY_CONFIG
+            **AVAILABILITY_CONFIG,
         }
 
         # Reset received counter button
@@ -2051,7 +2214,7 @@ class MQTTPublisher:
             "payload_press": "PRESS",
             "icon": "mdi:restart",
             "device": DEVICE_CONFIG,
-            **AVAILABILITY_CONFIG
+            **AVAILABILITY_CONFIG,
         }
 
         # Delete all SMS button
@@ -2062,7 +2225,7 @@ class MQTTPublisher:
             "payload_press": "PRESS",
             "icon": "mdi:delete-sweep",
             "device": DEVICE_CONFIG,
-            **AVAILABILITY_CONFIG
+            **AVAILABILITY_CONFIG,
         }
 
         # Clear delivery reports button
@@ -2073,7 +2236,7 @@ class MQTTPublisher:
             "payload_press": "PRESS",
             "icon": "mdi:email-remove",
             "device": DEVICE_CONFIG,
-            **AVAILABILITY_CONFIG
+            **AVAILABILITY_CONFIG,
         }
 
         # Modem IMEI sensor
@@ -2084,7 +2247,7 @@ class MQTTPublisher:
             "value_template": "{{ value_json.IMEI }}",
             "icon": "mdi:identifier",
             "device": DEVICE_CONFIG,
-            **AVAILABILITY_CONFIG
+            **AVAILABILITY_CONFIG,
         }
 
         # Modem Model sensor
@@ -2095,7 +2258,7 @@ class MQTTPublisher:
             "value_template": "{{ value_json.Manufacturer }} {{ value_json.Model }}",
             "icon": "mdi:cellphone",
             "device": DEVICE_CONFIG,
-            **AVAILABILITY_CONFIG
+            **AVAILABILITY_CONFIG,
         }
 
         # Modem Firmware sensor
@@ -2107,7 +2270,7 @@ class MQTTPublisher:
             "icon": "mdi:chip",
             "entity_category": "diagnostic",
             "device": DEVICE_CONFIG,
-            **AVAILABILITY_CONFIG
+            **AVAILABILITY_CONFIG,
         }
 
         # SIM IMSI sensor
@@ -2118,7 +2281,7 @@ class MQTTPublisher:
             "value_template": "{{ value_json.IMSI }}",
             "icon": "mdi:sim",
             "device": DEVICE_CONFIG,
-            **AVAILABILITY_CONFIG
+            **AVAILABILITY_CONFIG,
         }
 
         # SMS Capacity sensor
@@ -2132,12 +2295,12 @@ class MQTTPublisher:
             "icon": "mdi:email-multiple",
             "state_class": "measurement",
             "device": DEVICE_CONFIG,
-            **AVAILABILITY_CONFIG
+            **AVAILABILITY_CONFIG,
         }
 
         # Balance sensors (only added if balance_sms_enabled is true)
-        balance_currency = self.config.get('balance_currency', 'USD')
-        
+        balance_currency = self.config.get("balance_currency", "USD")
+
         balance_account_config = {
             "name": "Account Balance",
             "unique_id": "sms_gateway_account_balance",
@@ -2148,7 +2311,7 @@ class MQTTPublisher:
             "unit_of_measurement": balance_currency,
             "icon": "mdi:cash",
             "device": DEVICE_CONFIG,
-            **AVAILABILITY_CONFIG
+            **AVAILABILITY_CONFIG,
         }
 
         balance_data_config = {
@@ -2161,7 +2324,7 @@ class MQTTPublisher:
             "unit_of_measurement": "MB",
             "icon": "mdi:database",
             "device": DEVICE_CONFIG,
-            **AVAILABILITY_CONFIG
+            **AVAILABILITY_CONFIG,
         }
 
         balance_minutes_config = {
@@ -2174,7 +2337,7 @@ class MQTTPublisher:
             "icon": "mdi:phone",
             "state_class": "measurement",
             "device": DEVICE_CONFIG,
-            **AVAILABILITY_CONFIG
+            **AVAILABILITY_CONFIG,
         }
 
         balance_messages_config = {
@@ -2186,7 +2349,7 @@ class MQTTPublisher:
             "icon": "mdi:message-text",
             "state_class": "measurement",
             "device": DEVICE_CONFIG,
-            **AVAILABILITY_CONFIG
+            **AVAILABILITY_CONFIG,
         }
 
         balance_expiry_config = {
@@ -2197,7 +2360,7 @@ class MQTTPublisher:
             "device_class": "date",
             "icon": "mdi:calendar-end",
             "device": DEVICE_CONFIG,
-            **AVAILABILITY_CONFIG
+            **AVAILABILITY_CONFIG,
         }
 
         # Publish discovery configs - all using consistent node_id "sms_gateway" for proper grouping
@@ -2208,56 +2371,124 @@ class MQTTPublisher:
             ("homeassistant/sensor/sms_gateway/ber/config", ber_config),
             # Network sensors
             ("homeassistant/sensor/sms_gateway/network/config", network_config),
-            ("homeassistant/sensor/sms_gateway/network_state/config", network_state_config),
-            ("homeassistant/sensor/sms_gateway/network_code/config", network_code_config),
+            (
+                "homeassistant/sensor/sms_gateway/network_state/config",
+                network_state_config,
+            ),
+            (
+                "homeassistant/sensor/sms_gateway/network_code/config",
+                network_code_config,
+            ),
             ("homeassistant/sensor/sms_gateway/cid/config", cid_config),
             ("homeassistant/sensor/sms_gateway/lac/config", lac_config),
             ("homeassistant/sensor/sms_gateway/packet_lac/config", packet_lac_config),
-            ("homeassistant/sensor/sms_gateway/network_type/config", network_type_config),
+            (
+                "homeassistant/sensor/sms_gateway/network_type/config",
+                network_type_config,
+            ),
             # SMS sensors
             ("homeassistant/sensor/sms_gateway/last_sms/config", sms_config),
-            ("homeassistant/sensor/sms_gateway/last_sms_sender/config", sms_sender_config),
+            (
+                "homeassistant/sensor/sms_gateway/last_sms_sender/config",
+                sms_sender_config,
+            ),
             ("homeassistant/sensor/sms_gateway/send_status/config", send_status_config),
-            ("homeassistant/sensor/sms_gateway/delete_status/config", delete_status_config),
-            ("homeassistant/sensor/sms_gateway/delivery_status/config", delivery_report_config),
+            (
+                "homeassistant/sensor/sms_gateway/delete_status/config",
+                delete_status_config,
+            ),
+            (
+                "homeassistant/sensor/sms_gateway/delivery_status/config",
+                delivery_report_config,
+            ),
             ("homeassistant/sensor/sms_gateway/sent_count/config", sms_counter_config),
-            ("homeassistant/sensor/sms_gateway/received_count/config", sms_received_counter_config),
-            ("homeassistant/sensor/sms_gateway/sms_capacity/config", sms_capacity_config),
+            (
+                "homeassistant/sensor/sms_gateway/received_count/config",
+                sms_received_counter_config,
+            ),
+            (
+                "homeassistant/sensor/sms_gateway/sms_capacity/config",
+                sms_capacity_config,
+            ),
             # Modem/SIM sensors
-            ("homeassistant/sensor/sms_gateway/modem_status/config", device_status_config),
+            (
+                "homeassistant/sensor/sms_gateway/modem_status/config",
+                device_status_config,
+            ),
             ("homeassistant/sensor/sms_gateway/modem_imei/config", modem_imei_config),
             ("homeassistant/sensor/sms_gateway/modem_model/config", modem_model_config),
-            ("homeassistant/sensor/sms_gateway/modem_firmware/config", modem_firmware_config),
+            (
+                "homeassistant/sensor/sms_gateway/modem_firmware/config",
+                modem_firmware_config,
+            ),
             ("homeassistant/sensor/sms_gateway/sim_imsi/config", sim_imsi_config),
             # Controls
             ("homeassistant/button/sms_gateway/send_button/config", button_config),
-            ("homeassistant/button/sms_gateway/send_flash_button/config", flash_button_config),
-            ("homeassistant/button/sms_gateway/reset_counter/config", reset_counter_button_config),
-            ("homeassistant/button/sms_gateway/reset_received_counter/config", reset_received_counter_button_config),
-            ("homeassistant/button/sms_gateway/delete_all_sms/config", delete_all_sms_button_config),
-            ("homeassistant/button/sms_gateway/clear_delivery_reports/config", clear_delivery_reports_button_config),
-            ("homeassistant/button/sms_gateway/send_ussd_button/config", ussd_button_config),
+            (
+                "homeassistant/button/sms_gateway/send_flash_button/config",
+                flash_button_config,
+            ),
+            (
+                "homeassistant/button/sms_gateway/reset_counter/config",
+                reset_counter_button_config,
+            ),
+            (
+                "homeassistant/button/sms_gateway/reset_received_counter/config",
+                reset_received_counter_button_config,
+            ),
+            (
+                "homeassistant/button/sms_gateway/delete_all_sms/config",
+                delete_all_sms_button_config,
+            ),
+            (
+                "homeassistant/button/sms_gateway/clear_delivery_reports/config",
+                clear_delivery_reports_button_config,
+            ),
+            (
+                "homeassistant/button/sms_gateway/send_ussd_button/config",
+                ussd_button_config,
+            ),
             ("homeassistant/text/sms_gateway/phone_number/config", phone_text_config),
             ("homeassistant/text/sms_gateway/message_text/config", message_text_config),
             ("homeassistant/text/sms_gateway/ussd_code/config", ussd_code_text_config),
             # USSD response sensor
-            ("homeassistant/sensor/sms_gateway/ussd_response/config", ussd_response_config)
+            (
+                "homeassistant/sensor/sms_gateway/ussd_response/config",
+                ussd_response_config,
+            ),
         ]
 
         # Add balance sensors if enabled
-        if self.config.get('balance_sms_enabled', False):
-            discoveries.extend([
-                ("homeassistant/sensor/sms_gateway/account_balance/config", balance_account_config),
-                ("homeassistant/sensor/sms_gateway/data_remaining/config", balance_data_config),
-                ("homeassistant/sensor/sms_gateway/minutes_remaining/config", balance_minutes_config),
-                ("homeassistant/sensor/sms_gateway/messages_remaining/config", balance_messages_config),
-                ("homeassistant/sensor/sms_gateway/plan_expiry/config", balance_expiry_config),
-            ])
+        if self.config.get("balance_sms_enabled", False):
+            discoveries.extend(
+                [
+                    (
+                        "homeassistant/sensor/sms_gateway/account_balance/config",
+                        balance_account_config,
+                    ),
+                    (
+                        "homeassistant/sensor/sms_gateway/data_remaining/config",
+                        balance_data_config,
+                    ),
+                    (
+                        "homeassistant/sensor/sms_gateway/minutes_remaining/config",
+                        balance_minutes_config,
+                    ),
+                    (
+                        "homeassistant/sensor/sms_gateway/messages_remaining/config",
+                        balance_messages_config,
+                    ),
+                    (
+                        "homeassistant/sensor/sms_gateway/plan_expiry/config",
+                        balance_expiry_config,
+                    ),
+                ]
+            )
             logger.info("💰 Added balance sensors to Home Assistant discovery")
-        
+
         # Add cost sensor only if cost is configured (> 0)
         if sms_cost_per_message > 0:
-            sms_cost_currency = self.config.get('sms_cost_currency', 'CZK')
+            sms_cost_currency = self.config.get("sms_cost_currency", "CZK")
             sms_cost_config = {
                 "name": "SMS Total Cost",
                 "unique_id": "sms_gateway_total_cost",
@@ -2268,14 +2499,14 @@ class MQTTPublisher:
                 "device_class": "monetary",
                 "state_class": "total",
                 "device": DEVICE_CONFIG,
-                **AVAILABILITY_CONFIG
+                **AVAILABILITY_CONFIG,
             }
             discoveries.append(
                 ("homeassistant/sensor/sms_gateway/total_cost/config", sms_cost_config)
             )
 
         # Add call monitoring sensors if enabled
-        if self.config.get('missed_calls_monitoring_enabled', False):
+        if self.config.get("missed_calls_monitoring_enabled", False):
             # Binary sensor - Incoming Call (real-time ringing detection)
             incoming_call_config = {
                 "name": "Incoming Call",
@@ -2288,7 +2519,7 @@ class MQTTPublisher:
                 "icon": "mdi:phone-ring",
                 "device_class": "sound",
                 "device": DEVICE_CONFIG,
-                **AVAILABILITY_CONFIG
+                **AVAILABILITY_CONFIG,
             }
 
             # Sensor - Last Missed Call (with extended attributes)
@@ -2300,207 +2531,252 @@ class MQTTPublisher:
                 "json_attributes_topic": f"{self.topic_prefix}/missed_call/state",
                 "icon": "mdi:phone-missed",
                 "device": DEVICE_CONFIG,
-                **AVAILABILITY_CONFIG
+                **AVAILABILITY_CONFIG,
             }
 
-            discoveries.extend([
-                ("homeassistant/binary_sensor/sms_gateway/incoming_call/config",
-                 incoming_call_config),
-                ("homeassistant/sensor/sms_gateway/last_missed_call/config",
-                 missed_call_config),
-            ])
+            discoveries.extend(
+                [
+                    (
+                        "homeassistant/binary_sensor/sms_gateway/incoming_call/config",
+                        incoming_call_config,
+                    ),
+                    (
+                        "homeassistant/sensor/sms_gateway/last_missed_call/config",
+                        missed_call_config,
+                    ),
+                ]
+            )
             logger.info("📞 Added call monitoring sensors to Home Assistant discovery")
-        
+
         for topic, config in discoveries:
             self.client.publish(topic, json.dumps(config), retain=True, qos=1)
-        
+
         logger.info("Published MQTT discovery configurations including SMS send button")
-        
+
         # Publish initial states immediately after discovery
         self._publish_initial_states()
 
         # Give HA a moment to process discovery and send retained state messages back to us
         import time
+
         time.sleep(1)
-        
+
         # Now restore SMS history after HA has processed discovery
         self._restore_sms_history()
-        
+
         # Restore missed call history if call monitoring is enabled
         self._restore_missed_call_history()
-        
+
         # Restore balance data if balance parsing is enabled
         self._restore_balance_data()
-    
-    def publish_signal_strength(self, signal_data: Dict[str, Any], silent: bool = False):
+
+    def publish_signal_strength(
+        self, signal_data: Dict[str, Any], silent: bool = False
+    ):
         """Publish signal strength data"""
         if not self.connected:
             return
-            
+
         topic = f"{self.topic_prefix}/signal/state"
         self.client.publish(topic, json.dumps(signal_data), retain=True)
-        
+
         if not silent:
             # Normal logging: show both signal level sensors
-            signal_percent = signal_data.get('SignalPercent', 'N/A')
-            signal_dbm = signal_data.get('SignalStrength', 'N/A')
-            logger.info(f"📡 Published signal strength to MQTT: {signal_percent}% ({signal_dbm} dBm)")
-            
+            signal_percent = signal_data.get("SignalPercent", "N/A")
+            signal_dbm = signal_data.get("SignalStrength", "N/A")
+            logger.info(
+                f"📡 Published signal strength to MQTT: {signal_percent}% ({signal_dbm} dBm)"
+            )
+
             # Verbose/debug logging: show all sensor data
-            ber = signal_data.get('BitErrorRate', 'N/A')
-            logger.debug(f"   📊 Signal details: Percent={signal_percent}%, dBm={signal_dbm}, BER={ber}")
-    
+            ber = signal_data.get("BitErrorRate", "N/A")
+            logger.debug(
+                f"   📊 Signal details: Percent={signal_percent}%, dBm={signal_dbm}, BER={ber}"
+            )
+
     def publish_network_info(self, network_data: Dict[str, Any], silent: bool = False):
         """Publish network information"""
         if not self.connected:
             return
-        
+
         # Ensure NetworkType is included (default to Unknown if not present)
-        if 'NetworkType' not in network_data:
-            network_data['NetworkType'] = 'Unknown'
-            
+        if "NetworkType" not in network_data:
+            network_data["NetworkType"] = "Unknown"
+
         topic = f"{self.topic_prefix}/network/state"
         self.client.publish(topic, json.dumps(network_data), retain=True)
-        
+
         if not silent:
-            network_type = network_data.get('NetworkType', 'Unknown')
-            network_name = network_data.get('NetworkName', 'Unknown')
-            logger.info(f"📡 Published network info to MQTT: {network_name} ({network_type})")
-            
+            network_type = network_data.get("NetworkType", "Unknown")
+            network_name = network_data.get("NetworkName", "Unknown")
+            logger.info(
+                f"📡 Published network info to MQTT: {network_name} ({network_type})"
+            )
+
             # Verbose/debug logging: show all network sensor data
-            network_code = network_data.get('NetworkCode', 'N/A')
-            state = network_data.get('State', 'N/A')
-            lac = network_data.get('LAC', 'N/A')
-            packet_lac = network_data.get('PacketLAC', 'N/A')
-            cell_id = network_data.get('CID', 'N/A')
-            logger.debug(f"   📡 Network details: Code={network_code}, State={state}, Type={network_type}, LAC={lac}, PacketLAC={packet_lac}, CID={cell_id}")
-    
-    def publish_status_combined(self, signal_data: Dict[str, Any], network_data: Dict[str, Any]):
+            network_code = network_data.get("NetworkCode", "N/A")
+            state = network_data.get("State", "N/A")
+            lac = network_data.get("LAC", "N/A")
+            packet_lac = network_data.get("PacketLAC", "N/A")
+            cell_id = network_data.get("CID", "N/A")
+            logger.debug(
+                f"   📡 Network details: Code={network_code}, State={state}, Type={network_type}, LAC={lac}, PacketLAC={packet_lac}, CID={cell_id}"
+            )
+
+    def publish_status_combined(
+        self, signal_data: Dict[str, Any], network_data: Dict[str, Any]
+    ):
         """Publish both signal strength and network info with combined logging"""
         if not self.connected:
             return
-        
+
         # Publish both silently
         self.publish_signal_strength(signal_data, silent=True)
         self.publish_network_info(network_data, silent=True)
-        
+
         # Combined log message
-        signal_percent = signal_data.get('SignalPercent', 'N/A')
-        signal_dbm = signal_data.get('SignalStrength', 'N/A')
-        network_name = network_data.get('NetworkName', 'Unknown')
-        network_type = network_data.get('NetworkType', 'Unknown')
-        logger.info(f"📡 Status update: {signal_percent}% ({signal_dbm} dBm) | {network_name} ({network_type})")
-        
+        signal_percent = signal_data.get("SignalPercent", "N/A")
+        signal_dbm = signal_data.get("SignalStrength", "N/A")
+        network_name = network_data.get("NetworkName", "Unknown")
+        network_type = network_data.get("NetworkType", "Unknown")
+        logger.info(
+            f"📡 Status update: {signal_percent}% ({signal_dbm} dBm) | {network_name} ({network_type})"
+        )
+
         # Verbose/debug logging: show all sensor details
-        ber = signal_data.get('BitErrorRate', 'N/A')
-        network_code = network_data.get('NetworkCode', 'N/A')
-        state = network_data.get('State', 'N/A')
-        lac = network_data.get('LAC', 'N/A')
-        packet_lac = network_data.get('PacketLAC', 'N/A')
-        cell_id = network_data.get('CID', 'N/A')
-        logger.debug(f"   📊 Signal: Percent={signal_percent}%, dBm={signal_dbm}, BER={ber}")
-        logger.debug(f"   📡 Network: Code={network_code}, State={state}, Type={network_type}, LAC={lac}, PacketLAC={packet_lac}, CID={cell_id}")
-    
+        ber = signal_data.get("BitErrorRate", "N/A")
+        network_code = network_data.get("NetworkCode", "N/A")
+        state = network_data.get("State", "N/A")
+        lac = network_data.get("LAC", "N/A")
+        packet_lac = network_data.get("PacketLAC", "N/A")
+        cell_id = network_data.get("CID", "N/A")
+        logger.debug(
+            f"   📊 Signal: Percent={signal_percent}%, dBm={signal_dbm}, BER={ber}"
+        )
+        logger.debug(
+            f"   📡 Network: Code={network_code}, State={state}, Type={network_type}, LAC={lac}, PacketLAC={packet_lac}, CID={cell_id}"
+        )
+
     def publish_sms_received(self, sms_data: Dict[str, Any]):
         """Publish received SMS data and fire Home Assistant event"""
         if not self.connected:
             return
-            
+
         # Add timestamp
-        timestamp = time.strftime('%Y-%m-%d %H:%M:%S')
-        sms_data['timestamp'] = timestamp
-        
+        timestamp = time.strftime("%Y-%m-%d %H:%M:%S")
+        sms_data["timestamp"] = timestamp
+
         # Increment received counter
         new_count = self.sms_counter.increment_received()
         self.publish_sms_received_counter()
         logger.debug(f"📊 SMS received counter incremented to {new_count}")
-        
+
         # Check if this is a balance SMS and parse it
         if self.balance_parser:
-            sender = sms_data.get('Number', '')
-            message_text = sms_data.get('Text', '')
-            expected_sender = self.config.get('balance_sms_sender', '7069')
-            balance_keywords = self.config.get('balance_keywords', ['Balance', 'balance'])
-            
+            sender = sms_data.get("Number", "")
+            message_text = sms_data.get("Text", "")
+            expected_sender = self.config.get("balance_sms_sender", "7069")
+            balance_keywords = self.config.get(
+                "balance_keywords", ["Balance", "balance"]
+            )
+
             # Check if SMS is from balance sender and contains balance keywords
-            if sender == expected_sender and any(keyword in message_text for keyword in balance_keywords):
+            if sender == expected_sender and any(
+                keyword in message_text for keyword in balance_keywords
+            ):
                 logger.info(f"💰 Detected balance SMS from {sender}")
                 balance_data = self.balance_parser.parse_balance_sms(message_text)
                 # Publish balance data immediately
                 self.publish_balance_info(balance_data)
-        
+
         # Add message to history
         self.sms_history.add_message(
-            number=sms_data.get('Number', 'Unknown'),
-            text=sms_data.get('Text', ''),
-            timestamp=timestamp
+            number=sms_data.get("Number", "Unknown"),
+            text=sms_data.get("Text", ""),
+            timestamp=timestamp,
         )
-        
+
         # Include history in published data
-        sms_data['history'] = self.sms_history.get_history()
-        
+        sms_data["history"] = self.sms_history.get_history()
+
         topic = f"{self.topic_prefix}/sms/state"
         self.client.publish(topic, json.dumps(sms_data), qos=1, retain=True)
-        
+
         # Fire Home Assistant event for reliable automation triggering
         self.fire_ha_event(sms_data)
-        
-        logger.info(f"📡 Published SMS to MQTT: {sms_data.get('Number', 'Unknown')} -> {sms_data.get('Text', '')}")
-    
+
+        logger.info(
+            f"📡 Published SMS to MQTT: {sms_data.get('Number', 'Unknown')} -> {sms_data.get('Text', '')}"
+        )
+
     def fire_ha_event(self, sms_data: Dict[str, Any]):
         """Fire a Home Assistant event for received SMS using HTTP API"""
         # Prepare event data - field names match deprecated legacy_gsm_sms integration
         # for backwards compatibility: phone, text, date (+ timestamp, state for extra info)
         event_data = {
-            "phone": sms_data.get('Number', 'Unknown'),  # Matches deprecated integration
-            "text": sms_data.get('Text', ''),            # Matches deprecated integration
-            "date": sms_data.get('Date', ''),            # Matches deprecated integration
-            "timestamp": sms_data.get('timestamp', ''),  # Additional field for unix timestamp
-            "state": sms_data.get('State', 'UnRead')     # Additional field for SMS state
+            "phone": sms_data.get(
+                "Number", "Unknown"
+            ),  # Matches deprecated integration
+            "text": sms_data.get("Text", ""),  # Matches deprecated integration
+            "date": sms_data.get("Date", ""),  # Matches deprecated integration
+            "timestamp": sms_data.get(
+                "timestamp", ""
+            ),  # Additional field for unix timestamp
+            "state": sms_data.get("State", "UnRead"),  # Additional field for SMS state
         }
-        
-        logger.info(f"🔔 Attempting to fire HA event for SMS from {event_data['phone']}")
-        
+
+        logger.info(
+            f"🔔 Attempting to fire HA event for SMS from {event_data['phone']}"
+        )
+
         try:
             # Use Home Assistant API - requires homeassistant_api: true in config.yaml
-            ha_token = os.environ.get('SUPERVISOR_TOKEN', '')
+            ha_token = os.environ.get("SUPERVISOR_TOKEN", "")
             if not ha_token:
                 logger.error("❌ No SUPERVISOR_TOKEN found - cannot fire HA event")
                 return
-            
+
             # Use supervisor proxy to HA Core API (same as standalone addon)
             ha_url = "http://supervisor/core/api"
             url = f"{ha_url}/events/sms_gateway_message_received"
             headers = {
-                'Authorization': f'Bearer {ha_token}',
-                'Content-Type': 'application/json'
+                "Authorization": f"Bearer {ha_token}",
+                "Content-Type": "application/json",
             }
-            
+
             logger.debug(f"Posting to {url} with token length: {len(ha_token)}")
             response = requests.post(url, headers=headers, json=event_data, timeout=5)
-            
+
             if response.status_code in [200, 201]:
-                logger.info(f"✅ Successfully fired Home Assistant event: sms_gateway_message_received from {event_data['phone']}")
+                logger.info(
+                    f"✅ Successfully fired Home Assistant event: sms_gateway_message_received from {event_data['phone']}"
+                )
             else:
-                logger.error(f"❌ Failed to fire HA event: HTTP {response.status_code} - {response.text}")
-                
+                logger.error(
+                    f"❌ Failed to fire HA event: HTTP {response.status_code} - {response.text}"
+                )
+
         except requests.exceptions.RequestException as e:
             logger.error(f"❌ Network error firing HA event: {e}")
         except Exception as e:
             logger.error(f"❌ Unexpected error firing HA event: {e}", exc_info=True)
-    
+
     def publish_device_status(self):
         """Publish USB device connectivity status"""
         status_data = self.device_tracker.get_status_data()
-        status = status_data.get('status')
+        status = status_data.get("status")
 
         # Always log status changes, even if MQTT is disconnected
-        if hasattr(self, '_last_device_status') and self._last_device_status != status:
-            if status == 'online':
-                logger.info(f"📶 Modem: ONLINE (after {status_data.get('consecutive_failures', 0)} failures)")
-            elif status == 'offline':
-                logger.warning(f"❌ Modem: OFFLINE (no response for {status_data.get('seconds_since_last_success', 0)}s)")
-            elif status == 'unknown':
+        if hasattr(self, "_last_device_status") and self._last_device_status != status:
+            if status == "online":
+                logger.info(
+                    f"📶 Modem: ONLINE (after {status_data.get('consecutive_failures', 0)} failures)"
+                )
+            elif status == "offline":
+                logger.warning(
+                    f"❌ Modem: OFFLINE (no response for {status_data.get('seconds_since_last_success', 0)}s)"
+                )
+            elif status == "unknown":
                 logger.info("❓ Modem: UNKNOWN (no communication attempts yet)")
 
         self._last_device_status = status
@@ -2511,42 +2787,60 @@ class MQTTPublisher:
         # - total_operations / successful_operations: increment every successful operation
         # - last_seen: updates every successful operation
         # Only publish when event-driven fields change (status, failures, errors, hard_offline)
-        _volatile_fields = {'seconds_since_last_success', 'total_operations', 'successful_operations', 'last_seen'}
-        stable_data = {k: v for k, v in status_data.items() if k not in _volatile_fields}
-        if hasattr(self, '_last_published_stable_data') and self._last_published_stable_data == stable_data:
-            logger.debug("Device status data unchanged (excluding volatile fields), skipping redundant MQTT publish")
+        _volatile_fields = {
+            "seconds_since_last_success",
+            "total_operations",
+            "successful_operations",
+            "last_seen",
+        }
+        stable_data = {
+            k: v for k, v in status_data.items() if k not in _volatile_fields
+        }
+        if (
+            hasattr(self, "_last_published_stable_data")
+            and self._last_published_stable_data == stable_data
+        ):
+            logger.debug(
+                "Device status data unchanged (excluding volatile fields), skipping redundant MQTT publish"
+            )
             return
 
         # Publish to MQTT if connected
         if self.connected:
             topic = f"{self.topic_prefix}/device_status/state"
             self.client.publish(topic, json.dumps(status_data), retain=True, qos=1)
-            self._last_published_stable_data = stable_data.copy()  # Cache stable fields for dedup
+            self._last_published_stable_data = (
+                stable_data.copy()
+            )  # Cache stable fields for dedup
             logger.debug(f"📡 Published device status to MQTT: {status}")
         else:
-            logger.debug("Device status changed but MQTT not connected, skipping publish")
-    
+            logger.debug(
+                "Device status changed but MQTT not connected, skipping publish"
+            )
+
     def cache_smsc(self):
         """Cache SMSC number from modem for reliable SMS sending"""
         if not self.gammu_machine:
             return False
-        
+
         try:
             smsc_info = self.gammu_machine.GetSMSC(Location=1)
-            if smsc_info and smsc_info.get('Number'):
-                self.cached_smsc = smsc_info['Number']
+            if smsc_info and smsc_info.get("Number"):
+                self.cached_smsc = smsc_info["Number"]
                 self.smsc_cache_time = time.time()
                 logger.info(f"📞 Cached SMSC: {self.cached_smsc}")
                 return True
         except Exception as e:
             logger.warning(f"⚠️ Failed to cache SMSC: {e}")
         return False
-    
+
     def get_cached_smsc(self):
         """Get cached SMSC, refresh if expired"""
-        if (self.cached_smsc is None or 
-            self.smsc_cache_time is None or
-            time.time() - self.smsc_cache_time > self.smsc_cache_ttl):
+        if (
+            self.cached_smsc is None
+            or self.smsc_cache_time is None
+            or time.time() - self.smsc_cache_time > self.smsc_cache_ttl
+        ):
             self.cache_smsc()
         return self.cached_smsc
 
@@ -2563,70 +2857,68 @@ class MQTTPublisher:
         if not pending:
             logger.info("📥 No pending SMS to process")
             return
-        
+
         logger.info(f"📥 Processing {len(pending)} pending SMS from queue...")
-        
+
         for msg in pending:
-            number = msg.get('number')
-            text = msg.get('text')
-            smsc = msg.get('smsc')
-            attempts = msg.get('attempts', 0)
-            
-            logger.info(f"📤 Attempting to send queued SMS to {number} "
-                        f"(attempt #{attempts + 1})")
-            
+            number = msg.get("number")
+            text = msg.get("text")
+            smsc = msg.get("smsc")
+            attempts = msg.get("attempts", 0)
+
+            logger.info(
+                f"📤 Attempting to send queued SMS to {number} "
+                f"(attempt #{attempts + 1})"
+            )
+
             try:
                 from gammu import EncodeSMS
-                
+
                 # Build SMS message
                 smsinfo = {
-                    'Class': -1,
-                    'Unicode': False,
-                    'Entries': [
-                        {'ID': 'ConcatenatedTextLong', 'Buffer': text}
-                    ]
+                    "Class": -1,
+                    "Unicode": False,
+                    "Entries": [{"ID": "ConcatenatedTextLong", "Buffer": text}],
                 }
-                
+
                 # Detect if unicode needed
                 if detect_unicode_needed(text):
-                    smsinfo['Unicode'] = True
-                
+                    smsinfo["Unicode"] = True
+
                 # Encode and send
                 messages = EncodeSMS(smsinfo)
                 success = True
-                
+
                 for message in messages:
                     if smsc:
-                        message['SMSC'] = {'Number': smsc}
+                        message["SMSC"] = {"Number": smsc}
                     elif self.cached_smsc:
-                        message['SMSC'] = {'Number': self.cached_smsc}
+                        message["SMSC"] = {"Number": self.cached_smsc}
                     else:
-                        message['SMSC'] = {'Location': 1}
-                    
-                    message['Number'] = number
-                    
+                        message["SMSC"] = {"Location": 1}
+
+                    message["Number"] = number
+
                     try:
                         self.track_gammu_operation(
-                            "SendSMS",
-                            self.gammu_machine.SendSMS,
-                            message
+                            "SendSMS", self.gammu_machine.SendSMS, message
                         )
                     except Exception as e:
                         logger.error(f"❌ Failed to send queued SMS to {number}: {e}")
                         self.sms_queue.increment_attempts(number, text)
                         success = False
                         break
-                
+
                 if success:
                     # Successfully sent - remove from queue
                     self.sms_queue.remove(number, text)
                     self.sms_counter.increment()
                     logger.info(f"✅ Queued SMS sent successfully to {number}")
-                    
+
             except Exception as e:
                 logger.error(f"❌ Error processing queued SMS for {number}: {e}")
                 self.sms_queue.increment_attempts(number, text)
-        
+
         # Publish updated counter after processing queue
         self.publish_sms_counter()
         remaining = self.sms_queue.get_count()
@@ -2639,13 +2931,10 @@ class MQTTPublisher:
             return
 
         count = self.sms_counter.get_sent_count()
-        sms_cost_per_message = self.config.get('sms_cost_per_message', 0.0)
+        sms_cost_per_message = self.config.get("sms_cost_per_message", 0.0)
         total_cost = count * sms_cost_per_message
 
-        counter_data = {
-            "count": count,
-            "cost": round(total_cost, 2)
-        }
+        counter_data = {"count": count, "cost": round(total_cost, 2)}
 
         topic = f"{self.topic_prefix}/sms_counter/state"
         self.client.publish(topic, json.dumps(counter_data), retain=True)
@@ -2658,9 +2947,7 @@ class MQTTPublisher:
 
         count = self.sms_counter.get_received_count()
 
-        counter_data = {
-            "count": count
-        }
+        counter_data = {"count": count}
 
         topic = f"{self.topic_prefix}/sms_received_counter/state"
         self.client.publish(topic, json.dumps(counter_data), retain=True)
@@ -2673,7 +2960,9 @@ class MQTTPublisher:
 
         topic = f"{self.topic_prefix}/modem_info/state"
         self.client.publish(topic, json.dumps(modem_data), retain=True)
-        logger.info(f"📡 Published modem info to MQTT: {modem_data.get('Manufacturer', 'Unknown')} {modem_data.get('Model', 'Unknown')}")
+        logger.info(
+            f"📡 Published modem info to MQTT: {modem_data.get('Manufacturer', 'Unknown')} {modem_data.get('Model', 'Unknown')}"
+        )
 
     def publish_sim_info(self, sim_data: Dict[str, Any]):
         """Publish SIM card information"""
@@ -2682,7 +2971,9 @@ class MQTTPublisher:
 
         topic = f"{self.topic_prefix}/sim_info/state"
         self.client.publish(topic, json.dumps(sim_data), retain=True)
-        logger.info(f"📡 Published SIM info to MQTT: IMSI={sim_data.get('IMSI', 'Unknown')}")
+        logger.info(
+            f"📡 Published SIM info to MQTT: IMSI={sim_data.get('IMSI', 'Unknown')}"
+        )
 
     def publish_sms_capacity(self, capacity_data: Dict[str, Any]):
         """Publish SMS storage capacity"""
@@ -2691,53 +2982,57 @@ class MQTTPublisher:
 
         topic = f"{self.topic_prefix}/sms_capacity/state"
         self.client.publish(topic, json.dumps(capacity_data), retain=True)
-        logger.info(f"📡 Published SMS capacity to MQTT: {capacity_data.get('SIMUsed', 0)}/{capacity_data.get('SIMSize', 0)}")
-    
+        logger.info(
+            f"📡 Published SMS capacity to MQTT: {capacity_data.get('SIMUsed', 0)}/{capacity_data.get('SIMSize', 0)}"
+        )
+
     def publish_balance_info(self, balance_data: Dict[str, Any]):
         """Publish account balance information parsed from SMS"""
         if not self.connected:
             return
-        
+
         topic = f"{self.topic_prefix}/balance/state"
         self.client.publish(topic, json.dumps(balance_data), retain=True)
-        
+
         # Log readable summary
         summary_parts = []
-        if balance_data.get('account_balance'):
+        if balance_data.get("account_balance"):
             summary_parts.append(f"Balance: {balance_data['account_balance']}")
-        if balance_data.get('data_remaining'):
+        if balance_data.get("data_remaining"):
             summary_parts.append(f"Data: {balance_data['data_remaining']}")
-        if balance_data.get('minutes_remaining'):
+        if balance_data.get("minutes_remaining"):
             summary_parts.append(f"Minutes: {balance_data['minutes_remaining']}")
-        if balance_data.get('messages_remaining'):
+        if balance_data.get("messages_remaining"):
             summary_parts.append(f"Messages: {balance_data['messages_remaining']}")
-        if balance_data.get('plan_expiry'):
+        if balance_data.get("plan_expiry"):
             summary_parts.append(f"Expires: {balance_data['plan_expiry']}")
-        
+
         summary = ", ".join(summary_parts) if summary_parts else "No data parsed"
         logger.info(f"💰 Published balance info to MQTT: {summary}")
-    
+
     def publish_delivery_pending(self, message_refs, number):
         """Publish pending delivery status"""
         if not self.connected or not message_refs:
             return
-        
+
         topic = f"{self.topic_prefix}/delivery_status"
         status_data = {
             "status": "pending",
             "message_refs": message_refs,
             "number": number,
             "pending_count": self.delivery_tracker.get_pending_count(),
-            "timestamp": time.strftime("%Y-%m-%d %H:%M:%S")
+            "timestamp": time.strftime("%Y-%m-%d %H:%M:%S"),
         }
         self.client.publish(topic, json.dumps(status_data), retain=True)
-        logger.info(f"📬 Published pending delivery status for {len(message_refs)} message(s) to {number}")
-    
+        logger.info(
+            f"📬 Published pending delivery status for {len(message_refs)} message(s) to {number}"
+        )
+
     def publish_delivery_report(self, message_ref, status, delivery_info):
         """Publish delivery report when received"""
         if not self.connected:
             return
-        
+
         topic = f"{self.topic_prefix}/delivery_status"
         status_data = {
             "status": status,
@@ -2747,26 +3042,28 @@ class MQTTPublisher:
             "sent_timestamp": delivery_info.get("sent_timestamp", ""),
             "delivered_timestamp": delivery_info.get("delivered_timestamp", ""),
             "pending_count": self.delivery_tracker.get_pending_count(),
-            "timestamp": time.strftime("%Y-%m-%d %H:%M:%S")
+            "timestamp": time.strftime("%Y-%m-%d %H:%M:%S"),
         }
         self.client.publish(topic, json.dumps(status_data), retain=True)
         logger.info(f"📬 Published delivery report: ref={message_ref}, status={status}")
-    
+
     def _attempt_reconnect_if_needed(self):
         """Attempt to reconnect to modem if auto_recovery is enabled and threshold is reached"""
         if not self.auto_recovery:
             return
-        
+
         if self.consecutive_failures < self.reconnect_threshold:
             return
-        
+
         current_time = time.time()
         if current_time - self.last_reconnect_attempt < self.reconnect_cooldown:
             return  # Still in cooldown period
-        
+
         self.last_reconnect_attempt = current_time
-        logger.warning(f"🔄 Attempting automatic modem reconnection after {self.consecutive_failures} failures...")
-        
+        logger.warning(
+            f"🔄 Attempting automatic modem reconnection after {self.consecutive_failures} failures..."
+        )
+
         if self._reconnect_gammu():
             logger.info("✅ Automatic modem reconnection successful!")
             self.consecutive_failures = 0
@@ -2774,17 +3071,20 @@ class MQTTPublisher:
             # The reconnect may succeed but modem can still be in bad state.
             # Only reset on actual successful Gammu operation (in track_gammu_operation)
         else:
-            logger.error(f"❌ Automatic modem reconnection failed. Will retry in {self.reconnect_cooldown}s")
+            logger.error(
+                f"❌ Automatic modem reconnection failed. Will retry in {self.reconnect_cooldown}s"
+            )
             # Track failure time for restart timeout (applies to ALL errors, not just specific codes)
             self._check_restart_timeout()
-    
+
     def _reconnect_gammu(self):
         """Attempt to re-initialize Gammu state machine"""
         try:
             from support import init_state_machine
-            pin = self.config.get('pin', '')
-            device_path = self.config.get('device_path', '/dev/ttyUSB0')
-            
+
+            pin = self.config.get("pin", "")
+            device_path = self.config.get("device_path", "/dev/ttyUSB0")
+
             # Acquire lock to prevent other threads from using modem during reinit
             with self.gammu_lock:
                 # CRITICAL: Close existing connection first to release the serial port
@@ -2794,11 +3094,13 @@ class MQTTPublisher:
                         self.gammu_machine.Terminate()
                         logger.info("✅ Existing connection terminated")
                     except Exception as e:
-                        logger.warning(f"⚠️ Terminate failed (may already be closed): {e}")
-                
+                        logger.warning(
+                            f"⚠️ Terminate failed (may already be closed): {e}"
+                        )
+
                 logger.info(f"🔌 Re-initializing Gammu with device: {device_path}")
                 new_machine = init_state_machine(pin, device_path)
-                
+
                 # Test the new connection with a simple operation
                 try:
                     new_machine.GetManufacturer()
@@ -2808,73 +3110,85 @@ class MQTTPublisher:
                 except Exception as e:
                     logger.error(f"❌ Reconnected machine failed test: {e}")
                     return False
-                
+
         except Exception as e:
             logger.error(f"❌ Failed to re-initialize Gammu: {e}")
             return False
 
     def _check_restart_timeout(self):
         """Check if failure duration exceeds restart timeout and trigger restart if needed.
-        
+
         This is called for ALL failures (not just specific error codes) to ensure
         the addon restarts after prolonged modem problems of any kind.
-        
+
         Uses shorter timeout when in hard_offline state (modem completely frozen).
         """
         if not self.auto_restart_on_failure:
             return
-        
+
         current_time = time.time()
         if self.failure_start_time is None:
             self.failure_start_time = current_time
             logger.info(f"⏱️ Failure tracking started at {time.strftime('%H:%M:%S')}")
-        
+
         failure_duration = current_time - self.failure_start_time
-        
+
         # Use shorter timeout when modem is in hard offline state (completely frozen)
         is_hard_offline = self.device_tracker.hard_offline
-        effective_timeout = self.hard_offline_restart_timeout if is_hard_offline else self.restart_timeout
+        effective_timeout = (
+            self.hard_offline_restart_timeout
+            if is_hard_offline
+            else self.restart_timeout
+        )
         timeout_type = "hard offline" if is_hard_offline else "standard"
-        
-        logger.info(f"⏱️ Modem failing for {int(failure_duration)}s "
-                    f"(restart after {effective_timeout}s, {timeout_type})")
-        
+
+        logger.info(
+            f"⏱️ Modem failing for {int(failure_duration)}s "
+            f"(restart after {effective_timeout}s, {timeout_type})"
+        )
+
         if failure_duration >= effective_timeout:
             logger.error(
                 f"🔴 Modem failed for {int(failure_duration)}s - triggering restart!"
             )
             time.sleep(2)  # Brief pause for logs to flush
             os._exit(1)  # Force exit even from threads - HA Supervisor will restart us
-    
+
     def _trigger_emergency_reset(self, error_code=None):
         """Emergency modem reset for hung state recovery - full reconnect or restart"""
         logger.warning("🚨 Triggering emergency modem recovery...")
-        
+
         # Check for device I/O errors (USB is broken - addon restart is the only fix)
         # Code 2: ERR_DEVICEOPENERROR - device unavailable
         # Code 11: ERR_DEVICEWRITEERROR - error writing to device
         if error_code in (2, 11):
-            error_names = {2: 'Device unavailable', 11: 'Device write error'}
-            logger.error(f"🔴 {error_names.get(error_code, 'Device error')} "
-                         "(USB broken) - restart required!")
+            error_names = {2: "Device unavailable", 11: "Device write error"}
+            logger.error(
+                f"🔴 {error_names.get(error_code, 'Device error')} "
+                "(USB broken) - restart required!"
+            )
             if self.auto_restart_on_failure:
                 logger.warning("🔄 Auto-restarting addon to recover device...")
                 time.sleep(2)  # Brief pause for logs to flush
-                os._exit(1)  # Force exit even from threads - HA Supervisor will restart us
+                os._exit(
+                    1
+                )  # Force exit even from threads - HA Supervisor will restart us
             else:
                 logger.warning("⚠️ Auto-restart disabled, manual intervention required")
                 return False
-        
+
         # Track continuous failure time for timeout-based restart
         current_time = time.time()
         if self.failure_start_time is None:
             self.failure_start_time = current_time
             logger.info(f"⏱️ Failure tracking started at {time.strftime('%H:%M:%S')}")
-        
+
         failure_duration = current_time - self.failure_start_time
-        logger.info(f"⏱️ Modem failing for {int(failure_duration)}s "
-                    f"(restart after {self.restart_timeout}s)")
-        
+        logger.info(
+            f"⏱️ Modem failing for {int(failure_duration)}s "
+            f"(restart after {self.restart_timeout}s)"
+        )
+
         # Check if we've exceeded the restart timeout
         if failure_duration >= self.restart_timeout and self.auto_restart_on_failure:
             logger.error(
@@ -2882,18 +3196,18 @@ class MQTTPublisher:
             )
             time.sleep(2)  # Brief pause for logs to flush
             os._exit(1)  # Force exit even from threads - HA Supervisor will restart us
-        
+
         # Clear SMSC cache first
         self.cached_smsc = None
         self.smsc_cache_time = None
         logger.info("🔄 SMSC cache cleared")
-        
+
         # Try soft reset first (faster if it works)
         try:
             self.gammu_machine.Reset(False)
             logger.info("✅ Soft reset completed, waiting 10s...")
             time.sleep(10)
-            
+
             # Test if modem responds after soft reset
             try:
                 self.gammu_machine.GetManufacturer()
@@ -2906,7 +3220,7 @@ class MQTTPublisher:
                 logger.warning("⚠️ Modem still unresponsive, trying full reconnect...")
         except Exception as e:
             logger.warning(f"⚠️ Soft reset failed: {e}, trying full reconnect...")
-        
+
         # Full reconnect if soft reset didn't work
         if self._reconnect_gammu():
             logger.info("✅ Full modem reconnect successful, waiting 5s...")
@@ -2924,9 +3238,10 @@ class MQTTPublisher:
     def publish_missed_call(self, call_data: dict):
         """Publish missed call to MQTT (real-time callback version)."""
         from datetime import datetime
+
         # Add processed_at if missing
-        if 'processed_at' not in call_data:
-            call_data['processed_at'] = datetime.now().isoformat()
+        if "processed_at" not in call_data:
+            call_data["processed_at"] = datetime.now().isoformat()
 
         # Save to persistent storage (backup for MQTT retained message loss)
         self.missed_call_tracker.add_call(call_data)
@@ -2957,10 +3272,10 @@ class MQTTPublisher:
             last_call = self.call_queue[-1]
             payload = {
                 "state": "ON",
-                "Number": last_call['number'],
-                "ring_start": last_call['ring_start'].isoformat(),
-                "ring_count": last_call['ring_count'],
-                "queue_size": len(self.call_queue)
+                "Number": last_call["number"],
+                "ring_start": last_call["ring_start"].isoformat(),
+                "ring_count": last_call["ring_count"],
+                "queue_size": len(self.call_queue),
             }
         else:
             payload = {"state": "OFF"}
@@ -2976,9 +3291,9 @@ class MQTTPublisher:
         try:
             logger.debug(f"📱 Gammu event: type={event_type}, data={data}")
 
-            if event_type == 'Call':
+            if event_type == "Call":
                 self._handle_call_event(data)
-            elif event_type == 'SMS':
+            elif event_type == "SMS":
                 self._handle_sms_event(data)
             else:
                 logger.debug(f"📱 Unknown event type: {event_type}")
@@ -2989,18 +3304,19 @@ class MQTTPublisher:
     def _handle_call_event(self, call_data):
         """Handle call event with queue support (up to 5 simultaneous calls)."""
         from datetime import datetime
-        status = call_data.get('Status', '')
-        number = call_data.get('Number', '') or 'Unknown'
+
+        status = call_data.get("Status", "")
+        number = call_data.get("Number", "") or "Unknown"
 
         logger.debug(f"📞 Call event: status={status}, number={number}")
 
-        if status == 'IncomingCall':
+        if status == "IncomingCall":
             # Find existing call by number
-            existing = next((c for c in self.call_queue if c['number'] == number), None)
+            existing = next((c for c in self.call_queue if c["number"] == number), None)
 
             if existing:
                 # Continued ringing (RING) - increment ring_count
-                existing['ring_count'] += 1
+                existing["ring_count"] += 1
                 logger.info(f"📞 RING #{existing['ring_count']} from {number}")
             else:
                 # New call
@@ -3008,12 +3324,14 @@ class MQTTPublisher:
                     # Queue full - publish oldest as missed
                     oldest = self.call_queue.pop(0)
                     self._publish_missed_call_from_queue(oldest, queue_full=True)
-                    logger.info(f"📞 Queue full, evicting oldest call from {oldest['number']}")
+                    logger.info(
+                        f"📞 Queue full, evicting oldest call from {oldest['number']}"
+                    )
 
                 new_call = {
-                    'number': number,
-                    'ring_start': datetime.now(),
-                    'ring_count': 1
+                    "number": number,
+                    "ring_start": datetime.now(),
+                    "ring_count": 1,
                 }
                 self.call_queue.append(new_call)
                 logger.info(f"📞 Incoming call from {number}")
@@ -3023,50 +3341,60 @@ class MQTTPublisher:
             self._start_call_auto_reset_timer()
             self.publish_incoming_call_state(True)
 
-        elif status in ['CallRemoteEnd', 'CallLocalEnd']:
+        elif status in ["CallRemoteEnd", "CallLocalEnd"]:
             # Call ended - find call by number
             call = None
 
-            if number and number != 'Unknown':
+            if number and number != "Unknown":
                 # Have number - search by it
-                call = next((c for c in self.call_queue if c['number'] == number), None)
+                call = next((c for c in self.call_queue if c["number"] == number), None)
 
             if not call and len(self.call_queue) == 1:
                 # No number (or not found), but only 1 call - remove it
                 call = self.call_queue[0]
-                logger.info(f"📞 CallEnd without number, removing only queued call from {call['number']}")
+                logger.info(
+                    f"📞 CallEnd without number, removing only queued call from {call['number']}"
+                )
 
             elif not call and len(self.call_queue) > 1:
                 # Multiple calls and don't know which - log warning
-                logger.warning(f"📞 CallEnd without number, but {len(self.call_queue)} calls in queue - cannot determine which to remove")
+                logger.warning(
+                    f"📞 CallEnd without number, but {len(self.call_queue)} calls in queue - cannot determine which to remove"
+                )
 
             if call:
                 self.call_queue.remove(call)
                 self._publish_missed_call_from_queue(call)
-                logger.info(f"📞 Call ended from {call['number']} (rang {call['ring_count']} times)")
+                logger.info(
+                    f"📞 Call ended from {call['number']} (rang {call['ring_count']} times)"
+                )
 
             # If queue is empty, reset state
             if not self.call_queue:
                 self._cancel_call_auto_reset_timer()
                 self._call_ended_at = datetime.now()  # Start cooldown
-                self._post_call_reinit_needed = True  # Request modem reinit after cooldown
+                self._post_call_reinit_needed = (
+                    True  # Request modem reinit after cooldown
+                )
                 logger.info("🔄 Modem reinit requested after cooldown")
                 self.publish_incoming_call_state(False)
             else:
                 # Update binary sensor to show last number in queue
                 self.publish_incoming_call_state(True)
 
-        elif status == 'CallStart':
+        elif status == "CallStart":
             # Call was answered - not missed, remove from queue
             call = None
 
-            if number and number != 'Unknown':
-                call = next((c for c in self.call_queue if c['number'] == number), None)
+            if number and number != "Unknown":
+                call = next((c for c in self.call_queue if c["number"] == number), None)
 
             if not call and len(self.call_queue) == 1:
                 # No number, but only 1 call - remove it
                 call = self.call_queue[0]
-                logger.info(f"📞 CallStart without number, removing only queued call from {call['number']}")
+                logger.info(
+                    f"📞 CallStart without number, removing only queued call from {call['number']}"
+                )
 
             if call:
                 self.call_queue.remove(call)
@@ -3075,30 +3403,35 @@ class MQTTPublisher:
             if not self.call_queue:
                 self._cancel_call_auto_reset_timer()
                 self._call_ended_at = datetime.now()  # Start cooldown
-                self._post_call_reinit_needed = True  # Request modem reinit after cooldown
+                self._post_call_reinit_needed = (
+                    True  # Request modem reinit after cooldown
+                )
                 logger.info("🔄 Modem reinit requested after cooldown")
                 self.publish_incoming_call_state(False)
             else:
                 self.publish_incoming_call_state(True)
 
-    def _publish_missed_call_from_queue(self, call: dict, queue_full: bool = False, auto_reset: bool = False):
+    def _publish_missed_call_from_queue(
+        self, call: dict, queue_full: bool = False, auto_reset: bool = False
+    ):
         """Publish missed call from queue with additional attributes."""
         from datetime import datetime
+
         ring_end = datetime.now()
-        duration = (ring_end - call['ring_start']).total_seconds()
+        duration = (ring_end - call["ring_start"]).total_seconds()
 
         missed_data = {
-            'Number': call['number'],
-            'ring_start': call['ring_start'].isoformat(),
-            'ring_end': ring_end.isoformat(),
-            'ring_duration_seconds': int(duration),
-            'ring_count': call['ring_count']
+            "Number": call["number"],
+            "ring_start": call["ring_start"].isoformat(),
+            "ring_end": ring_end.isoformat(),
+            "ring_duration_seconds": int(duration),
+            "ring_count": call["ring_count"],
         }
 
         if queue_full:
-            missed_data['queue_full'] = True
+            missed_data["queue_full"] = True
         if auto_reset:
-            missed_data['auto_reset'] = True
+            missed_data["auto_reset"] = True
 
         self.publish_missed_call(missed_data)
 
@@ -3106,12 +3439,11 @@ class MQTTPublisher:
         """Start timer to auto-reset incoming call state (fallback for modems that don't send CallEnd events)."""
         self._cancel_call_auto_reset_timer()
 
-        timeout = self.config.get('incoming_call_auto_reset_seconds', 60)
+        timeout = self.config.get("incoming_call_auto_reset_seconds", 60)
         logger.debug(f"📞 Starting call auto-reset timer: {timeout}s")
 
         self._call_auto_reset_timer = threading.Timer(
-            timeout,
-            self._auto_reset_incoming_call
+            timeout, self._auto_reset_incoming_call
         )
         self._call_auto_reset_timer.daemon = True
         self._call_auto_reset_timer.start()
@@ -3125,8 +3457,11 @@ class MQTTPublisher:
     def _auto_reset_incoming_call(self):
         """Auto-reset: publish all calls in queue as missed."""
         from datetime import datetime
+
         if self.call_queue:
-            logger.info(f"📞 Auto-reset timeout - publishing {len(self.call_queue)} missed call(s)")
+            logger.info(
+                f"📞 Auto-reset timeout - publishing {len(self.call_queue)} missed call(s)"
+            )
 
             for call in self.call_queue:
                 self._publish_missed_call_from_queue(call, auto_reset=True)
@@ -3142,7 +3477,7 @@ class MQTTPublisher:
     def _handle_sms_event(self, sms_data):
         """Handle SMS event - trigger for faster processing."""
         # Respect sms_monitoring_enabled setting
-        if not self.config.get('sms_monitoring_enabled', True):
+        if not self.config.get("sms_monitoring_enabled", True):
             logger.debug("📨 SMS event ignored (sms_monitoring_enabled=false)")
             return
 
@@ -3154,10 +3489,7 @@ class MQTTPublisher:
 
         # Set flag and start timer (3s debounce for multi-part SMS)
         self._sms_callback_pending = True
-        self._sms_callback_timer = threading.Timer(
-            3.0,
-            self._process_sms_from_callback
-        )
+        self._sms_callback_timer = threading.Timer(3.0, self._process_sms_from_callback)
         self._sms_callback_timer.start()
 
     def _process_sms_from_callback(self):
@@ -3173,7 +3505,7 @@ class MQTTPublisher:
             return
 
         try:
-            from support import retrieveAllSms, deleteSms
+            from support import deleteSms, retrieveAllSms
 
             with self.gammu_lock:
                 all_sms = retrieveAllSms(self.gammu_machine)
@@ -3187,7 +3519,7 @@ class MQTTPublisher:
                 self.publish_sms_received(sms)
 
                 # Auto-delete if enabled
-                if self.config.get('auto_delete_read_sms', True):
+                if self.config.get("auto_delete_read_sms", True):
                     with self.gammu_lock:
                         deleteSms(self.gammu_machine, sms)
 
@@ -3207,14 +3539,11 @@ class MQTTPublisher:
         from support import setupCallbacks
 
         # Setup unified callback for calls and SMS
-        result = setupCallbacks(
-            gammu_machine,
-            self._handle_gammu_event
-        )
+        result = setupCallbacks(gammu_machine, self._handle_gammu_event)
 
         # Our setupCallbacks returns 'incoming_call' and 'incoming_sms' keys
-        self.call_monitoring_enabled = result.get('incoming_call', False)
-        self.sms_callback_enabled = result.get('incoming_sms', False)
+        self.call_monitoring_enabled = result.get("incoming_call", False)
+        self.sms_callback_enabled = result.get("incoming_sms", False)
 
         if self.call_monitoring_enabled:
             logger.info("📞 Call callback: ENABLED (real-time detection)")
@@ -3230,6 +3559,7 @@ class MQTTPublisher:
 
         # Start ReadDevice loop only if at least one callback works
         if self.call_monitoring_enabled or self.sms_callback_enabled:
+
             def _read_device_loop():
                 logger.info("🔄 ReadDevice loop started (1s interval)")
                 while self.connected and not self.disconnecting:
@@ -3253,9 +3583,7 @@ class MQTTPublisher:
                 logger.info("🔄 ReadDevice loop stopped")
 
             self._read_device_thread = threading.Thread(
-                target=_read_device_loop,
-                daemon=True,
-                name="ReadDeviceLoop"
+                target=_read_device_loop, daemon=True, name="ReadDeviceLoop"
             )
             self._read_device_thread.start()
             return True
@@ -3263,7 +3591,7 @@ class MQTTPublisher:
         return False
 
     # ==================== END CALL MONITORING METHODS ====================
-        
+
     def track_gammu_operation(self, operation_name, gammu_function, *args, **kwargs):
         """Execute gammu operation with connectivity tracking, thread safety, and Python-level timeout"""
         # Use lock to serialize all Gammu operations (prevent race conditions on serial port)
@@ -3273,8 +3601,10 @@ class MQTTPublisher:
             if self.device_tracker.hard_offline:
                 logger.debug(f"Skipping {operation_name} - modem in hard_offline state")
                 self._check_restart_timeout()
-                raise TimeoutError(f"Modem in hard_offline state, skipping {operation_name}")
-            
+                raise TimeoutError(
+                    f"Modem in hard_offline state, skipping {operation_name}"
+                )
+
             # Use ThreadPoolExecutor WITHOUT context manager to avoid shutdown(wait=True)
             # which would block until the hung thread completes (could be minutes!)
             executor = concurrent.futures.ThreadPoolExecutor(max_workers=1)
@@ -3284,13 +3614,13 @@ class MQTTPublisher:
                     # Python-level timeout (15s) as second defense layer
                     # Primary defense is Gammu commtimeout=10s in config
                     result = future.result(timeout=15)
-                    
+
                     # Check if we were previously failing (modem recovered)
                     was_failing = self.failure_start_time is not None
-                    
+
                     self.device_tracker.record_success(operation_name=operation_name)
                     self.consecutive_failures = 0  # Reset failure counter on success
-                    
+
                     # Only reset restart timer if NOT in hard_offline state
                     # In hard_offline, we want the timer to keep running until restart
                     if not self.device_tracker.hard_offline:
@@ -3298,18 +3628,18 @@ class MQTTPublisher:
                     else:
                         # Still in hard offline - check if we should restart
                         self._check_restart_timeout()
-                    
+
                     self.publish_device_status()
                     logger.debug(f"✅ Gammu operation '{operation_name}' succeeded")
-                    
+
                     # If modem just recovered, process any pending SMS
                     if was_failing and self.sms_queue.get_count() > 0:
                         logger.info("📥 Modem recovered! Processing pending SMS...")
                         # Schedule processing in background to not block current op
                         import threading
+
                         threading.Thread(
-                            target=self.process_pending_sms,
-                            daemon=True
+                            target=self.process_pending_sms, daemon=True
                         ).start()
 
                     # Configurable delay after each operation to let modem "breathe"
@@ -3325,42 +3655,48 @@ class MQTTPublisher:
                     self.device_tracker.record_failure(
                         f"{operation_name}: Python timeout (15s)",
                         is_timeout=True,
-                        operation_name=operation_name
+                        operation_name=operation_name,
                     )
                     self.publish_device_status()
                     self._attempt_reconnect_if_needed()
                     self._check_restart_timeout()  # Check if restart is needed
-                    logger.error(f"⏱️ Gammu operation '{operation_name}' timed out after 15s")
-                    raise TimeoutError(f"Gammu operation '{operation_name}' timed out after 15s")
+                    logger.error(
+                        f"⏱️ Gammu operation '{operation_name}' timed out after 15s"
+                    )
+                    raise TimeoutError(
+                        f"Gammu operation '{operation_name}' timed out after 15s"
+                    )
                 except Exception as e:
                     # Check for modem hung/communication errors that benefit from reset+retry
                     # These errors indicate the modem is in a bad state and needs a reset
                     # Reference: https://docs.gammu.org/c/error.html
                     RECOVERABLE_ERROR_CODES = {
-                        2: 'ERR_DEVICEOPENERROR',   # Device unavailable (USB gone)
-                        11: 'ERR_DEVICEWRITEERROR', # Error writing to device (USB broken)
-                        14: 'ERR_TIMEOUT',          # Command timed out
-                        31: 'ERR_EMPTYSMSC',        # SMSC number is empty
-                        33: 'ERR_NOTCONNECTED',     # Phone NOT connected
-                        37: 'ERR_BUG',              # Bug in implementation/phone
-                        56: 'ERR_PHONE_INTERNAL',   # Internal phone error
-                        69: 'ERR_GETTING_SMSC',     # Failed to get SMSC from phone
+                        2: "ERR_DEVICEOPENERROR",  # Device unavailable (USB gone)
+                        11: "ERR_DEVICEWRITEERROR",  # Error writing to device (USB broken)
+                        14: "ERR_TIMEOUT",  # Command timed out
+                        31: "ERR_EMPTYSMSC",  # SMSC number is empty
+                        33: "ERR_NOTCONNECTED",  # Phone NOT connected
+                        37: "ERR_BUG",  # Bug in implementation/phone
+                        56: "ERR_PHONE_INTERNAL",  # Internal phone error
+                        69: "ERR_GETTING_SMSC",  # Failed to get SMSC from phone
                     }
-                    
+
                     # Device I/O errors that require immediate restart (USB is broken)
                     DEVICE_ERROR_CODES = {2, 11}  # DEVICEOPENERROR, DEVICEWRITEERROR
-                    
+
                     needs_reset_retry = False
                     error_code = None
                     try:
                         # Try to extract error code from Gammu exception
                         # Gammu exceptions have args[0] as a dict with 'Code' key
-                        if hasattr(e, 'args') and len(e.args) > 0:
+                        if hasattr(e, "args") and len(e.args) > 0:
                             arg0 = e.args[0]
                             if isinstance(arg0, dict):
-                                error_code = arg0.get('Code')
+                                error_code = arg0.get("Code")
                                 if error_code is not None:
-                                    logger.debug(f"Extracted Gammu error code: {error_code}")
+                                    logger.debug(
+                                        f"Extracted Gammu error code: {error_code}"
+                                    )
                                     if error_code in RECOVERABLE_ERROR_CODES:
                                         needs_reset_retry = True
                             else:
@@ -3369,18 +3705,21 @@ class MQTTPublisher:
                                 err_str = str(e)
                                 if "'Code':" in err_str:
                                     import re
+
                                     match = re.search(r"'Code':\s*(\d+)", err_str)
                                     if match:
                                         error_code = int(match.group(1))
-                                        logger.debug(f"Extracted error code from string: {error_code}")
+                                        logger.debug(
+                                            f"Extracted error code from string: {error_code}"
+                                        )
                                         if error_code in RECOVERABLE_ERROR_CODES:
                                             needs_reset_retry = True
                     except Exception as extract_err:
                         logger.debug(f"Error code extraction failed: {extract_err}")
-                    
+
                     if needs_reset_retry:
                         error_name = RECOVERABLE_ERROR_CODES.get(
-                            error_code, f'Code {error_code}'
+                            error_code, f"Code {error_code}"
                         )
                         logger.error(
                             f"🚨 {error_name} detected in '{operation_name}' - "
@@ -3390,12 +3729,11 @@ class MQTTPublisher:
                         # Mark exception for retry logic
                         e.err_recoverable_detected = True
                         raise
-                    
+
                     # All other errors (including Gammu commtimeout errors)
                     self.consecutive_failures += 1
                     self.device_tracker.record_failure(
-                        f"{operation_name}: {str(e)}",
-                        operation_name=operation_name
+                        f"{operation_name}: {str(e)}", operation_name=operation_name
                     )
                     self.publish_device_status()
                     self._attempt_reconnect_if_needed()
@@ -3405,12 +3743,12 @@ class MQTTPublisher:
                 # CRITICAL: shutdown(wait=False) to NOT wait for hung thread
                 # The thread may still be blocked in Gammu for minutes, but we don't care
                 executor.shutdown(wait=False)
-    
+
     def _publish_initial_states(self):
         """Publish initial sensor states on startup"""
         if self.connected:
             import time
-            
+
             # Reset all text input fields on startup (clear old values)
             phone_state_topic = f"{self.topic_prefix}/phone_number/state"
             message_state_topic = f"{self.topic_prefix}/message_text/state"
@@ -3434,45 +3772,58 @@ class MQTTPublisher:
             self.current_phone_number = ""
             self.current_message_text = ""
 
-            logger.info("📡 Published initial text field states: cleared phone, message, and USSD fields")
+            logger.info(
+                "📡 Published initial text field states: cleared phone, message, and USSD fields"
+            )
 
             # Publish initial status sensor states (with retain=True to replace old messages)
             send_status_topic = f"{self.topic_prefix}/send_status"
             delete_status_topic = f"{self.topic_prefix}/delete_sms_status"
             delivery_status_topic = f"{self.topic_prefix}/delivery_status"
-            
+
             # Publish initial send_status as "ready"
             send_status_data = {
                 "status": "ready",
                 "message": "SMS Gateway ready to send messages",
-                "timestamp": time.strftime("%Y-%m-%d %H:%M:%S")
+                "timestamp": time.strftime("%Y-%m-%d %H:%M:%S"),
             }
-            self.client.publish(send_status_topic, json.dumps(send_status_data), retain=True, qos=1)
+            self.client.publish(
+                send_status_topic, json.dumps(send_status_data), retain=True, qos=1
+            )
 
             # Publish initial delete_status as "idle"
             delete_status_data = {
                 "status": "idle",
                 "message": "No delete operations yet",
-                "timestamp": time.strftime("%Y-%m-%d %H:%M:%S")
+                "timestamp": time.strftime("%Y-%m-%d %H:%M:%S"),
             }
-            self.client.publish(delete_status_topic, json.dumps(delete_status_data), retain=True, qos=1)
+            self.client.publish(
+                delete_status_topic, json.dumps(delete_status_data), retain=True, qos=1
+            )
 
             # Publish initial delivery_status as "idle"
             delivery_status_data = {
                 "status": "idle",
                 "message": "No delivery reports yet",
                 "pending_count": 0,
-                "timestamp": time.strftime("%Y-%m-%d %H:%M:%S")
+                "timestamp": time.strftime("%Y-%m-%d %H:%M:%S"),
             }
-            self.client.publish(delivery_status_topic, json.dumps(delivery_status_data), retain=True, qos=1)
+            self.client.publish(
+                delivery_status_topic,
+                json.dumps(delivery_status_data),
+                retain=True,
+                qos=1,
+            )
 
-            logger.info("📡 Published initial status states (send_status: ready, delete_status: idle, delivery_status: idle)")
-    
+            logger.info(
+                "📡 Published initial status states (send_status: ready, delete_status: idle, delivery_status: idle)"
+            )
+
     def _restore_sms_history(self):
         """Restore last SMS from history after discovery is complete"""
         if not self.connected:
             return
-        
+
         history = self.sms_history.get_history()
         if history:
             last_sms = history[-1]  # Get most recent message
@@ -3481,20 +3832,18 @@ class MQTTPublisher:
                 "Number": last_sms.get("number", "Unknown"),
                 "Text": last_sms.get("text", ""),
                 "timestamp": last_sms.get("timestamp", ""),
-                "history": history
+                "history": history,
             }
-            
+
             # Publish to SMS state topic with retain
             topic = f"{self.topic_prefix}/sms/state"
             self.client.publish(
                 topic, json.dumps(restored_sms_data), qos=1, retain=True
             )
-            
-            sender = last_sms.get('number', 'Unknown')
-            timestamp = last_sms.get('timestamp', '')
-            logger.info(
-                f"📡 Restored last SMS from history: {sender} at {timestamp}"
-            )
+
+            sender = last_sms.get("number", "Unknown")
+            timestamp = last_sms.get("timestamp", "")
+            logger.info(f"📡 Restored last SMS from history: {sender} at {timestamp}")
         else:
             logger.info("📡 No SMS history to restore")
 
@@ -3502,20 +3851,18 @@ class MQTTPublisher:
         """Restore last missed call from history after discovery is complete"""
         if not self.connected:
             return
-        
-        if not self.config.get('missed_calls_monitoring_enabled', False):
+
+        if not self.config.get("missed_calls_monitoring_enabled", False):
             return
-        
+
         last_call = self.missed_call_tracker.get_last_call()
         if last_call:
             # Publish to missed call state topic with retain
             topic = f"{self.topic_prefix}/missed_call/state"
-            self.client.publish(
-                topic, json.dumps(last_call), qos=1, retain=True
-            )
-            
-            number = last_call.get('Number', 'Unknown')
-            timestamp = last_call.get('processed_at', '')
+            self.client.publish(topic, json.dumps(last_call), qos=1, retain=True)
+
+            number = last_call.get("Number", "Unknown")
+            timestamp = last_call.get("processed_at", "")
             logger.info(
                 f"📡 Restored last missed call from history: {number} at {timestamp}"
             )
@@ -3526,13 +3873,13 @@ class MQTTPublisher:
         """Restore balance data from persistent storage after discovery"""
         if not self.connected:
             return
-        
+
         if not self.balance_parser:
             return
-        
+
         balance_data = self.balance_parser.get_balance_data()
         # Only restore if we have actual data (not all None)
-        if balance_data.get('last_updated'):
+        if balance_data.get("last_updated"):
             self.publish_balance_info(balance_data)
             logger.info(
                 f"📡 Restored balance from storage: "
@@ -3541,7 +3888,7 @@ class MQTTPublisher:
             )
         else:
             logger.info("📡 No balance data to restore")
-    
+
     def publish_initial_states_with_machine(self, gammu_machine):
         """Publish initial states with gammu machine access"""
         if not self.connected:
@@ -3553,34 +3900,40 @@ class MQTTPublisher:
 
             # Publish initial offline status (will change to online on first successful operation)
             self.publish_device_status()
-            logger.info("📡 Published initial modem status: offline (waiting for first successful communication)")
+            logger.info(
+                "📡 Published initial modem status: offline (waiting for first successful communication)"
+            )
 
             # Cache SMSC on initialization
             logger.info("📞 Caching SMSC for reliable SMS sending...")
             self.cache_smsc()
 
             # Publish initial signal strength with connectivity tracking
-            signal = self.track_gammu_operation("GetSignalQuality", self.gammu_machine.GetSignalQuality)
+            signal = self.track_gammu_operation(
+                "GetSignalQuality", self.gammu_machine.GetSignalQuality
+            )
             # Filter out invalid BER value (-1 means not available)
             if signal.get("BitErrorRate") == -1:
                 signal["BitErrorRate"] = None
             self.publish_signal_strength(signal)
 
             # Publish initial network info with connectivity tracking
-            network = self.track_gammu_operation("GetNetworkInfo", self.gammu_machine.GetNetworkInfo)
+            network = self.track_gammu_operation(
+                "GetNetworkInfo", self.gammu_machine.GetNetworkInfo
+            )
             network_code = network.get("NetworkCode", "")
             network_name = network.get("NetworkName")
-            
+
             # Try multiple lookup methods if name is empty (fixed in python-gammu 3.2.5, kept as defense-in-depth)
             if not network_name and network_code:
                 # First try our comprehensive database
                 network_name = get_network_name(network_code)
                 # Fallback to Gammu's database
                 if not network_name:
-                    network_name = GSMNetworks.get(network_code, 'Unknown')
-            
-            network["NetworkName"] = network_name or 'Unknown'
-            
+                    network_name = GSMNetworks.get(network_code, "Unknown")
+
+            network["NetworkName"] = network_name or "Unknown"
+
             # Map Gammu's state to human-readable format
             state = network.get("State", "Unknown")
             state_map = {
@@ -3592,16 +3945,17 @@ class MQTTPublisher:
                 "Unknown": "Unknown",
             }
             network["State"] = state_map.get(state, state)
-            
+
             # Add network type detection
             try:
                 from support import get_network_type
+
                 network_type = get_network_type(self.gammu_machine)
                 network["NetworkType"] = network_type
             except Exception as e:
                 logger.warning(f"Could not detect network type: {e}")
                 network["NetworkType"] = "Unknown"
-            
+
             self.publish_network_info(network)
 
             # Don't publish empty SMS state on startup - it would overwrite the last real SMS
@@ -3609,7 +3963,9 @@ class MQTTPublisher:
             # 1. A new SMS arrives (SMS monitoring)
             # 2. User retrieves SMS via API
             # This preserves the last SMS value across restarts
-            logger.info("📡 Skipping empty SMS state publish (preserves last SMS across restarts)")
+            logger.info(
+                "📡 Skipping empty SMS state publish (preserves last SMS across restarts)"
+            )
 
             # Publish initial SMS counters
             self.publish_sms_counter()
@@ -3618,12 +3974,20 @@ class MQTTPublisher:
             # Publish modem info
             try:
                 modem_info = {
-                    "IMEI": self.track_gammu_operation("GetIMEI", self.gammu_machine.GetIMEI),
-                    "Manufacturer": self.track_gammu_operation("GetManufacturer", self.gammu_machine.GetManufacturer),
-                    "Model": self.track_gammu_operation("GetModel", self.gammu_machine.GetModel)
+                    "IMEI": self.track_gammu_operation(
+                        "GetIMEI", self.gammu_machine.GetIMEI
+                    ),
+                    "Manufacturer": self.track_gammu_operation(
+                        "GetManufacturer", self.gammu_machine.GetManufacturer
+                    ),
+                    "Model": self.track_gammu_operation(
+                        "GetModel", self.gammu_machine.GetModel
+                    ),
                 }
                 try:
-                    modem_info["Firmware"] = self.track_gammu_operation("GetFirmware", self.gammu_machine.GetFirmware)[0]
+                    modem_info["Firmware"] = self.track_gammu_operation(
+                        "GetFirmware", self.gammu_machine.GetFirmware
+                    )[0]
                 except Exception:
                     modem_info["Firmware"] = "Unknown"
                 self.publish_modem_info(modem_info)
@@ -3632,20 +3996,26 @@ class MQTTPublisher:
 
             # Publish SIM info
             try:
-                sim_info = {"IMSI": self.track_gammu_operation("GetSIMIMSI", self.gammu_machine.GetSIMIMSI)}
+                sim_info = {
+                    "IMSI": self.track_gammu_operation(
+                        "GetSIMIMSI", self.gammu_machine.GetSIMIMSI
+                    )
+                }
                 self.publish_sim_info(sim_info)
             except Exception as e:
                 logger.warning(f"Could not publish SIM info: {e}")
 
             # Publish SMS capacity
             try:
-                capacity = self.track_gammu_operation("GetSMSStatus", self.gammu_machine.GetSMSStatus)
+                capacity = self.track_gammu_operation(
+                    "GetSMSStatus", self.gammu_machine.GetSMSStatus
+                )
                 self.publish_sms_capacity(capacity)
             except Exception as e:
                 logger.warning(f"Could not publish SMS capacity: {e}")
 
             logger.info("📡 Published initial states to MQTT")
-            
+
             # Process any pending SMS from queue (from previous failed sends)
             if self.sms_queue.get_count() > 0:
                 logger.info("📥 Found pending SMS in queue, processing...")
@@ -3653,12 +4023,12 @@ class MQTTPublisher:
 
         except Exception as e:
             logger.error(f"Error publishing initial states: {e}")
-    
+
     def start_sms_monitoring(self, gammu_machine, check_interval=10):
         """Start SMS monitoring in background thread"""
         if not self.connected:
             return
-            
+
         def _sms_monitor_loop():
             logger.info(f"📱 Started SMS monitoring (check every {check_interval}s)")
 
@@ -3667,7 +4037,7 @@ class MQTTPublisher:
             first_run = True
 
             while self.connected and not self.disconnecting:
-                from support import retrieveAllSms, deleteSms
+                from support import deleteSms, retrieveAllSms
 
                 # Skip SMS polling during active incoming call to avoid modem conflicts
                 # The ReadDevice loop handles the call, and SMS operations can cause timeouts
@@ -3680,10 +4050,13 @@ class MQTTPublisher:
                 # Modem needs recovery time after handling an incoming call
                 if self._call_ended_at is not None:
                     from datetime import datetime
+
                     elapsed = (datetime.now() - self._call_ended_at).total_seconds()
                     if elapsed < self.CALL_COOLDOWN_SECONDS:
                         remaining = self.CALL_COOLDOWN_SECONDS - elapsed
-                        logger.debug(f"📱 Skipping SMS poll - post-call cooldown ({remaining:.0f}s remaining)")
+                        logger.debug(
+                            f"📱 Skipping SMS poll - post-call cooldown ({remaining:.0f}s remaining)"
+                        )
                         time.sleep(check_interval)
                         continue
                     else:
@@ -3691,19 +4064,27 @@ class MQTTPublisher:
                         # This prevents race condition with status poll
                         if self._post_call_reinit_needed:
                             self._post_call_reinit_needed = False
-                            self._reinit_in_progress = True  # Block other threads BEFORE clearing cooldown
+                            self._reinit_in_progress = (
+                                True  # Block other threads BEFORE clearing cooldown
+                            )
                             self._call_ended_at = None  # Now safe to clear
-                            logger.info("📱 Post-call cooldown complete, starting modem reinit...")
+                            logger.info(
+                                "📱 Post-call cooldown complete, starting modem reinit..."
+                            )
                             try:
                                 if self._reconnect_gammu():
                                     logger.info("✅ Post-call modem reinit successful")
                                 else:
-                                    logger.warning("⚠️ Post-call modem reinit failed - will retry on next failure")
+                                    logger.warning(
+                                        "⚠️ Post-call modem reinit failed - will retry on next failure"
+                                    )
                             finally:
                                 self._reinit_in_progress = False  # Release lock
                         else:
                             self._call_ended_at = None
-                            logger.info("📱 Post-call cooldown complete, resuming SMS monitoring")
+                            logger.info(
+                                "📱 Post-call cooldown complete, resuming SMS monitoring"
+                            )
 
                 # When in hard_offline, skip ALL modem operations to avoid blocking
                 # Just check restart timeout, publish status (to update seconds_since_last_success), and wait
@@ -3715,16 +4096,24 @@ class MQTTPublisher:
 
                 # Check for new SMS with connectivity tracking (this will handle errors and update status)
                 try:
-                    all_sms = self.track_gammu_operation("retrieveAllSms", retrieveAllSms, self.gammu_machine)
+                    all_sms = self.track_gammu_operation(
+                        "retrieveAllSms", retrieveAllSms, self.gammu_machine
+                    )
                     current_count = len(all_sms)
                     # Only log routine polling in debug mode to reduce log spam
-                    if self.log_level == 'debug':
-                        logger.info(f"✅ SMS monitoring cycle OK: {current_count} messages on SIM")
+                    if self.log_level == "debug":
+                        logger.info(
+                            f"✅ SMS monitoring cycle OK: {current_count} messages on SIM"
+                        )
                     else:
-                        logger.debug(f"SMS monitoring cycle OK: {current_count} messages on SIM")
+                        logger.debug(
+                            f"SMS monitoring cycle OK: {current_count} messages on SIM"
+                        )
                 except Exception as e:
                     # track_gammu_operation already recorded the failure and published status
-                    logger.warning(f"❌ SMS monitoring cycle failed (modem offline): {e}")
+                    logger.warning(
+                        f"❌ SMS monitoring cycle failed (modem offline): {e}"
+                    )
 
                     # Check restart timeout on EVERY failed cycle (not just inside track_gammu_operation)
                     # This ensures the restart timer keeps being checked even after initial timeout
@@ -3733,7 +4122,9 @@ class MQTTPublisher:
                     # When in hard_offline (modem completely frozen), skip retry attempts
                     # that would block for 15+ seconds. Just wait for restart timeout.
                     if self.device_tracker.hard_offline:
-                        logger.debug("Skipping soft reset - modem in hard_offline state, waiting for restart")
+                        logger.debug(
+                            "Skipping soft reset - modem in hard_offline state, waiting for restart"
+                        )
                         time.sleep(check_interval)
                         continue
 
@@ -3741,11 +4132,17 @@ class MQTTPublisher:
                     # Then retry every 5 failures (5, 10, 15, 20...)
                     failures = self.device_tracker.get_consecutive_failures()
                     if failures == 2 or (failures > 2 and failures % 5 == 0):
-                        logger.warning(f"🔄 Attempting modem soft reset after {failures} failures...")
+                        logger.warning(
+                            f"🔄 Attempting modem soft reset after {failures} failures..."
+                        )
                         try:
                             # Soft reset: AT+CFUN=1,1 (restart modem software, keep SIM state)
-                            self.track_gammu_operation("Reset", self.gammu_machine.Reset, False)
-                            logger.info("✅ Modem soft reset completed, waiting 5s for recovery...")
+                            self.track_gammu_operation(
+                                "Reset", self.gammu_machine.Reset, False
+                            )
+                            logger.info(
+                                "✅ Modem soft reset completed, waiting 5s for recovery..."
+                            )
                             time.sleep(5)
                         except Exception as reset_err:
                             logger.error(f"❌ Modem soft reset failed: {reset_err}")
@@ -3756,71 +4153,100 @@ class MQTTPublisher:
                 try:
                     if first_run:
                         # On first run, publish only unread SMS and process delivery reports
-                        logger.info(f"📱 Initial SMS check: {current_count} total SMS on SIM")
+                        logger.info(
+                            f"📱 Initial SMS check: {current_count} total SMS on SIM"
+                        )
                         unread_count = 0
                         delivery_reports_processed = 0
                         deleted_count = 0
-                        
+
                         for i, sms in enumerate(all_sms):
                             # Check if this is a delivery report (process even if read)
-                            if self.config.get('sms_delivery_reports', False):
-                                sms_type = sms.get('Type', '')
-                                if sms_type == 'Status_Report':
-                                    message_ref = sms.get('MessageReference', None)
-                                    status = sms.get('DeliveryStatus', 'unknown')
-                                    
+                            if self.config.get("sms_delivery_reports", False):
+                                sms_type = sms.get("Type", "")
+                                if sms_type == "Status_Report":
+                                    message_ref = sms.get("MessageReference", None)
+                                    status = sms.get("DeliveryStatus", "unknown")
+
                                     if message_ref:
                                         delivery_info = self.delivery_tracker.update_delivery_status(
                                             message_ref, status
                                         )
                                         if delivery_info:
-                                            self.publish_delivery_report(message_ref, status, delivery_info)
+                                            self.publish_delivery_report(
+                                                message_ref, status, delivery_info
+                                            )
                                             delivery_reports_processed += 1
-                                    
+
                                     # Auto-delete delivery report
                                     try:
-                                        self.track_gammu_operation("deleteSms", deleteSms, self.gammu_machine, all_sms[i])
-                                        logger.debug(f"🗑️ Auto-deleted delivery report (ref={message_ref})")
+                                        self.track_gammu_operation(
+                                            "deleteSms",
+                                            deleteSms,
+                                            self.gammu_machine,
+                                            all_sms[i],
+                                        )
+                                        logger.debug(
+                                            f"🗑️ Auto-deleted delivery report (ref={message_ref})"
+                                        )
                                         deleted_count += 1
                                     except Exception as e:
-                                        logger.error(f"Error deleting delivery report: {e}")
+                                        logger.error(
+                                            f"Error deleting delivery report: {e}"
+                                        )
                                     continue  # Skip publishing as regular SMS
-                            
+
                             # Publish unread regular SMS
-                            if sms.get('State') == 'UnRead':
+                            if sms.get("State") == "UnRead":
                                 sms_copy = sms.copy()
                                 sms_copy.pop("Locations", None)
                                 self.publish_sms_received(sms_copy)
                                 unread_count += 1
 
                         if unread_count > 0:
-                            logger.info(f"📱 Published {unread_count} unread SMS messages")
+                            logger.info(
+                                f"📱 Published {unread_count} unread SMS messages"
+                            )
                         if delivery_reports_processed > 0:
-                            logger.info(f"📬 Processed {delivery_reports_processed} delivery reports")
+                            logger.info(
+                                f"📬 Processed {delivery_reports_processed} delivery reports"
+                            )
                         if deleted_count > 0:
-                            logger.info(f"🗑️ Auto-deleted {deleted_count} delivery report(s)")
+                            logger.info(
+                                f"🗑️ Auto-deleted {deleted_count} delivery report(s)"
+                            )
                         if unread_count == 0 and delivery_reports_processed == 0:
                             logger.info(f"📱 No unread messages or delivery reports")
 
                         # If we deleted any delivery reports, update SMS capacity
                         if deleted_count > 0:
                             try:
-                                capacity = self.track_gammu_operation("GetSMSStatus", self.gammu_machine.GetSMSStatus)
+                                capacity = self.track_gammu_operation(
+                                    "GetSMSStatus", self.gammu_machine.GetSMSStatus
+                                )
                                 self.publish_sms_capacity(capacity)
                                 # Update count to reflect deleted delivery reports
-                                current_count = capacity.get('SIMUsed', 0) + capacity.get('PhoneUsed', 0)
-                                logger.info(f"📊 After deleting delivery reports: {current_count} SMS remaining on SIM")
+                                current_count = capacity.get(
+                                    "SIMUsed", 0
+                                ) + capacity.get("PhoneUsed", 0)
+                                logger.info(
+                                    f"📊 After deleting delivery reports: {current_count} SMS remaining on SIM"
+                                )
                             except Exception as e:
-                                logger.warning(f"Could not update SMS capacity after deleting delivery reports: {e}")
+                                logger.warning(
+                                    f"Could not update SMS capacity after deleting delivery reports: {e}"
+                                )
 
                         last_sms_count = current_count
                         first_run = False
                     elif current_count > last_sms_count:
                         # On subsequent runs, publish all new SMS
-                        logger.info(f"📱 Detected {current_count - last_sms_count} new SMS messages")
+                        logger.info(
+                            f"📱 Detected {current_count - last_sms_count} new SMS messages"
+                        )
 
                         deleted_count = 0
-                        auto_delete = self.config.get('auto_delete_read_sms', False)
+                        auto_delete = self.config.get("auto_delete_read_sms", False)
 
                         # Process new SMS (from the end, newest first)
                         for i in range(last_sms_count, current_count):
@@ -3829,42 +4255,65 @@ class MQTTPublisher:
                                 sms.pop("Locations", None)
 
                                 # Check if this is a delivery report
-                                if self.config.get('sms_delivery_reports', False):
-                                    sms_type = sms.get('Type', '')
-                                    if sms_type == 'Status_Report':
+                                if self.config.get("sms_delivery_reports", False):
+                                    sms_type = sms.get("Type", "")
+                                    if sms_type == "Status_Report":
                                         # This is a delivery report
-                                        message_ref = sms.get('MessageReference', None)
-                                        status = sms.get('DeliveryStatus', 'unknown')
-                                        
+                                        message_ref = sms.get("MessageReference", None)
+                                        status = sms.get("DeliveryStatus", "unknown")
+
                                         if message_ref:
                                             # Update delivery tracking
                                             delivery_info = self.delivery_tracker.update_delivery_status(
                                                 message_ref, status
                                             )
-                                            
+
                                             if delivery_info:
                                                 # Publish delivery report
-                                                self.publish_delivery_report(message_ref, status, delivery_info)
-                                                logger.info(f"📬 Processed delivery report: ref={message_ref}, status={status}")
-                                        
+                                                self.publish_delivery_report(
+                                                    message_ref, status, delivery_info
+                                                )
+                                                logger.info(
+                                                    f"📬 Processed delivery report: ref={message_ref}, status={status}"
+                                                )
+
                                         # Don't publish delivery reports as regular SMS
                                         # Auto-delete delivery report
                                         try:
-                                            self.track_gammu_operation("deleteSms", deleteSms, self.gammu_machine, all_sms[i])
-                                            logger.debug(f"🗑️ Auto-deleted delivery report (ref={message_ref})")
+                                            self.track_gammu_operation(
+                                                "deleteSms",
+                                                deleteSms,
+                                                self.gammu_machine,
+                                                all_sms[i],
+                                            )
+                                            logger.debug(
+                                                f"🗑️ Auto-deleted delivery report (ref={message_ref})"
+                                            )
                                             deleted_count += 1
                                         except Exception as e:
-                                            logger.error(f"Error deleting delivery report: {e}")
+                                            logger.error(
+                                                f"Error deleting delivery report: {e}"
+                                            )
                                         continue  # Skip regular SMS processing
 
                                 # Publish regular SMS to MQTT
                                 self.publish_sms_received(sms)
 
                                 # Auto-delete if enabled and SMS is read
-                                if auto_delete and sms.get('State') in ['Read', 'UnRead']:
+                                if auto_delete and sms.get("State") in [
+                                    "Read",
+                                    "UnRead",
+                                ]:
                                     try:
-                                        self.track_gammu_operation("deleteSms", deleteSms, self.gammu_machine, all_sms[i])
-                                        logger.info(f"🗑️ Auto-deleted SMS from {sms.get('Number', 'Unknown')}")
+                                        self.track_gammu_operation(
+                                            "deleteSms",
+                                            deleteSms,
+                                            self.gammu_machine,
+                                            all_sms[i],
+                                        )
+                                        logger.info(
+                                            f"🗑️ Auto-deleted SMS from {sms.get('Number', 'Unknown')}"
+                                        )
                                         deleted_count += 1
                                     except Exception as e:
                                         logger.error(f"Error auto-deleting SMS: {e}")
@@ -3872,13 +4321,21 @@ class MQTTPublisher:
                         # If we deleted any SMS (delivery reports or auto-delete), update capacity and get new count
                         if deleted_count > 0:
                             try:
-                                capacity = self.track_gammu_operation("GetSMSStatus", self.gammu_machine.GetSMSStatus)
+                                capacity = self.track_gammu_operation(
+                                    "GetSMSStatus", self.gammu_machine.GetSMSStatus
+                                )
                                 self.publish_sms_capacity(capacity)
                                 # Update count to reflect deleted SMS
-                                current_count = capacity.get('SIMUsed', 0) + capacity.get('PhoneUsed', 0)
-                                logger.info(f"📊 After deleting {deleted_count} SMS: {current_count} remaining on SIM")
+                                current_count = capacity.get(
+                                    "SIMUsed", 0
+                                ) + capacity.get("PhoneUsed", 0)
+                                logger.info(
+                                    f"📊 After deleting {deleted_count} SMS: {current_count} remaining on SIM"
+                                )
                             except Exception as e:
-                                logger.warning(f"Could not update SMS capacity after deletion: {e}")
+                                logger.warning(
+                                    f"Could not update SMS capacity after deletion: {e}"
+                                )
 
                     last_sms_count = current_count
 
@@ -3887,18 +4344,19 @@ class MQTTPublisher:
                     logger.error(f"Error processing SMS data: {e}")
 
                 time.sleep(check_interval)
-        
-        # Only start if both MQTT and SMS monitoring are enabled  
-        if (self.config.get('mqtt_enabled', False) and 
-            self.config.get('sms_monitoring_enabled', True)):
+
+        # Only start if both MQTT and SMS monitoring are enabled
+        if self.config.get("mqtt_enabled", False) and self.config.get(
+            "sms_monitoring_enabled", True
+        ):
             thread = threading.Thread(target=_sms_monitor_loop, daemon=True)
             thread.start()
-    
+
     def publish_status_periodic(self, gammu_machine, interval=60):
         """Publish status data periodically in background thread"""
         if not self.connected:
             return
-            
+
         def _publish_loop():
             while self.connected and not self.disconnecting:
                 # Skip periodic status polling during active incoming call
@@ -3912,6 +4370,7 @@ class MQTTPublisher:
                 # Modem needs recovery time after handling an incoming call
                 if self._call_ended_at is not None:
                     from datetime import datetime
+
                     elapsed = (datetime.now() - self._call_ended_at).total_seconds()
                     if elapsed < self.CALL_COOLDOWN_SECONDS:
                         logger.debug(f"📡 Skipping status poll - post-call cooldown")
@@ -3934,10 +4393,12 @@ class MQTTPublisher:
 
                 signal = None
                 network = None
-                
+
                 # Get signal strength with connectivity tracking
                 try:
-                    signal = self.track_gammu_operation("GetSignalQuality", self.gammu_machine.GetSignalQuality)
+                    signal = self.track_gammu_operation(
+                        "GetSignalQuality", self.gammu_machine.GetSignalQuality
+                    )
                     # Filter out invalid BER value (-1 means not available)
                     if signal.get("BitErrorRate") == -1:
                         signal["BitErrorRate"] = None
@@ -3956,20 +4417,23 @@ class MQTTPublisher:
                 # Get network info with connectivity tracking
                 try:
                     from gammu import GSMNetworks
-                    network = self.track_gammu_operation("GetNetworkInfo", self.gammu_machine.GetNetworkInfo)
+
+                    network = self.track_gammu_operation(
+                        "GetNetworkInfo", self.gammu_machine.GetNetworkInfo
+                    )
                     network_code = network.get("NetworkCode", "")
                     network_name = network.get("NetworkName")
-                    
+
                     # Try multiple lookup methods if name is empty (fixed in python-gammu 3.2.5, kept as defense-in-depth)
                     if not network_name and network_code:
                         # First try our comprehensive database
                         network_name = get_network_name(network_code)
                         # Fallback to Gammu's database
                         if not network_name:
-                            network_name = GSMNetworks.get(network_code, 'Unknown')
-                    
-                    network["NetworkName"] = network_name or 'Unknown'
-                    
+                            network_name = GSMNetworks.get(network_code, "Unknown")
+
+                    network["NetworkName"] = network_name or "Unknown"
+
                     # Map Gammu's state to human-readable format
                     state = network.get("State", "Unknown")
                     state_map = {
@@ -3981,20 +4445,21 @@ class MQTTPublisher:
                         "Unknown": "Unknown",
                     }
                     network["State"] = state_map.get(state, state)
-                    
+
                     # Add network type detection
                     try:
                         from support import get_network_type
+
                         network_type = get_network_type(self.gammu_machine)
                         network["NetworkType"] = network_type
                     except Exception as net_type_err:
                         logger.debug(f"Could not detect network type: {net_type_err}")
                         network["NetworkType"] = "Unknown"
-                        
+
                 except Exception as e:
                     # track_gammu_operation already recorded the failure
                     pass  # Warning already logged by track_gammu_operation
-                
+
                 # Publish combined status if we have both
                 if signal and network:
                     self.publish_status_combined(signal, network)
@@ -4004,12 +4469,12 @@ class MQTTPublisher:
                     self.publish_network_info(network)
 
                 time.sleep(interval)
-        
-        if self.config.get('mqtt_enabled', False):
+
+        if self.config.get("mqtt_enabled", False):
             thread = threading.Thread(target=_publish_loop, daemon=True)
             thread.start()
             logger.info(f"Started MQTT periodic publishing (interval: {interval}s)")
-    
+
     def disconnect(self):
         """Disconnect from MQTT broker - thread-safe with duplicate call prevention"""
         if self.disconnecting:
@@ -4021,8 +4486,12 @@ class MQTTPublisher:
         if self.client and self.connected:
             # Publish offline availability - makes ALL entities unavailable in HA
             try:
-                self.client.publish(self.availability_topic, "offline", qos=1, retain=True)
-                logger.info("📡 Published availability: offline (all entities now unavailable)")
+                self.client.publish(
+                    self.availability_topic, "offline", qos=1, retain=True
+                )
+                logger.info(
+                    "📡 Published availability: offline (all entities now unavailable)"
+                )
                 time.sleep(0.5)  # Give time for message to be sent
             except Exception as e:
                 logger.warning(f"Could not publish offline availability: {e}")

--- a/addon-gsm-gateway/network_codes.py
+++ b/addon-gsm-gateway/network_codes.py
@@ -15,8 +15,6 @@ Auto-update: Monthly via GitHub Actions
 # Comprehensive database of mobile network operators by MCC+MNC
 # Format: "MCCMNC": "Operator Name"
 NETWORK_OPERATORS = {
-
-
     # United States (MCC 310-316)
     "310005": "Verizon",
     "310006": "Verizon",
@@ -352,7 +350,6 @@ NETWORK_OPERATORS = {
     "310970": "Globalstar",
     "310980": "Peoples Telephone",
     "310990": "Evolve Broadband",
-
     # US MVNOs with unique codes
     "310032": "IT&E Wireless",
     "310053": "Virgin Mobile",
@@ -483,7 +480,6 @@ NETWORK_OPERATORS = {
     "313970": "Tycrhron",
     "313980": "Next Generation Application LLC",
     "313990": "Ericsson US",
-
     # Canada (MCC 302)
     "302100": "dotmobile",
     "302130": "Xplore",
@@ -566,7 +562,6 @@ NETWORK_OPERATORS = {
     "302996": "Powertech Labs",
     "302997": "Powertech Labs",
     "302998": "Institut de Recherche d’Hydro-Québec",
-
     # United Kingdom (MCC 234, 235)
     "23400": "BT",
     "23401": "Vectone Mobile",
@@ -631,7 +626,6 @@ NETWORK_OPERATORS = {
     "23479": "UKTL",
     "23486": "EE",
     "23488": "telet",
-
     # Germany (MCC 262)
     "26201": "Telekom",
     "26202": "Vodafone",
@@ -675,7 +669,6 @@ NETWORK_OPERATORS = {
     "26279": "ng4T GmbH",
     "26292": "Nash Technologies",
     "26298": "private networks",
-
     # France (MCC 208)
     "20801": "Orange",
     "20802": "Orange",
@@ -753,7 +746,6 @@ NETWORK_OPERATORS = {
     "20896": "Région Bourgogne-Franche-Comté",
     "20897": "Thales Communications & Security SAS",
     "20898": "Société Air France",
-
     # Spain (MCC 214)
     "21401": "Vodafone",
     "21402": "Fibracat",
@@ -796,7 +788,6 @@ NETWORK_OPERATORS = {
     "21451": "ADIF",
     "214700": "Iberdrola",
     "214701": "Endesa",
-
     # Italy (MCC 222)
     "22201": "TIM",
     "22202": "Elsacom",
@@ -827,7 +818,6 @@ NETWORK_OPERATORS = {
     "22288": "WINDTRE",
     "22298": "BLU",
     "22299": "WINDTRE",
-
     # Netherlands (MCC 204)
     "20400": "Intovoice B.V.",
     "20401": "RadioAccess Network Services",
@@ -873,7 +863,6 @@ NETWORK_OPERATORS = {
     "20468": "Roamware (Netherlands) B.V.",
     "20469": "KPN Mobile The Netherlands B.V.",
     "20491": "Enexis Netbeheer B.V.",
-
     # Australia (MCC 505)
     "50501": "Telstra",
     "50502": "Optus",
@@ -936,7 +925,6 @@ NETWORK_OPERATORS = {
     "50588": "Pivotel Group Pty Ltd",
     "50590": "Optus",
     "50599": "One.Tel",
-
     # China (MCC 460, 461)
     "46000": "China Mobile",
     "46001": "China Unicom",
@@ -951,7 +939,6 @@ NETWORK_OPERATORS = {
     "46011": "China Telecom",
     "46015": "China Broadnet",
     "46020": "China Tietong",
-
     # Japan (MCC 440, 441)
     "44000": "Y!Mobile",
     "44001": "KDDI Corporation",
@@ -990,7 +977,6 @@ NETWORK_OPERATORS = {
     "44075": "au",
     "44076": "au",
     "44078": "au",
-
     # India (MCC 404, 405)
     "40401": "Vi India",
     "40402": "AirTel",
@@ -1080,7 +1066,6 @@ NETWORK_OPERATORS = {
     "40496": "AirTel",
     "40497": "AirTel",
     "40498": "AirTel",
-
     # Brazil (MCC 724)
     "72400": "Nextel",
     "72401": "SISTEER DO BRASIL TELECOMUNICAÇÔES",
@@ -1113,7 +1098,6 @@ NETWORK_OPERATORS = {
     "72439": "Nextel",
     "72454": "Conecta",
     "72499": "Local",
-
     # Mexico (MCC 334)
     "334001": "Comunicaciones Digitales Del Norte, S.A. de C.V.",
     "334010": "AT&T",
@@ -1143,7 +1127,6 @@ NETWORK_OPERATORS = {
     "334200": "Virgin Mobile",
     "334210": "YO Mobile",
     "334220": "Megamóvil",
-
     # Russia (MCC 250)
     "25001": "MTS",
     "25002": "MegaFon",
@@ -1194,7 +1177,6 @@ NETWORK_OPERATORS = {
     "25096": "+7Telecom",
     "25097": "Phoenix",
     "25099": "Beeline",
-
     # South Africa (MCC 655)
     "65501": "Vodacom",
     "65502": "Telkom",
@@ -1235,9 +1217,7 @@ NETWORK_OPERATORS = {
     "65575": "ACSA",
     "65576": "Comsol Networks (Pty) Ltd",
     "65577": "Umoja Connect",
-
     # Add more countries as needed...
-
     # Additional network codes
     "001001": "TEST",
     "00101": "TEST",
@@ -3114,10 +3094,10 @@ NETWORK_OPERATORS = {
 
 def get_network_name(network_code: str):
     """Get network operator name from MCC+MNC code.
-    
+
     Args:
         network_code: MCC+MNC code (e.g., "310260" for T-Mobile USA)
-        
+
     Returns:
         Network operator name or None if not found
     """

--- a/addon-gsm-gateway/run.py
+++ b/addon-gsm-gateway/run.py
@@ -11,31 +11,39 @@ Credits:
 Licensed under Apache License 2.0
 """
 
-import os
 import json
 import logging
+import os
 import signal
 import sys
+
 from flask import Flask, request
 from flask_httpauth import HTTPBasicAuth
 from flask_restx import Api, Resource, fields, reqparse
-
-from support import init_state_machine, retrieveAllSms, deleteSms, encodeSms, set_network_type_cache_duration, invalidate_network_type_cache
-from mqtt_publisher import MQTTPublisher
 from gammu import GSMNetworks
+from mqtt_publisher import MQTTPublisher
+from support import (
+    deleteSms,
+    encodeSms,
+    init_state_machine,
+    invalidate_network_type_cache,
+    retrieveAllSms,
+    set_network_type_cache_duration,
+)
+
 from network_codes import get_network_name
 
 # Configure logging with timestamp
 logging.basicConfig(
     level=logging.INFO,
-    format='[%(asctime)s] %(levelname)s: %(message)s',
-    datefmt='%H:%M:%S'
+    format="[%(asctime)s] %(levelname)s: %(message)s",
+    datefmt="%H:%M:%S",
 )
-mqtt_logger = logging.getLogger('mqtt_publisher')
+mqtt_logger = logging.getLogger("mqtt_publisher")
 mqtt_logger.setLevel(logging.INFO)
 
 # Suppress Flask development server warnings
-log = logging.getLogger('werkzeug')
+log = logging.getLogger("werkzeug")
 log.setLevel(logging.ERROR)
 
 # Load version early for startup banner
@@ -43,14 +51,20 @@ VERSION = None  # Will be loaded properly later
 
 # Monkey-patch click.echo to suppress Flask CLI startup messages
 import click
+
 _original_echo = click.echo
+
+
 def _silent_echo(message=None, **kwargs):
     # Only suppress Flask's "Debug mode:" and "Serving Flask app" messages
     if message and isinstance(message, str):
-        if 'Debug mode:' in message or 'Serving Flask app' in message:
+        if "Debug mode:" in message or "Serving Flask app" in message:
             return
     _original_echo(message, **kwargs)
+
+
 click.echo = _silent_echo
+
 
 def load_version():
     """Load version from config.yaml"""
@@ -60,17 +74,20 @@ def load_version():
         if supervisor_token:
             try:
                 import requests
-                response = requests.get('http://supervisor/addons/self/info',
-                                       headers={'Authorization': f'Bearer {supervisor_token}'},
-                                       timeout=2)
+
+                response = requests.get(
+                    "http://supervisor/addons/self/info",
+                    headers={"Authorization": f"Bearer {supervisor_token}"},
+                    timeout=2,
+                )
                 if response.status_code == 200:
                     data = response.json()
                     logging.debug(f"Supervisor API response: {data}")
                     # The structure might be: {'result': 'ok', 'data': {'version': 'x.x.x'}}
                     # or just: {'data': {'version': 'x.x.x'}}
-                    if 'data' in data and 'version' in data['data']:
-                        version = data['data']['version']
-                        if version and version != 'unknown':
+                    if "data" in data and "version" in data["data"]:
+                        version = data["data"]["version"]
+                        if version and version != "unknown":
                             logging.debug(f"Got version from Supervisor API: {version}")
                             return version
             except Exception as e:
@@ -79,18 +96,21 @@ def load_version():
 
         # Fallback: try to read from config.yaml in multiple locations
         possible_paths = [
-            '/config.yaml',  # Root location when copied to container
-            os.path.join(os.path.dirname(__file__), 'config.yaml'),  # Same directory as run.py
-            '/data/../config.yaml',  # Relative to data directory
+            "/config.yaml",  # Root location when copied to container
+            os.path.join(
+                os.path.dirname(__file__), "config.yaml"
+            ),  # Same directory as run.py
+            "/data/../config.yaml",  # Relative to data directory
         ]
-        
+
         import yaml
+
         for config_yaml_path in possible_paths:
             logging.debug(f"Trying to read version from: {config_yaml_path}")
             if os.path.exists(config_yaml_path):
-                with open(config_yaml_path, 'r') as f:
+                with open(config_yaml_path, "r") as f:
                     config_data = yaml.safe_load(f)
-                    version = config_data.get('version')
+                    version = config_data.get("version")
                     if version:
                         logging.debug(f"Got version from {config_yaml_path}: {version}")
                         return version
@@ -101,38 +121,41 @@ def load_version():
         logging.warning(f"Could not read version: {e}")
         return "unknown"
 
+
 def load_ha_config():
     """Load Home Assistant add-on configuration"""
-    config_path = '/data/options.json'
+    config_path = "/data/options.json"
     if os.path.exists(config_path):
-        with open(config_path, 'r') as f:
+        with open(config_path, "r") as f:
             return json.load(f)
     else:
         # Default values for testing outside HA
         return {
-            'device_path': '/dev/ttyUSB0',
-            'pin': '',
-            'port': 5000,
-            'ssl': False,
-            'username': 'admin',
-            'password': 'password',
-            'mqtt_enabled': True,
-            'mqtt_host': 'localhost',
-            'mqtt_port': 1883,
-            'mqtt_username': '',
-            'mqtt_password': '',
-            'mqtt_topic_prefix': 'homeassistant/sensor/sms_gateway',
-            'sms_monitoring_enabled': True,
-            'sms_check_interval': 60,
-            'sms_cost_per_message': 0.0,
-            'sms_cost_currency': 'CZK',
-            'auto_delete_read_sms': False
+            "device_path": "/dev/ttyUSB0",
+            "pin": "",
+            "port": 5000,
+            "ssl": False,
+            "username": "admin",
+            "password": "password",
+            "mqtt_enabled": True,
+            "mqtt_host": "localhost",
+            "mqtt_port": 1883,
+            "mqtt_username": "",
+            "mqtt_password": "",
+            "mqtt_topic_prefix": "homeassistant/sensor/sms_gateway",
+            "sms_monitoring_enabled": True,
+            "sms_check_interval": 60,
+            "sms_cost_per_message": 0.0,
+            "sms_cost_currency": "CZK",
+            "auto_delete_read_sms": False,
         }
+
 
 # Helper function for IP whitelist checking
 def is_ip_allowed(client_ip, allowed_networks):
     """Check if client IP is in allowed network ranges"""
     import ipaddress
+
     try:
         client = ipaddress.ip_address(client_ip)
         for network_str in allowed_networks:
@@ -147,16 +170,17 @@ def is_ip_allowed(client_ip, allowed_networks):
         logging.error(f"Invalid client IP: {client_ip}")
         return False
 
+
 # Load version and configuration
 VERSION = load_version()
 config = load_ha_config()
 
 # Configure logging level based on config
-log_level = config.get('log_level', 'info')
-if log_level == 'debug':
+log_level = config.get("log_level", "info")
+if log_level == "debug":
     logging.getLogger().setLevel(logging.DEBUG)
     logging.info("🔍 Logging level set to DEBUG (all messages)")
-elif log_level == 'warning':
+elif log_level == "warning":
     logging.getLogger().setLevel(logging.WARNING)
     logging.warning("⚠️  Logging level set to WARNING (warnings and errors only)")
 else:  # info
@@ -166,17 +190,19 @@ else:  # info
 # Log version at startup
 logging.info(f"GSM SMS Gateway Enhanced v{VERSION}")
 
-pin = config.get('pin') if config.get('pin') else None
-ssl = config.get('ssl', False)
-port = config.get('port', 5000)
-username = config.get('username', 'admin')
-password = config.get('password', 'password')
-device_path = config.get('device_path', '/dev/ttyUSB0')
+pin = config.get("pin") if config.get("pin") else None
+ssl = config.get("ssl", False)
+port = config.get("port", 5000)
+username = config.get("username", "admin")
+password = config.get("password", "password")
+device_path = config.get("device_path", "/dev/ttyUSB0")
 
 # GET endpoint security settings
-get_endpoint_auth_required = config.get('get_endpoint_auth_required', False)
-get_endpoint_allowed_ips = config.get('get_endpoint_allowed_ips', [])
-get_endpoint_deduplication_enabled = config.get('get_endpoint_deduplication_enabled', True)
+get_endpoint_auth_required = config.get("get_endpoint_auth_required", False)
+get_endpoint_allowed_ips = config.get("get_endpoint_allowed_ips", [])
+get_endpoint_deduplication_enabled = config.get(
+    "get_endpoint_deduplication_enabled", True
+)
 logging.info(
     f"🔒 GET endpoint auth: {'REQUIRED' if get_endpoint_auth_required else 'DISABLED'}"
 )
@@ -192,28 +218,34 @@ _sms_dedup_cache = {}
 _sms_dedup_window = 15  # seconds
 
 # Configure network type cache duration
-network_type_cache_seconds = config.get('network_type_cache_seconds', 300)
+network_type_cache_seconds = config.get("network_type_cache_seconds", 300)
 set_network_type_cache_duration(network_type_cache_seconds)
 
 # Log device path and check accessibility
 logging.info(f"📱 Configured device path: {device_path}")
 
 # Check if it's a by-id symlink
-if '/dev/serial/by-id/' in device_path:
+if "/dev/serial/by-id/" in device_path:
     if os.path.islink(device_path):
         resolved_path = os.path.realpath(device_path)
         logging.info(f"🔗 By-ID symlink resolves to: {resolved_path}")
-        
+
         # Check if resolved device exists and is accessible
         if os.path.exists(resolved_path):
             logging.info(f"✅ Resolved device {resolved_path} is accessible")
         else:
-            logging.error(f"❌ ERROR: Resolved device {resolved_path} is NOT accessible!")
-            logging.error(f"💡 TIP: Add '{resolved_path}' to the 'devices' list in config.yaml")
+            logging.error(
+                f"❌ ERROR: Resolved device {resolved_path} is NOT accessible!"
+            )
+            logging.error(
+                f"💡 TIP: Add '{resolved_path}' to the 'devices' list in config.yaml"
+            )
     else:
         logging.error(f"❌ ERROR: {device_path} is not a valid symlink!")
         if not os.path.exists(device_path):
-            logging.error(f"💡 TIP: Check if /dev/serial/by-id is mounted (add to 'devices' list)")
+            logging.error(
+                f"💡 TIP: Check if /dev/serial/by-id is mounted (add to 'devices' list)"
+            )
 elif os.path.exists(device_path):
     logging.info(f"✅ Device {device_path} is accessible")
 else:
@@ -236,6 +268,7 @@ machine = init_state_machine(pin, device_path)
 # Set gammu machine for MQTT SMS sending
 mqtt_publisher.set_gammu_machine(machine)
 
+
 # Setup signal handlers for graceful shutdown
 def signal_handler(signum, frame):
     """Handle shutdown signals (SIGTERM, SIGINT)"""
@@ -248,11 +281,14 @@ def signal_handler(signum, frame):
     finally:
         sys.exit(0)
 
+
 signal.signal(signal.SIGTERM, signal_handler)
 signal.signal(signal.SIGINT, signal_handler)
 
 # Register atexit handler as backup
 import atexit
+
+
 def cleanup():
     """Cleanup function called on normal exit"""
     logging.info("🧹 Cleanup: Publishing offline status...")
@@ -261,20 +297,25 @@ def cleanup():
     except Exception as e:
         logging.error(f"Error during cleanup: {e}")
 
+
 atexit.register(cleanup)
 
 app = Flask(__name__)
 
 # Check if running under Ingress
 import os
-ingress_path = os.environ.get('INGRESS_PATH', '')
+
+ingress_path = os.environ.get("INGRESS_PATH", "")
+
 
 # Create simple HTML page for Ingress
-@app.route('/')
+@app.route("/")
 def home():
     """Simple status page for Home Assistant Ingress"""
     from flask import Response, request
-    html = '''
+
+    html = (
+        """
     <!DOCTYPE html>
     <html>
     <head>
@@ -341,7 +382,9 @@ def home():
                 Version: {VERSION}
             </div>
             
-            <a href="http://''' + request.host.split(':')[0] + ''':5000/docs/" 
+            <a href="http://"""
+        + request.host.split(":")[0]
+        + """:5000/docs/" 
                class="swagger-link" target="_blank">
                 📋 Open Swagger API Documentation
             </a>
@@ -362,29 +405,28 @@ def home():
         </div>
     </body>
     </html>
-    '''
-    return Response(html.replace('{VERSION}', VERSION), mimetype='text/html')
+    """
+    )
+    return Response(html.replace("{VERSION}", VERSION), mimetype="text/html")
+
 
 # Swagger UI Configuration
 # Put Swagger UI on /docs/ path for direct access via port 5000
 api = Api(
     app,
     version=VERSION,
-    title='SMS Gammu Gateway API',
-    description='REST API for sending and receiving SMS messages via USB GSM modems (SIM800L, Huawei, etc.). Modern replacement for deprecated SMS notifications via GSM-modem integration.',
-    doc='/docs/',  # Swagger UI on /docs/ path
-    prefix='',
+    title="SMS Gammu Gateway API",
+    description="REST API for sending and receiving SMS messages via USB GSM modems (SIM800L, Huawei, etc.). Modern replacement for deprecated SMS notifications via GSM-modem integration.",
+    doc="/docs/",  # Swagger UI on /docs/ path
+    prefix="",
     authorizations={
-        'basicAuth': {
-            'type': 'basic',
-            'in': 'header',
-            'name': 'Authorization'
-        }
+        "basicAuth": {"type": "basic", "in": "header", "name": "Authorization"}
     },
-    security='basicAuth'
+    security="basicAuth",
 )
 
 auth = HTTPBasicAuth()
+
 
 @auth.verify_password
 def verify(user, pwd):
@@ -392,173 +434,273 @@ def verify(user, pwd):
         return False
     return user == username and pwd == password
 
+
 # API Models for Swagger documentation
-sms_model = api.model('SMS', {
-    'text': fields.String(required=True, description='SMS message text', example='Hello, how are you?'),
-    'number': fields.String(required=True, description='Phone number (international format)', example='+420123456789'),
-    'smsc': fields.String(required=False, description='SMS Center number (optional)', example='+420603052000'),
-    'unicode': fields.Boolean(required=False, description='Use Unicode encoding', default=False),
-    'flash': fields.Boolean(required=False, description='Send as Flash SMS (displays on screen, not saved)', default=False)
-})
+sms_model = api.model(
+    "SMS",
+    {
+        "text": fields.String(
+            required=True, description="SMS message text", example="Hello, how are you?"
+        ),
+        "number": fields.String(
+            required=True,
+            description="Phone number (international format)",
+            example="+420123456789",
+        ),
+        "smsc": fields.String(
+            required=False,
+            description="SMS Center number (optional)",
+            example="+420603052000",
+        ),
+        "unicode": fields.Boolean(
+            required=False, description="Use Unicode encoding", default=False
+        ),
+        "flash": fields.Boolean(
+            required=False,
+            description="Send as Flash SMS (displays on screen, not saved)",
+            default=False,
+        ),
+    },
+)
 
-sms_response = api.model('SMS Response', {
-    'Date': fields.String(description='Date and time received', example='2025-01-19 14:30:00'),
-    'Number': fields.String(description='Sender phone number', example='+420123456789'),
-    'State': fields.String(description='SMS state', example='UnRead'),
-    'Text': fields.String(description='SMS message text', example='Hello World!')
-})
+sms_response = api.model(
+    "SMS Response",
+    {
+        "Date": fields.String(
+            description="Date and time received", example="2025-01-19 14:30:00"
+        ),
+        "Number": fields.String(
+            description="Sender phone number", example="+420123456789"
+        ),
+        "State": fields.String(description="SMS state", example="UnRead"),
+        "Text": fields.String(description="SMS message text", example="Hello World!"),
+    },
+)
 
-signal_response = api.model('Signal Quality', {
-    'SignalStrength': fields.Integer(description='Signal strength in dBm', example=-75),
-    'SignalPercent': fields.Integer(description='Signal strength percentage', example=65),
-    'BitErrorRate': fields.Integer(description='Bit error rate', example=-1)
-})
+signal_response = api.model(
+    "Signal Quality",
+    {
+        "SignalStrength": fields.Integer(
+            description="Signal strength in dBm", example=-75
+        ),
+        "SignalPercent": fields.Integer(
+            description="Signal strength percentage", example=65
+        ),
+        "BitErrorRate": fields.Integer(description="Bit error rate", example=-1),
+    },
+)
 
-network_response = api.model('Network Info', {
-    'NetworkName': fields.String(description='Network operator name', example='T-Mobile'),
-    'State': fields.String(description='Network registration state', example='HomeNetwork'),
-    'NetworkCode': fields.String(description='Network operator code', example='230 01'),
-    'CID': fields.String(description='Cell ID', example='0A1B2C3D'),
-    'LAC': fields.String(description='Location Area Code', example='1234')
-})
+network_response = api.model(
+    "Network Info",
+    {
+        "NetworkName": fields.String(
+            description="Network operator name", example="T-Mobile"
+        ),
+        "State": fields.String(
+            description="Network registration state", example="HomeNetwork"
+        ),
+        "NetworkCode": fields.String(
+            description="Network operator code", example="230 01"
+        ),
+        "CID": fields.String(description="Cell ID", example="0A1B2C3D"),
+        "LAC": fields.String(description="Location Area Code", example="1234"),
+    },
+)
 
-send_response = api.model('Send Response', {
-    'status': fields.Integer(description='HTTP status code', example=200),
-    'message': fields.String(description='Response message', example='[1]')
-})
+send_response = api.model(
+    "Send Response",
+    {
+        "status": fields.Integer(description="HTTP status code", example=200),
+        "message": fields.String(description="Response message", example="[1]"),
+    },
+)
 
-reset_response = api.model('Reset Response', {
-    'status': fields.Integer(description='HTTP status code', example=200),
-    'message': fields.String(description='Reset message', example='Reset done')
-})
+reset_response = api.model(
+    "Reset Response",
+    {
+        "status": fields.Integer(description="HTTP status code", example=200),
+        "message": fields.String(description="Reset message", example="Reset done"),
+    },
+)
 
-modem_info_response = api.model('Modem Info', {
-    'IMEI': fields.String(description='Modem IMEI number', example='123456789012345'),
-    'Manufacturer': fields.String(description='Modem manufacturer', example='Huawei'),
-    'Model': fields.String(description='Modem model', example='E3372'),
-    'Firmware': fields.String(description='Firmware version', example='22.323.62.00.143')
-})
+modem_info_response = api.model(
+    "Modem Info",
+    {
+        "IMEI": fields.String(
+            description="Modem IMEI number", example="123456789012345"
+        ),
+        "Manufacturer": fields.String(
+            description="Modem manufacturer", example="Huawei"
+        ),
+        "Model": fields.String(description="Modem model", example="E3372"),
+        "Firmware": fields.String(
+            description="Firmware version", example="22.323.62.00.143"
+        ),
+    },
+)
 
-sim_info_response = api.model('SIM Info', {
-    'IMSI': fields.String(description='SIM IMSI number', example='230011234567890')
-})
+sim_info_response = api.model(
+    "SIM Info",
+    {"IMSI": fields.String(description="SIM IMSI number", example="230011234567890")},
+)
 
-sms_capacity_response = api.model('SMS Capacity', {
-    'SIMUsed': fields.Integer(description='SMS count in SIM memory', example=5),
-    'SIMSize': fields.Integer(description='SIM total capacity', example=50),
-    'PhoneUsed': fields.Integer(description='SMS count in phone memory', example=0),
-    'PhoneSize': fields.Integer(description='Phone memory capacity', example=100),
-    'TemplatesUsed': fields.Integer(description='SMS templates used', example=0)
-})
+sms_capacity_response = api.model(
+    "SMS Capacity",
+    {
+        "SIMUsed": fields.Integer(description="SMS count in SIM memory", example=5),
+        "SIMSize": fields.Integer(description="SIM total capacity", example=50),
+        "PhoneUsed": fields.Integer(description="SMS count in phone memory", example=0),
+        "PhoneSize": fields.Integer(description="Phone memory capacity", example=100),
+        "TemplatesUsed": fields.Integer(description="SMS templates used", example=0),
+    },
+)
 
 # API Namespaces
-ns_sms = api.namespace('sms', description='SMS operations (requires authentication)')
-ns_status = api.namespace('status', description='Device status and information (public)')
+ns_sms = api.namespace("sms", description="SMS operations (requires authentication)")
+ns_status = api.namespace(
+    "status", description="Device status and information (public)"
+)
 
-@ns_sms.route('')
-@ns_sms.doc('sms_operations')
+
+@ns_sms.route("")
+@ns_sms.doc("sms_operations")
 class SmsCollection(Resource):
-    @ns_sms.doc('get_all_sms')
+    @ns_sms.doc("get_all_sms")
     @ns_sms.marshal_list_with(sms_response, code=200)
-    @ns_sms.doc(security='basicAuth')
+    @ns_sms.doc(security="basicAuth")
     @auth.login_required
     def get(self):
         """Get all SMS messages from SIM/device memory"""
-        allSms = mqtt_publisher.track_gammu_operation("retrieveAllSms", retrieveAllSms, machine)
+        allSms = mqtt_publisher.track_gammu_operation(
+            "retrieveAllSms", retrieveAllSms, machine
+        )
         list(map(lambda sms: sms.pop("Locations", None), allSms))
         return allSms
 
-    @ns_sms.doc('send_sms')
+    @ns_sms.doc("send_sms")
     @ns_sms.expect(sms_model)
     @ns_sms.marshal_with(send_response, code=200)
-    @ns_sms.doc(security='basicAuth')
+    @ns_sms.doc(security="basicAuth")
     @auth.login_required
     def post(self):
         """Send SMS message(s)"""
         # Support both JSON and form-encoded data
         # Check Content-Type to decide how to parse request
-        content_type = request.content_type or ''
-        
-        if 'application/json' in content_type:
+        content_type = request.content_type or ""
+
+        if "application/json" in content_type:
             # JSON request - use get_json()
             data = request.get_json() or {}
-        elif 'application/x-www-form-urlencoded' in content_type or 'multipart/form-data' in content_type:
+        elif (
+            "application/x-www-form-urlencoded" in content_type
+            or "multipart/form-data" in content_type
+        ):
             # Form-encoded request - use form data
             data = dict(request.form)
             # Convert boolean strings to actual booleans
-            if 'unicode' in data:
-                data['unicode'] = data['unicode'].lower() in ('true', '1', 'yes')
-            if 'flash' in data:
-                data['flash'] = data['flash'].lower() in ('true', '1', 'yes')
+            if "unicode" in data:
+                data["unicode"] = data["unicode"].lower() in ("true", "1", "yes")
+            if "flash" in data:
+                data["flash"] = data["flash"].lower() in ("true", "1", "yes")
         else:
             # Try both methods as fallback
             data = request.get_json(silent=True) or {}
             if not data:
                 # Fall back to form data
                 data = dict(request.form)
-        
+
         # If still no data, try query parameters as last resort
         if not data:
             parser = reqparse.RequestParser()
-            parser.add_argument('text', required=False, help='SMS message text')
-            parser.add_argument('message', required=False, help='SMS message text (alias for text)')
-            parser.add_argument('number', required=False, help='Phone number(s), comma separated')
-            parser.add_argument('target', required=False, help='Phone number (alias for number)')
-            parser.add_argument('smsc', required=False, help='SMS Center number (optional)')
-            parser.add_argument('unicode', type=bool, required=False, default=None, help='Use Unicode encoding (auto-detect if not specified)')
-            parser.add_argument('flash', type=bool, required=False, default=False, help='Send as Flash SMS')
+            parser.add_argument("text", required=False, help="SMS message text")
+            parser.add_argument(
+                "message", required=False, help="SMS message text (alias for text)"
+            )
+            parser.add_argument(
+                "number", required=False, help="Phone number(s), comma separated"
+            )
+            parser.add_argument(
+                "target", required=False, help="Phone number (alias for number)"
+            )
+            parser.add_argument(
+                "smsc", required=False, help="SMS Center number (optional)"
+            )
+            parser.add_argument(
+                "unicode",
+                type=bool,
+                required=False,
+                default=None,
+                help="Use Unicode encoding (auto-detect if not specified)",
+            )
+            parser.add_argument(
+                "flash",
+                type=bool,
+                required=False,
+                default=False,
+                help="Send as Flash SMS",
+            )
             data = parser.parse_args()
         # Note: Don't set unicode default here - let auto-detection handle it
-        
+
         # Support both 'text' and 'message' parameters
-        sms_text = data.get('text') or data.get('message')
+        sms_text = data.get("text") or data.get("message")
         if not sms_text:
-            return {"status": 400, "message": "Missing required field: text or message"}, 400
-        
+            return {
+                "status": 400,
+                "message": "Missing required field: text or message",
+            }, 400
+
         # Support both 'number' and 'target' parameters
-        sms_number = data.get('number') or data.get('target')
+        sms_number = data.get("number") or data.get("target")
         if not sms_number:
-            return {"status": 400, "message": "Missing required field: number or target"}, 400
-        
-        logging.info(f"SMS send request - Text: '{sms_text}', Numbers: '{sms_number}', Type: {type(sms_number)}")
-        
+            return {
+                "status": 400,
+                "message": "Missing required field: number or target",
+            }, 400
+
+        logging.info(
+            f"SMS send request - Text: '{sms_text}', Numbers: '{sms_number}', Type: {type(sms_number)}"
+        )
+
         # Handle both string (comma-separated) and list formats
         if isinstance(sms_number, list):
             numbers = sms_number
         else:
             # Check if it's a string representation of a list (e.g., "['phone1', 'phone2']")
             sms_number_str = str(sms_number).strip()
-            if sms_number_str.startswith('[') and sms_number_str.endswith(']'):
+            if sms_number_str.startswith("[") and sms_number_str.endswith("]"):
                 try:
                     # Try to parse as JSON array first
                     import json
+
                     numbers = json.loads(sms_number_str)
                 except:
                     # If JSON parsing fails, try Python literal eval
                     try:
                         import ast
+
                         numbers = ast.literal_eval(sms_number_str)
                     except:
                         # Fall back to treating as single number
                         numbers = [sms_number_str]
             else:
                 # Comma-separated string
-                numbers = [n.strip() for n in sms_number_str.split(',')]
-        
+                numbers = [n.strip() for n in sms_number_str.split(",")]
+
         # Auto-detect unicode if not explicitly specified
         # This matches the behavior of MQTT send methods
-        unicode_mode = data.get('unicode')
+        unicode_mode = data.get("unicode")
         if unicode_mode is None:
             # Auto-detect: check if text contains non-ASCII characters (emojis, etc.)
             try:
-                sms_text.encode('ascii')
+                sms_text.encode("ascii")
                 unicode_mode = False
             except UnicodeEncodeError:
                 unicode_mode = True
                 logging.info("🔤 Auto-detected Unicode mode for non-ASCII text")
 
         # Determine SMS class based on flash parameter
-        flash_mode = data.get('flash', False)
+        flash_mode = data.get("flash", False)
         sms_class = 0 if flash_mode else -1
         if flash_mode:
             logging.info("⚡ Sending Flash SMS (will display on screen without saving)")
@@ -573,24 +715,24 @@ class SmsCollection(Resource):
                 }
             ],
         }
-        
+
         # Get cached SMSC for reliable sending
         cached_smsc = mqtt_publisher.get_cached_smsc()
-        
+
         messages = []
         for number in numbers:
             for message in encodeSms(smsinfo):
                 # Use cached SMSC if available (more reliable)
                 if data.get("smsc"):
-                    message["SMSC"] = {'Number': data.get("smsc")}
+                    message["SMSC"] = {"Number": data.get("smsc")}
                 elif cached_smsc:
-                    message["SMSC"] = {'Number': cached_smsc}
+                    message["SMSC"] = {"Number": cached_smsc}
                 else:
-                    message["SMSC"] = {'Location': 1}
-                
+                    message["SMSC"] = {"Location": 1}
+
                 message["Number"] = number.strip()
                 messages.append(message)
-        
+
         # Send SMS with automatic retry on recoverable errors
         # Queue SMS BEFORE sending to survive restarts during send/retry
         results = []
@@ -600,10 +742,10 @@ class SmsCollection(Resource):
             smsc = None
             if message.get("SMSC") and message["SMSC"].get("Number"):
                 smsc = message["SMSC"]["Number"]
-            
+
             # Queue SMS first to survive restarts during send attempt
             mqtt_publisher.queue_sms_for_retry(number, sms_text, smsc)
-            
+
             try:
                 mqtt_publisher.track_gammu_operation(
                     "SendSMS", machine.SendSMS, message
@@ -614,48 +756,41 @@ class SmsCollection(Resource):
                 mqtt_publisher.sms_counter.increment()
             except Exception as e:
                 # Check if recoverable error was detected and reset triggered
-                if getattr(e, 'err_recoverable_detected', False):
+                if getattr(e, "err_recoverable_detected", False):
                     logging.warning(
-                        f"🔄 Retrying SMS to {number} "
-                        "after modem reconnect..."
+                        f"🔄 Retrying SMS to {number} " "after modem reconnect..."
                     )
                     time.sleep(5)  # Additional wait after reconnect
                     try:
                         # Use publisher's gammu_machine (may have been reconnected)
                         mqtt_publisher.track_gammu_operation(
-                            "SendSMS",
-                            mqtt_publisher.gammu_machine.SendSMS,
-                            message
+                            "SendSMS", mqtt_publisher.gammu_machine.SendSMS, message
                         )
                         # Success - remove from queue
                         mqtt_publisher.sms_queue.remove(number, sms_text)
                         results.append(number)
                         mqtt_publisher.sms_counter.increment()
-                        logging.info(
-                            f"✅ SMS sent to {number} after retry"
-                        )
+                        logging.info(f"✅ SMS sent to {number} after retry")
                     except Exception as retry_error:
                         # Final failure - already in queue, just log
                         logging.error(
                             f"❌ SMS retry failed for {number}: {retry_error}"
                         )
-                        logging.info(
-                            f"📥 SMS to {number} remains queued for later"
-                        )
+                        logging.info(f"📥 SMS to {number} remains queued for later")
                         # Don't raise - continue with other messages
                 else:
                     # Non-recoverable error - already in queue, just log
                     logging.error(f"❌ SMS failed for {number}: {e}")
                     logging.info(f"📥 SMS to {number} remains queued for later")
                     # Don't raise - continue with other messages
-        
+
         mqtt_publisher.publish_sms_counter()
-        
+
         # Build response message
         total_numbers = len(set([m["Number"] for m in messages]))
         sent_count = len(results)
         queued_count = total_numbers - sent_count
-        
+
         if queued_count > 0:
             msg = f"Sent to {sent_count} number(s), {queued_count} queued for retry"
             return {"status": 200, "message": msg}, 200
@@ -663,20 +798,20 @@ class SmsCollection(Resource):
             return {"status": 200, "message": f"Sent to {sent_count} number(s)"}, 200
 
 
-@ns_sms.route('/add/<path:sms_data>')
-@ns_sms.route('/<path:sms_data>')
-@ns_sms.doc('send_sms_get')
+@ns_sms.route("/add/<path:sms_data>")
+@ns_sms.route("/<path:sms_data>")
+@ns_sms.doc("send_sms_get")
 class SmsGet(Resource):
-    @ns_sms.doc('send_sms_via_get')
+    @ns_sms.doc("send_sms_via_get")
     @ns_sms.doc(
         params={
-            'sms_data': {
-                'description': 'Phone number and message format: {PHONE}&{MESSAGE}',
-                'type': 'string',
-                'example': '5555551234&Test+message'
+            "sms_data": {
+                "description": "Phone number and message format: {PHONE}&{MESSAGE}",
+                "type": "string",
+                "example": "5555551234&Test+message",
             }
         },
-        description='''
+        description="""
         Add/Send SMS via GET request with data in URL path - designed for legacy devices.
         
         📱 **Format:** GET /sms/add/{PHONE_NUMBER}&{MESSAGE} (or /sms/{PHONE_NUMBER}&{MESSAGE})
@@ -703,12 +838,12 @@ class SmsGet(Resource):
         • Authentication disabled by default for legacy device compatibility
         • Use POST /sms for authenticated requests in modern applications
         • Deduplication uses: {phone}|{message} as cache key
-        '''
+        """,
     )
-    @ns_sms.response(200, 'SMS sent successfully', send_response)
-    @ns_sms.response(400, 'Invalid request format')
-    @ns_sms.response(401, 'Authentication required')
-    @ns_sms.response(403, 'IP address not authorized')
+    @ns_sms.response(200, "SMS sent successfully", send_response)
+    @ns_sms.response(400, "Invalid request format")
+    @ns_sms.response(401, "Authentication required")
+    @ns_sms.response(403, "IP address not authorized")
     def get(self, sms_data):
         """Send SMS via GET request (legacy compatibility)"""
         # Check IP whitelist
@@ -716,85 +851,85 @@ class SmsGet(Resource):
         if get_endpoint_allowed_ips:
             if not is_ip_allowed(client_ip, get_endpoint_allowed_ips):
                 logging.warning(
-                    f"🚫 Access denied from {client_ip} "
-                    f"(not in whitelist)"
+                    f"🚫 Access denied from {client_ip} " f"(not in whitelist)"
                 )
                 return {
-                    'status': 403,
-                    'message': 'Access denied - IP not authorized'
+                    "status": 403,
+                    "message": "Access denied - IP not authorized",
                 }, 403
-        
+
         # Check auth if required
         if get_endpoint_auth_required:
-            auth_header = request.headers.get('Authorization')
+            auth_header = request.headers.get("Authorization")
             if not auth_header:
-                logging.warning(
-                    f"🔒 Unauthorized GET request from {client_ip}"
-                )
-                return {
-                    'status': 401,
-                    'message': 'Authentication required'
-                }, 401
-            
+                logging.warning(f"🔒 Unauthorized GET request from {client_ip}")
+                return {"status": 401, "message": "Authentication required"}, 401
+
             # Verify Basic Auth
             try:
                 import base64
-                auth_type, credentials = auth_header.split(' ', 1)
-                if auth_type.lower() != 'basic':
-                    return {'status': 401, 'message': 'Invalid auth'}, 401
-                
-                decoded = base64.b64decode(credentials).decode('utf-8')
-                provided_user, provided_pass = decoded.split(':', 1)
-                
+
+                auth_type, credentials = auth_header.split(" ", 1)
+                if auth_type.lower() != "basic":
+                    return {"status": 401, "message": "Invalid auth"}, 401
+
+                decoded = base64.b64decode(credentials).decode("utf-8")
+                provided_user, provided_pass = decoded.split(":", 1)
+
                 if provided_user != username or provided_pass != password:
                     logging.warning(f"🔒 Invalid credentials from {client_ip}")
-                    return {'status': 401, 'message': 'Invalid credentials'}, 401
+                    return {"status": 401, "message": "Invalid credentials"}, 401
             except Exception as e:
                 logging.error(f"Auth error: {e}")
-                return {'status': 401, 'message': 'Auth error'}, 401
-        
+                return {"status": 401, "message": "Auth error"}, 401
+
         # Parse path: {PHONE}&{MESSAGE}
-        if '&' not in sms_data:
+        if "&" not in sms_data:
             return {
-                "status": 400, 
-                "message": "Invalid format. Use: /sms/{PHONE}&{MESSAGE}"
+                "status": 400,
+                "message": "Invalid format. Use: /sms/{PHONE}&{MESSAGE}",
             }, 400
-        
+
         # Split on first &
-        parts = sms_data.split('&', 1)
+        parts = sms_data.split("&", 1)
         if len(parts) != 2:
             return {
                 "status": 400,
-                "message": "Invalid format. Use: /sms/{PHONE}&{MESSAGE}"
+                "message": "Invalid format. Use: /sms/{PHONE}&{MESSAGE}",
             }, 400
-        
+
         sms_number = parts[0].strip()
         sms_text = parts[1].strip()
-        
+
         # URL decode (replace + with space, etc.)
         from urllib.parse import unquote_plus
+
         sms_number = unquote_plus(sms_number)
         sms_text = unquote_plus(sms_text)
-        
+
         if not sms_number or not sms_text:
             return {
                 "status": 400,
-                "message": "Phone number and message cannot be empty"
+                "message": "Phone number and message cannot be empty",
             }, 400
-        
+
         logging.info(f"📨 GET SMS request - Number: '{sms_number}', Text: '{sms_text}'")
-        
+
         # Check for duplicate request (device retry) if enabled
         import time
+
         dedup_key = f"{sms_number}|{sms_text}"
         current_time = time.time()
-        
+
         if get_endpoint_deduplication_enabled:
             # Clean old entries from cache
             global _sms_dedup_cache
-            _sms_dedup_cache = {k: v for k, v in _sms_dedup_cache.items() 
-                                if current_time - v < _sms_dedup_window}
-            
+            _sms_dedup_cache = {
+                k: v
+                for k, v in _sms_dedup_cache.items()
+                if current_time - v < _sms_dedup_window
+            }
+
             # Check if this SMS was just sent
             if dedup_key in _sms_dedup_cache:
                 time_since = current_time - _sms_dedup_cache[dedup_key]
@@ -804,18 +939,18 @@ class SmsGet(Resource):
                 )
                 return {
                     "status": 200,
-                    "message": f"SMS already sent to {sms_number} recently"
+                    "message": f"SMS already sent to {sms_number} recently",
                 }, 200
-        
+
         # Encode and send SMS (same logic as POST)
         try:
             # Auto-detect unicode
             try:
-                sms_text.encode('ascii')
+                sms_text.encode("ascii")
                 unicode_mode = False
             except UnicodeEncodeError:
                 unicode_mode = True
-            
+
             # Build smsinfo dict (same as POST endpoint)
             smsinfo = {
                 "Class": -1,  # Normal SMS
@@ -827,65 +962,64 @@ class SmsGet(Resource):
                     }
                 ],
             }
-            
+
             # Get cached SMSC for reliable sending
             cached_smsc = mqtt_publisher.get_cached_smsc()
-            
+
             # Encode SMS (returns list of message parts)
             messages = []
             for message in encodeSms(smsinfo):
                 if cached_smsc:
-                    message["SMSC"] = {'Number': cached_smsc}
+                    message["SMSC"] = {"Number": cached_smsc}
                 else:
-                    message["SMSC"] = {'Location': 1}
+                    message["SMSC"] = {"Location": 1}
                 message["Number"] = sms_number
                 messages.append(message)
-            
+
             # Validate we got messages
             if not messages:
                 raise ValueError("encodeSms returned no messages")
-            
+
             # Queue SMS first
             smsc = messages[0].get("SMSC", {}).get("Number")
             mqtt_publisher.queue_sms_for_retry(sms_number, sms_text, smsc)
-            
+
             # Send all message parts
             for message in messages:
-                mqtt_publisher.track_gammu_operation("SendSMS", machine.SendSMS, message)
-            
+                mqtt_publisher.track_gammu_operation(
+                    "SendSMS", machine.SendSMS, message
+                )
+
             # Success - remove from queue
             mqtt_publisher.sms_queue.remove(sms_number, sms_text)
             mqtt_publisher.sms_counter.increment()
             mqtt_publisher.publish_sms_counter()
-            
+
             # Add to deduplication cache if enabled
             if get_endpoint_deduplication_enabled:
                 _sms_dedup_cache[dedup_key] = current_time
-            
+
             logging.info(f"✅ SMS sent via GET to {sms_number}")
-            
-            return {
-                "status": 200,
-                "message": f"SMS sent to {sms_number}"
-            }, 200
-            
+
+            return {"status": 200, "message": f"SMS sent to {sms_number}"}, 200
+
         except Exception as e:
             logging.error(f"❌ GET SMS failed for {sms_number}: {e}")
-            return {
-                "status": 500,
-                "message": f"Failed to send SMS: {str(e)}"
-            }, 500
+            return {"status": 500, "message": f"Failed to send SMS: {str(e)}"}, 500
 
-@ns_sms.route('/getsms')
-@ns_sms.doc('get_and_delete_first_sms')
+
+@ns_sms.route("/getsms")
+@ns_sms.doc("get_and_delete_first_sms")
 class GetSms(Resource):
-    @ns_sms.doc('pop_first_sms')
+    @ns_sms.doc("pop_first_sms")
     @ns_sms.marshal_with(sms_response, code=200)
-    @ns_sms.doc(security='basicAuth')
+    @ns_sms.doc(security="basicAuth")
     @auth.login_required
     def get(self):
         """Get first SMS and delete it from memory"""
-        allSms = mqtt_publisher.track_gammu_operation("retrieveAllSms", retrieveAllSms, machine)
+        allSms = mqtt_publisher.track_gammu_operation(
+            "retrieveAllSms", retrieveAllSms, machine
+        )
         sms = {"Date": "", "Number": "", "State": "", "Text": ""}
         if len(allSms) > 0:
             sms = allSms[0]
@@ -896,75 +1030,91 @@ class GetSms(Resource):
                 mqtt_publisher.publish_sms_received(sms)
         return sms
 
-@ns_sms.route('/deleteall')
-@ns_sms.doc('delete_all_sms')
+
+@ns_sms.route("/deleteall")
+@ns_sms.doc("delete_all_sms")
 class DeleteAllSms(Resource):
-    @ns_sms.doc('delete_all_messages')
-    @ns_sms.doc(security='basicAuth')
+    @ns_sms.doc("delete_all_messages")
+    @ns_sms.doc(security="basicAuth")
     @auth.login_required
     def delete(self):
         """Delete all SMS messages from SIM/device memory"""
-        allSms = mqtt_publisher.track_gammu_operation("retrieveAllSms", retrieveAllSms, machine)
+        allSms = mqtt_publisher.track_gammu_operation(
+            "retrieveAllSms", retrieveAllSms, machine
+        )
         count = len(allSms)
         for sms in allSms:
             mqtt_publisher.track_gammu_operation("deleteSms", deleteSms, machine, sms)
         return {"status": 200, "message": f"Deleted {count} SMS messages"}, 200
 
-@ns_sms.route('/<int:id>')
-@ns_sms.doc('sms_by_id')
+
+@ns_sms.route("/<int:id>")
+@ns_sms.doc("sms_by_id")
 class SmsItem(Resource):
-    @ns_sms.doc('get_sms_by_id')
+    @ns_sms.doc("get_sms_by_id")
     @ns_sms.marshal_with(sms_response, code=200)
-    @ns_sms.doc(security='basicAuth')
+    @ns_sms.doc(security="basicAuth")
     @auth.login_required
     def get(self, id):
         """Get specific SMS by ID"""
-        allSms = mqtt_publisher.track_gammu_operation("retrieveAllSms", retrieveAllSms, machine)
+        allSms = mqtt_publisher.track_gammu_operation(
+            "retrieveAllSms", retrieveAllSms, machine
+        )
         if id < 0 or id >= len(allSms):
             api.abort(404, f"SMS with id '{id}' not found")
         sms = allSms[id]
         sms.pop("Locations", None)
         return sms
 
-    @ns_sms.doc('delete_sms_by_id')
-    @ns_sms.doc(security='basicAuth')
+    @ns_sms.doc("delete_sms_by_id")
+    @ns_sms.doc(security="basicAuth")
     @auth.login_required
     def delete(self, id):
         """Delete SMS by ID"""
-        allSms = mqtt_publisher.track_gammu_operation("retrieveAllSms", retrieveAllSms, machine)
+        allSms = mqtt_publisher.track_gammu_operation(
+            "retrieveAllSms", retrieveAllSms, machine
+        )
         if id < 0 or id >= len(allSms):
             api.abort(404, f"SMS with id '{id}' not found")
-        mqtt_publisher.track_gammu_operation("deleteSms", deleteSms, machine, allSms[id])
-        return '', 204
+        mqtt_publisher.track_gammu_operation(
+            "deleteSms", deleteSms, machine, allSms[id]
+        )
+        return "", 204
 
-@ns_status.route('/signal')
-@ns_status.doc('get_signal_quality')
+
+@ns_status.route("/signal")
+@ns_status.doc("get_signal_quality")
 class Signal(Resource):
-    @ns_status.doc('signal_strength')
+    @ns_status.doc("signal_strength")
     @ns_status.marshal_with(signal_response)
     def get(self):
         """Get GSM signal strength and quality"""
-        signal_data = mqtt_publisher.track_gammu_operation("GetSignalQuality", machine.GetSignalQuality)
+        signal_data = mqtt_publisher.track_gammu_operation(
+            "GetSignalQuality", machine.GetSignalQuality
+        )
         # Publish to MQTT if enabled
         mqtt_publisher.publish_signal_strength(signal_data)
         return signal_data
 
-@ns_status.route('/network')
-@ns_status.doc('get_network_info')
+
+@ns_status.route("/network")
+@ns_status.doc("get_network_info")
 class Network(Resource):
     # Cache for last known numeric network code (for MVNO name handling)
     _last_network_code = None
-    
-    @ns_status.doc('network_information')
+
+    @ns_status.doc("network_information")
     @ns_status.marshal_with(network_response)
     def get(self):
         """Get network operator and registration information"""
-        network = mqtt_publisher.track_gammu_operation("GetNetworkInfo", machine.GetNetworkInfo)
+        network = mqtt_publisher.track_gammu_operation(
+            "GetNetworkInfo", machine.GetNetworkInfo
+        )
         raw_network_name = network.get("NetworkName")
         network_code = network.get("NetworkCode", "")
         network_name = raw_network_name
         resolved_code = None
-        
+
         # Handle modem quirk: Some modems put operator name (e.g., "Red Pocket") in NetworkCode field
         if network_code:
             if network_code.isdigit():
@@ -974,31 +1124,32 @@ class Network(Resource):
                     # Lookup name from database if NetworkName is empty
                     network_name = get_network_name(network_code)
                     if not network_name:
-                        network_name = GSMNetworks.get(network_code, 'Unknown')
+                        network_name = GSMNetworks.get(network_code, "Unknown")
             else:
                 # Operator name in NetworkCode field (e.g., "Red Pocket", "Xfinity Mobile")
                 if not network_name or not network_name.strip():
                     network_name = network_code
-                
+
                 # Try reverse lookup: find numeric code for this operator name
                 from network_codes import NETWORK_OPERATORS
+
                 for code, name in NETWORK_OPERATORS.items():
                     if name.lower() == network_code.lower():
                         resolved_code = code
                         break
-                
+
                 # If reverse lookup fails, use cached code from previous poll
                 if not resolved_code and Network._last_network_code:
                     resolved_code = Network._last_network_code
-        
+
         # Cache the numeric code for next time (when modem reports operator name)
         if resolved_code:
             Network._last_network_code = resolved_code
-        
+
         # Update network dict with resolved values
         network["NetworkCode"] = resolved_code
-        network["NetworkName"] = network_name or 'Unknown'
-        
+        network["NetworkName"] = network_name or "Unknown"
+
         # Map Gammu's state to human-readable format
         state = network.get("State", "Unknown")
         state_map = {
@@ -1010,27 +1161,36 @@ class Network(Resource):
             "Unknown": "Unknown",
         }
         network["State"] = state_map.get(state, state)
-        
+
         # Publish to MQTT if enabled
         mqtt_publisher.publish_network_info(network)
         return network
 
-@ns_status.route('/modem')
-@ns_status.doc('get_modem_info')
+
+@ns_status.route("/modem")
+@ns_status.doc("get_modem_info")
 class ModemInfo(Resource):
-    @ns_status.doc('modem_information')
+    @ns_status.doc("modem_information")
     @ns_status.marshal_with(modem_info_response)
     def get(self):
         """Get modem hardware information (IMEI, manufacturer, model, firmware)"""
         try:
             modem_info = {
-                "IMEI": mqtt_publisher.track_gammu_operation("GetIMEI", machine.GetIMEI),
-                "Manufacturer": mqtt_publisher.track_gammu_operation("GetManufacturer", machine.GetManufacturer),
-                "Model": mqtt_publisher.track_gammu_operation("GetModel", machine.GetModel)
+                "IMEI": mqtt_publisher.track_gammu_operation(
+                    "GetIMEI", machine.GetIMEI
+                ),
+                "Manufacturer": mqtt_publisher.track_gammu_operation(
+                    "GetManufacturer", machine.GetManufacturer
+                ),
+                "Model": mqtt_publisher.track_gammu_operation(
+                    "GetModel", machine.GetModel
+                ),
             }
             try:
                 # Firmware can fail on some modems
-                modem_info["Firmware"] = mqtt_publisher.track_gammu_operation("GetFirmware", machine.GetFirmware)[0]
+                modem_info["Firmware"] = mqtt_publisher.track_gammu_operation(
+                    "GetFirmware", machine.GetFirmware
+                )[0]
             except:
                 modem_info["Firmware"] = "Unknown"
 
@@ -1040,16 +1200,19 @@ class ModemInfo(Resource):
         except Exception as e:
             api.abort(500, f"Failed to get modem info: {str(e)}")
 
-@ns_status.route('/sim')
-@ns_status.doc('get_sim_info')
+
+@ns_status.route("/sim")
+@ns_status.doc("get_sim_info")
 class SimInfo(Resource):
-    @ns_status.doc('sim_information')
+    @ns_status.doc("sim_information")
     @ns_status.marshal_with(sim_info_response)
     def get(self):
         """Get SIM card information (IMSI)"""
         try:
             sim_info = {
-                "IMSI": mqtt_publisher.track_gammu_operation("GetSIMIMSI", machine.GetSIMIMSI)
+                "IMSI": mqtt_publisher.track_gammu_operation(
+                    "GetSIMIMSI", machine.GetSIMIMSI
+                )
             }
             # Publish to MQTT if enabled
             mqtt_publisher.publish_sim_info(sim_info)
@@ -1057,77 +1220,90 @@ class SimInfo(Resource):
         except Exception as e:
             api.abort(500, f"Failed to get SIM info: {str(e)}")
 
-@ns_status.route('/sms_capacity')
-@ns_status.doc('get_sms_capacity')
+
+@ns_status.route("/sms_capacity")
+@ns_status.doc("get_sms_capacity")
 class SmsCapacity(Resource):
-    @ns_status.doc('sms_storage_capacity')
+    @ns_status.doc("sms_storage_capacity")
     @ns_status.marshal_with(sms_capacity_response)
     def get(self):
         """Get SMS storage capacity and usage"""
         try:
-            capacity = mqtt_publisher.track_gammu_operation("GetSMSStatus", machine.GetSMSStatus)
+            capacity = mqtt_publisher.track_gammu_operation(
+                "GetSMSStatus", machine.GetSMSStatus
+            )
             # Publish to MQTT if enabled
             mqtt_publisher.publish_sms_capacity(capacity)
             return capacity
         except Exception as e:
             api.abort(500, f"Failed to get SMS capacity: {str(e)}")
 
-@ns_status.route('/reset')
-@ns_status.doc('reset_modem')
+
+@ns_status.route("/reset")
+@ns_status.doc("reset_modem")
 class Reset(Resource):
-    @ns_status.doc('modem_reset')
+    @ns_status.doc("modem_reset")
     @ns_status.marshal_with(reset_response)
     def get(self):
         """Reset GSM modem (useful for stuck connections)"""
         mqtt_publisher.track_gammu_operation("Reset", machine.Reset, False)
         return {"status": 200, "message": "Reset done"}, 200
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     print(f"🚀 SMS Gammu Gateway v{VERSION} started successfully!")
     print(f"📱 Device: {device_path}")
     print(f"🌐 API available on port {port}")
     print(f"🏠 Web UI: http://localhost:{port}/")
     print(f"🔒 SSL: {'Enabled' if ssl else 'Disabled'}")
-    
+
     # MQTT info
-    if config.get('mqtt_enabled', False):
-        print(f"📡 MQTT: Enabled -> {config.get('mqtt_host')}:{config.get('mqtt_port')}")
-        
+    if config.get("mqtt_enabled", False):
+        print(
+            f"📡 MQTT: Enabled -> {config.get('mqtt_host')}:{config.get('mqtt_port')}"
+        )
+
         # Wait a moment for MQTT connection, then publish initial states
         import time
+
         time.sleep(2)
         mqtt_publisher.publish_initial_states_with_machine(machine)
-        
+
         # Start periodic MQTT publishing
-        status_interval = config.get('status_update_interval', 300)
+        status_interval = config.get("status_update_interval", 300)
         mqtt_publisher.publish_status_periodic(machine, interval=status_interval)
         print(f"📊 Status Updates: Every {status_interval}s (signal, network)")
 
         # Start call monitoring via Gammu callbacks (real-time detection)
-        if config.get('missed_calls_monitoring_enabled', False):
+        if config.get("missed_calls_monitoring_enabled", False):
             if mqtt_publisher.start_callback_monitoring(machine):
                 print("📞 Call Monitoring: Enabled (real-time via callbacks)")
             else:
                 print("📞 Call Monitoring: Callbacks not supported by modem")
         else:
             print("📞 Call Monitoring: Disabled in configuration")
-        
+
         # Start SMS monitoring if enabled
-        if config.get('sms_monitoring_enabled', True):
-            check_interval = config.get('sms_check_interval', 60)
+        if config.get("sms_monitoring_enabled", True):
+            check_interval = config.get("sms_check_interval", 60)
             mqtt_publisher.start_sms_monitoring(machine, check_interval=check_interval)
             print(f"📱 SMS Monitoring: Enabled (check every {check_interval}s)")
         else:
             print(f"📱 SMS Monitoring: Disabled")
     else:
         print(f"📡 MQTT: Disabled")
-    
+
     print(f"✅ Ready to send/receive SMS messages")
 
     try:
         if ssl:
-            app.run(port=port, host="0.0.0.0", ssl_context=('/ssl/cert.pem', '/ssl/key.pem'),
-                    debug=False, use_reloader=False)
+            app.run(
+                port=port,
+                host="0.0.0.0",
+                ssl_context=("/ssl/cert.pem", "/ssl/key.pem"),
+                debug=False,
+                use_reloader=False,
+            )
         else:
             app.run(port=port, host="0.0.0.0", debug=False, use_reloader=False)
     finally:

--- a/addon-gsm-gateway/support.py
+++ b/addon-gsm-gateway/support.py
@@ -6,13 +6,14 @@ Based on: https://github.com/pajikos/sms-gammu-gateway
 Licensed under Apache License 2.0
 """
 
-import sys
 import os
-import gammu
+import sys
 import time as time_module
 
+import gammu
+
 # Cache for network type detection (avoid frequent disconnects)
-_network_type_cache = {'type': None, 'timestamp': 0}
+_network_type_cache = {"type": None, "timestamp": 0}
 _network_type_cache_seconds = 300  # Default: Cache for 5 minutes (configurable)
 
 
@@ -25,11 +26,11 @@ def set_network_type_cache_duration(seconds):
 def invalidate_network_type_cache():
     """Invalidate the network type cache (call when modem reconnects)"""
     global _network_type_cache
-    _network_type_cache['type'] = None
-    _network_type_cache['timestamp'] = 0
+    _network_type_cache["type"] = None
+    _network_type_cache["timestamp"] = 0
 
 
-def init_state_machine(pin, device_path='/dev/ttyUSB0'):
+def init_state_machine(pin, device_path="/dev/ttyUSB0"):
     """Initialize gammu state machine with HA add-on config"""
     sm = gammu.StateMachine()
 
@@ -41,46 +42,47 @@ commtimeout = 10
 """
 
     # Write config to temporary file
-    config_file = '/tmp/gammu.config'
-    with open(config_file, 'w') as f:
+    config_file = "/tmp/gammu.config"
+    with open(config_file, "w") as f:
         f.write(config_content)
 
     sm.ReadConfig(Filename=config_file)
-    
+
     try:
         sm.Init()
         print(f"Successfully initialized gammu with device: {device_path}")
-        
+
         # Try to check security status
         try:
             security_status = sm.GetSecurityStatus()
             print(f"SIM security status: {security_status}")
-            
-            if security_status == 'PIN':
-                if pin is None or pin == '':
+
+            if security_status == "PIN":
+                if pin is None or pin == "":
                     print("PIN is required but not provided.")
                     sys.exit(1)
                 else:
-                    sm.EnterSecurityCode('PIN', pin)
+                    sm.EnterSecurityCode("PIN", pin)
                     print("PIN entered successfully")
-                    
+
         except Exception as e:
             print(f"Warning: Could not check SIM security status: {e}")
-            
+
     except gammu.ERR_NOSIM:
         print("Warning: SIM card not accessible, but device is connected")
     except Exception as e:
         print(f"Error initializing device: {e}")
         print("Available devices:")
         import os
+
         try:
-            devices = [d for d in os.listdir('/dev/') if d.startswith('tty')]
+            devices = [d for d in os.listdir("/dev/") if d.startswith("tty")]
             for device in sorted(devices):
                 print(f"  /dev/{device}")
         except:
             pass
         raise
-        
+
     return sm
 
 
@@ -88,7 +90,9 @@ def retrieveAllSms(machine):
     """Retrieve all SMS messages from SIM/device memory"""
     try:
         status = machine.GetSMSStatus()
-        allMultiPartSmsCount = status['SIMUsed'] + status['PhoneUsed'] + status['TemplatesUsed']
+        allMultiPartSmsCount = (
+            status["SIMUsed"] + status["PhoneUsed"] + status["TemplatesUsed"]
+        )
 
         allMultiPartSms = []
         start = True
@@ -98,7 +102,9 @@ def retrieveAllSms(machine):
                 currentMultiPartSms = machine.GetNextSMS(Start=True, Folder=0)
                 start = False
             else:
-                currentMultiPartSms = machine.GetNextSMS(Location=currentMultiPartSms[0]['Location'], Folder=0)
+                currentMultiPartSms = machine.GetNextSMS(
+                    Location=currentMultiPartSms[0]["Location"], Folder=0
+                )
             allMultiPartSms.append(currentMultiPartSms)
 
         allSms = gammu.LinkSMS(allMultiPartSms)
@@ -108,10 +114,10 @@ def retrieveAllSms(machine):
             smsPart = sms[0]
 
             result = {
-                "Date": str(smsPart['DateTime']),
-                "Number": smsPart['Number'],
-                "State": smsPart['State'],
-                "Locations": [smsPart['Location'] for smsPart in sms],
+                "Date": str(smsPart["DateTime"]),
+                "Number": smsPart["Number"],
+                "State": smsPart["State"],
+                "Locations": [smsPart["Location"] for smsPart in sms],
             }
 
             # Try to decode SMS - this may fail for MMS notifications or corrupted messages
@@ -119,41 +125,47 @@ def retrieveAllSms(machine):
                 decodedSms = gammu.DecodeSMS(sms)
                 if decodedSms == None:
                     # DecodeSMS returned None - use raw text from SMS part
-                    result["Text"] = smsPart.get('Text', '')
+                    result["Text"] = smsPart.get("Text", "")
                 else:
                     # Successfully decoded - concatenate all text entries
                     text = ""
-                    for entry in decodedSms['Entries']:
-                        if entry.get('Buffer') is not None:
-                            text += entry['Buffer']
-                    result["Text"] = text if text else smsPart.get('Text', '')
+                    for entry in decodedSms["Entries"]:
+                        if entry.get("Buffer") is not None:
+                            text += entry["Buffer"]
+                    result["Text"] = text if text else smsPart.get("Text", "")
 
             except UnicodeDecodeError as e:
                 # MMS notification or binary message that can't be decoded as UTF-8
-                print(f"Warning: Cannot decode SMS as UTF-8 (probably MMS notification): {e}")
+                print(
+                    f"Warning: Cannot decode SMS as UTF-8 (probably MMS notification): {e}"
+                )
                 # Try to get raw text, but handle potential binary data safely
                 try:
-                    raw_text = smsPart.get('Text', '')
+                    raw_text = smsPart.get("Text", "")
                     # If Text is bytes, try to decode with error handling
                     if isinstance(raw_text, bytes):
-                        result["Text"] = raw_text.decode('utf-8', errors='replace')
+                        result["Text"] = raw_text.decode("utf-8", errors="replace")
                     else:
-                        result["Text"] = str(raw_text) if raw_text else '[MMS or binary message]'
+                        result["Text"] = (
+                            str(raw_text) if raw_text else "[MMS or binary message]"
+                        )
                 except Exception:
-                    result["Text"] = '[MMS or binary message - cannot display]'
+                    result["Text"] = "[MMS or binary message - cannot display]"
 
             except Exception as e:
                 # Any other decoding error (corrupted SMS, unknown format, etc.)
                 print(f"Warning: Error decoding SMS: {e}")
                 # Fallback to raw text with safe handling
                 try:
-                    raw_text = smsPart.get('Text', '')
+                    raw_text = smsPart.get("Text", "")
                     if isinstance(raw_text, bytes):
-                        result["Text"] = raw_text.decode('utf-8', errors='replace')
+                        result["Text"] = raw_text.decode("utf-8", errors="replace")
                     else:
-                        result["Text"] = str(raw_text) if raw_text else '[Decoding error]'
+                        result["Text"] = (
+                            str(raw_text) if raw_text else "[Decoding error]"
+                        )
                 except Exception:
-                    result["Text"] = '[Message decoding failed]'
+                    result["Text"] = "[Message decoding failed]"
 
             results.append(result)
 
@@ -167,7 +179,12 @@ def retrieveAllSms(machine):
 def deleteSms(machine, sms):
     """Delete SMS by location"""
     try:
-        list(map(lambda location: machine.DeleteSMS(Folder=0, Location=location), sms["Locations"]))
+        list(
+            map(
+                lambda location: machine.DeleteSMS(Folder=0, Location=location),
+                sms["Locations"],
+            )
+        )
     except Exception as e:
         print(f"Error deleting SMS: {e}")
 
@@ -183,17 +200,13 @@ def setupCallbacks(machine, unified_callback):
     Uses Gammu SetIncomingCall, SetIncomingSMS and SetIncomingCallback.
     Returns dict with status of each callback setup.
     """
-    results = {
-        'callback': False,
-        'incoming_call': False,
-        'incoming_sms': False
-    }
+    results = {"callback": False, "incoming_call": False, "incoming_sms": False}
 
     # Set unified callback handler
     try:
         machine.SetIncomingCallback(unified_callback)
         print("📱 Unified callback: SetIncomingCallback registered")
-        results['callback'] = True
+        results["callback"] = True
     except Exception as e:
         print(f"📱 SetIncomingCallback failed: {type(e).__name__}: {e}")
 
@@ -201,7 +214,7 @@ def setupCallbacks(machine, unified_callback):
     try:
         machine.SetIncomingCall()
         print("📞 SetIncomingCall: Enabled")
-        results['incoming_call'] = True
+        results["incoming_call"] = True
     except gammu.ERR_NOTSUPPORTED:
         print("📞 SetIncomingCall: Not supported by this modem")
     except Exception as e:
@@ -211,7 +224,7 @@ def setupCallbacks(machine, unified_callback):
     try:
         machine.SetIncomingSMS()
         print("📨 SetIncomingSMS: Enabled")
-        results['incoming_sms'] = True
+        results["incoming_sms"] = True
     except gammu.ERR_NOTSUPPORTED:
         print("📨 SetIncomingSMS: Not supported by this modem")
     except Exception as e:
@@ -222,133 +235,131 @@ def setupCallbacks(machine, unified_callback):
 
 def get_network_type(machine):
     """Get network type (2G/3G/4G/LTE) via AT commands
-    
+
     Uses AT+CEREG? command to retrieve Access Technology (AcT) parameter
     Returns human-readable network type string
-    
+
     Note: Temporarily disconnects Gammu to send AT commands, then reconnects
     Results are cached for 5 minutes to minimize disconnects
     """
     import logging
-    import serial
-    import time
     import os
-    
+    import time
+
+    import serial
+
     # Check cache first
     # If _network_type_cache_seconds <= 0, cache never expires (only on modem reconnect)
     # Otherwise, cache expires after the configured duration
     global _network_type_cache, _network_type_cache_seconds
     current_time = time_module.time()
-    if _network_type_cache['type'] is not None:
+    if _network_type_cache["type"] is not None:
         # Cache exists - check if it's still valid
         if _network_type_cache_seconds <= 0:
             # Cache never expires (reconnect-only mode)
-            return _network_type_cache['type']
-        cache_age = current_time - _network_type_cache['timestamp']
+            return _network_type_cache["type"]
+        cache_age = current_time - _network_type_cache["timestamp"]
         if cache_age < _network_type_cache_seconds:
             # Cache hasn't expired yet
-            return _network_type_cache['type']
-    
+            return _network_type_cache["type"]
+
     try:
         # Get the device path from Gammu config
         config = machine.GetConfig(0)
-        device_path = config.get('Device', '')
-        
+        device_path = config.get("Device", "")
+
         if not device_path:
-            return 'Unknown'
-        
+            return "Unknown"
+
         # Resolve symlinks to get actual device
         if os.path.islink(device_path):
             device_path = os.path.realpath(device_path)
-        
+
         # Temporarily disconnect Gammu to free the serial port
         try:
             machine.Terminate()
             time.sleep(0.5)
         except Exception:
-            return 'Unknown'
-        
+            return "Unknown"
+
         # Open serial connection
         ser = None
-        network_type = 'Unknown'
+        network_type = "Unknown"
         try:
             ser = serial.Serial(
-                port=device_path,
-                baudrate=115200,
-                timeout=2,
-                write_timeout=2
+                port=device_path, baudrate=115200, timeout=2, write_timeout=2
             )
-            
+
             time.sleep(0.1)
             ser.reset_input_buffer()
             ser.reset_output_buffer()
-            
+
             # Use AT+CEREG? (EPS/LTE registration) - most reliable for LTE modems
-            ser.write(b'AT+CEREG=2\r\n')
+            ser.write(b"AT+CEREG=2\r\n")
             time.sleep(0.2)
             ser.read_all()
-            
-            ser.write(b'AT+CEREG?\r\n')
+
+            ser.write(b"AT+CEREG?\r\n")
             time.sleep(0.2)
-            response = ser.read_all().decode('utf-8', errors='ignore')
-            
-            for line in response.split('\n'):
-                if '+CEREG:' in line:
-                    parts = line.split(':')[1].strip().split(',')
+            response = ser.read_all().decode("utf-8", errors="ignore")
+
+            for line in response.split("\n"):
+                if "+CEREG:" in line:
+                    parts = line.split(":")[1].strip().split(",")
                     if len(parts) >= 5:
                         try:
                             act = int(parts[4].strip().strip('"'))
                             network_type = map_act_to_network_type(act)
                         except (ValueError, IndexError):
                             pass
-            
+
             # Fallback: Try AT+CGREG? (GPRS) if CEREG didn't work
-            if network_type == 'Unknown':
-                ser.write(b'AT+CGREG=2\r\n')
+            if network_type == "Unknown":
+                ser.write(b"AT+CGREG=2\r\n")
                 time.sleep(0.2)
                 ser.read_all()
-                
-                ser.write(b'AT+CGREG?\r\n')
+
+                ser.write(b"AT+CGREG?\r\n")
                 time.sleep(0.2)
-                response = ser.read_all().decode('utf-8', errors='ignore')
-                
-                for line in response.split('\n'):
-                    if '+CGREG:' in line:
-                        parts = line.split(':')[1].strip().split(',')
+                response = ser.read_all().decode("utf-8", errors="ignore")
+
+                for line in response.split("\n"):
+                    if "+CGREG:" in line:
+                        parts = line.split(":")[1].strip().split(",")
                         if len(parts) >= 5:
                             try:
                                 act = int(parts[4].strip().strip('"'))
                                 network_type = map_act_to_network_type(act)
                             except (ValueError, IndexError):
                                 pass
-            
+
         except Exception:
             pass
-            
+
         finally:
             if ser and ser.is_open:
                 ser.close()
             time.sleep(0.3)
-        
+
         # Reconnect Gammu
         try:
             machine.Init()
         except Exception:
             pass
-        
+
         # Update cache
-        _network_type_cache['type'] = network_type
-        _network_type_cache['timestamp'] = current_time
-        
+        _network_type_cache["type"] = network_type
+        _network_type_cache["timestamp"] = current_time
+
         return network_type
-        
+
     except Exception:
         # Try to reconnect Gammu if it was disconnected
         try:
             machine.Init()
         except:
             pass
-        return 'Unknown'
+        return "Unknown"
 
 
 def map_act_to_network_type(act):
@@ -367,6 +378,6 @@ def map_act_to_network_type(act):
         10: "4G (LTE-5G)",
         11: "5G (NR)",
         12: "5G (NG-RAN)",
-        13: "4G+5G (EN-DC)"
+        13: "4G+5G (EN-DC)",
     }
     return act_map.get(act, f"Unknown (AcT={act})")

--- a/addon-gsm-gateway/tests/test_balance_parser.py
+++ b/addon-gsm-gateway/tests/test_balance_parser.py
@@ -8,21 +8,23 @@ These tests verify the balance SMS parsing and data migration:
 - Migration of old string-based format to new numeric format
 - Currency symbol detection
 """
+
 import json
 import os
 import tempfile
+
 import pytest
 
 
 class MockBalanceSMSParser:
     """
     Mock implementation of BalanceSMSParser for testing.
-    
+
     This mirrors the actual implementation in mqtt_publisher.py but without
     external dependencies (logging, file I/O during init).
     """
-    
-    def __init__(self, balance_file=None, currency='USD'):
+
+    def __init__(self, balance_file=None, currency="USD"):
         self.balance_file = balance_file
         self.currency = currency
         self.balance_data = {
@@ -34,50 +36,52 @@ class MockBalanceSMSParser:
             "messages_remaining": None,
             "plan_expiry": None,
             "last_updated": None,
-            "raw_message": None
+            "raw_message": None,
         }
-    
+
     def _migrate_old_format(self, data):
         """Migrate old string-based format to new numeric format"""
         import re
+
         migrated = False
-        
+
         # Migrate data_remaining from "200.00 MB" to 200.0
-        if isinstance(data.get('data_remaining'), str):
-            match = re.match(r'([\d.]+)\s*(MB|GB)?', data['data_remaining'])
+        if isinstance(data.get("data_remaining"), str):
+            match = re.match(r"([\d.]+)\s*(MB|GB)?", data["data_remaining"])
             if match:
                 value = float(match.group(1))
-                unit = match.group(2) or 'MB'
-                if unit.upper() == 'GB':
+                unit = match.group(2) or "MB"
+                if unit.upper() == "GB":
                     value *= 1024
-                data['data_remaining'] = value
-                data['data_remaining_unit'] = 'MB'
+                data["data_remaining"] = value
+                data["data_remaining_unit"] = "MB"
                 migrated = True
-        
+
         # Migrate account_balance from "$3.00" to 3.0
-        if isinstance(data.get('account_balance'), str):
-            match = re.match(r'[\$€£]?([\d.]+)', data['account_balance'])
+        if isinstance(data.get("account_balance"), str):
+            match = re.match(r"[\$€£]?([\d.]+)", data["account_balance"])
             if match:
                 value = float(match.group(1))
-                data['account_balance'] = value
-                data['account_balance_currency'] = self.currency
+                data["account_balance"] = value
+                data["account_balance_currency"] = self.currency
                 migrated = True
-        
+
         return data
-    
+
     def parse_balance_sms(self, message_text):
         """Parse balance information from SMS text"""
         import re
         import time
-        
+
         updated = False
-        self.balance_data["last_updated"] = time.strftime('%Y-%m-%d %H:%M:%S')
+        self.balance_data["last_updated"] = time.strftime("%Y-%m-%d %H:%M:%S")
         self.balance_data["raw_message"] = message_text
-        
+
         # Parse data remaining (MB or GB) - store as numeric MB
         data_match = re.search(
-            r'([\d.]+)\s*(MB|GB)\s*(?:of\s*)?(?:High\s*Speed\s*)?Data',
-            message_text, re.IGNORECASE
+            r"([\d.]+)\s*(MB|GB)\s*(?:of\s*)?(?:High\s*Speed\s*)?Data",
+            message_text,
+            re.IGNORECASE,
         )
         if data_match:
             amount = float(data_match.group(1))
@@ -88,42 +92,42 @@ class MockBalanceSMSParser:
             self.balance_data["data_remaining"] = amount
             self.balance_data["data_remaining_unit"] = "MB"
             updated = True
-        
+
         # Parse minutes remaining
-        minutes_match = re.search(r'([\d,]+)\s*Minutes', message_text, re.IGNORECASE)
+        minutes_match = re.search(r"([\d,]+)\s*Minutes", message_text, re.IGNORECASE)
         if minutes_match:
-            minutes = int(minutes_match.group(1).replace(',', ''))
+            minutes = int(minutes_match.group(1).replace(",", ""))
             self.balance_data["minutes_remaining"] = minutes
             updated = True
-        
+
         # Parse messages remaining
-        messages_match = re.search(r'([\d,]+)\s*Messages', message_text, re.IGNORECASE)
+        messages_match = re.search(r"([\d,]+)\s*Messages", message_text, re.IGNORECASE)
         if messages_match:
-            messages = int(messages_match.group(1).replace(',', ''))
+            messages = int(messages_match.group(1).replace(",", ""))
             self.balance_data["messages_remaining"] = messages
             updated = True
-        
+
         # Parse account balance (dollar amount) - store as numeric
         balance_match = re.search(
-            r'balance\s*of\s*\$?([\d.]+)', message_text, re.IGNORECASE
+            r"balance\s*of\s*\$?([\d.]+)", message_text, re.IGNORECASE
         )
         if balance_match:
             balance = float(balance_match.group(1))
             self.balance_data["account_balance"] = balance
             self.balance_data["account_balance_currency"] = self.currency
             updated = True
-        
+
         # Parse plan expiry date
         expiry_match = re.search(
-            r'expires?\s*on\s*([\d-]+)', message_text, re.IGNORECASE
+            r"expires?\s*on\s*([\d-]+)", message_text, re.IGNORECASE
         )
         if expiry_match:
             expiry_date = expiry_match.group(1)
             self.balance_data["plan_expiry"] = expiry_date
             updated = True
-        
+
         return self.balance_data
-    
+
     def get_balance_data(self):
         """Get current balance data"""
         return self.balance_data
@@ -131,96 +135,98 @@ class MockBalanceSMSParser:
 
 class TestBalanceSMSParsing:
     """Tests for parsing balance information from SMS messages."""
-    
+
     def test_parse_data_minutes_messages(self):
         """Test parsing data, minutes, and messages from typical carrier SMS."""
         parser = MockBalanceSMSParser()
-        message = "You have 200.00 MB of High Speed Data Remaining 200 Minutes & 991 Messages"
-        
+        message = (
+            "You have 200.00 MB of High Speed Data Remaining 200 Minutes & 991 Messages"
+        )
+
         result = parser.parse_balance_sms(message)
-        
+
         assert result["data_remaining"] == 200.0
         assert result["data_remaining_unit"] == "MB"
         assert result["minutes_remaining"] == 200
         assert result["messages_remaining"] == 991
-    
+
     def test_parse_account_balance_and_expiry(self):
         """Test parsing account balance and plan expiry date."""
         parser = MockBalanceSMSParser()
         message = "Your plan expires on 2026-01-19. You have balance of $2.00"
-        
+
         result = parser.parse_balance_sms(message)
-        
+
         assert result["account_balance"] == 2.0
         assert result["account_balance_currency"] == "USD"
         assert result["plan_expiry"] == "2026-01-19"
-    
+
     def test_parse_gb_to_mb_conversion(self):
         """Test that GB values are converted to MB."""
         parser = MockBalanceSMSParser()
         message = "You have 1.5 GB of High Speed Data Remaining"
-        
+
         result = parser.parse_balance_sms(message)
-        
+
         assert result["data_remaining"] == 1536.0  # 1.5 * 1024
         assert result["data_remaining_unit"] == "MB"
-    
+
     def test_parse_with_commas_in_numbers(self):
         """Test parsing numbers with comma separators."""
         parser = MockBalanceSMSParser()
         message = "You have 1,500 Minutes & 2,000 Messages remaining"
-        
+
         result = parser.parse_balance_sms(message)
-        
+
         assert result["minutes_remaining"] == 1500
         assert result["messages_remaining"] == 2000
-    
+
     def test_parse_balance_without_dollar_sign(self):
         """Test parsing balance amount without currency symbol."""
         parser = MockBalanceSMSParser()
         message = "You have balance of 5.50"
-        
+
         result = parser.parse_balance_sms(message)
-        
+
         assert result["account_balance"] == 5.50
-    
+
     def test_custom_currency_setting(self):
         """Test that custom currency is applied to parsed balance."""
-        parser = MockBalanceSMSParser(currency='EUR')
+        parser = MockBalanceSMSParser(currency="EUR")
         message = "You have balance of 10.00"
-        
+
         result = parser.parse_balance_sms(message)
-        
+
         assert result["account_balance"] == 10.0
         assert result["account_balance_currency"] == "EUR"
-    
+
     def test_partial_message_data_only(self):
         """Test parsing message with only data information."""
         parser = MockBalanceSMSParser()
         message = "You have 500 MB of Data remaining"
-        
+
         result = parser.parse_balance_sms(message)
-        
+
         assert result["data_remaining"] == 500.0
         assert result["minutes_remaining"] is None
         assert result["messages_remaining"] is None
-    
+
     def test_raw_message_stored(self):
         """Test that raw message is stored in balance data."""
         parser = MockBalanceSMSParser()
         message = "Test message content"
-        
+
         result = parser.parse_balance_sms(message)
-        
+
         assert result["raw_message"] == message
-    
+
     def test_last_updated_set(self):
         """Test that last_updated timestamp is set."""
         parser = MockBalanceSMSParser()
         message = "You have 100 MB of Data"
-        
+
         result = parser.parse_balance_sms(message)
-        
+
         assert result["last_updated"] is not None
         # Should be in format YYYY-MM-DD HH:MM:SS
         assert len(result["last_updated"]) == 19
@@ -228,203 +234,203 @@ class TestBalanceSMSParsing:
 
 class TestBalanceDataMigration:
     """Tests for migrating old string-based format to new numeric format."""
-    
+
     def test_migrate_data_remaining_mb(self):
         """Test migration of MB string format to numeric."""
         parser = MockBalanceSMSParser()
         old_data = {"data_remaining": "200.00 MB"}
-        
+
         migrated = parser._migrate_old_format(old_data)
-        
+
         assert migrated["data_remaining"] == 200.0
         assert migrated["data_remaining_unit"] == "MB"
-    
+
     def test_migrate_data_remaining_gb(self):
         """Test migration of GB string format to numeric MB."""
         parser = MockBalanceSMSParser()
         old_data = {"data_remaining": "2.5 GB"}
-        
+
         migrated = parser._migrate_old_format(old_data)
-        
+
         assert migrated["data_remaining"] == 2560.0  # 2.5 * 1024
         assert migrated["data_remaining_unit"] == "MB"
-    
+
     def test_migrate_account_balance_with_dollar(self):
         """Test migration of dollar balance string to numeric."""
         parser = MockBalanceSMSParser()
         old_data = {"account_balance": "$3.00"}
-        
+
         migrated = parser._migrate_old_format(old_data)
-        
+
         assert migrated["account_balance"] == 3.0
         assert migrated["account_balance_currency"] == "USD"
-    
+
     def test_migrate_account_balance_with_euro(self):
         """Test migration of euro balance string to numeric."""
-        parser = MockBalanceSMSParser(currency='EUR')
+        parser = MockBalanceSMSParser(currency="EUR")
         old_data = {"account_balance": "€15.50"}
-        
+
         migrated = parser._migrate_old_format(old_data)
-        
+
         assert migrated["account_balance"] == 15.50
         assert migrated["account_balance_currency"] == "EUR"
-    
+
     def test_migrate_account_balance_with_pound(self):
         """Test migration of pound balance string to numeric."""
-        parser = MockBalanceSMSParser(currency='GBP')
+        parser = MockBalanceSMSParser(currency="GBP")
         old_data = {"account_balance": "£7.25"}
-        
+
         migrated = parser._migrate_old_format(old_data)
-        
+
         assert migrated["account_balance"] == 7.25
         assert migrated["account_balance_currency"] == "GBP"
-    
+
     def test_migrate_already_numeric_data(self):
         """Test that already numeric data is not changed."""
         parser = MockBalanceSMSParser()
         old_data = {"data_remaining": 150.0, "account_balance": 5.0}
-        
+
         migrated = parser._migrate_old_format(old_data)
-        
+
         assert migrated["data_remaining"] == 150.0
         assert migrated["account_balance"] == 5.0
-    
+
     def test_migrate_mixed_format(self):
         """Test migration with mix of old string and new numeric formats."""
         parser = MockBalanceSMSParser()
         old_data = {
             "data_remaining": "100.50 MB",  # Old format
             "account_balance": 10.0,  # Already numeric
-            "minutes_remaining": 500  # Already numeric
+            "minutes_remaining": 500,  # Already numeric
         }
-        
+
         migrated = parser._migrate_old_format(old_data)
-        
+
         assert migrated["data_remaining"] == 100.5
         assert migrated["account_balance"] == 10.0
         assert migrated["minutes_remaining"] == 500
-    
+
     def test_migrate_preserves_other_fields(self):
         """Test that migration preserves unrelated fields."""
         parser = MockBalanceSMSParser()
         old_data = {
             "data_remaining": "50 MB",
             "plan_expiry": "2026-01-19",
-            "minutes_remaining": 200
+            "minutes_remaining": 200,
         }
-        
+
         migrated = parser._migrate_old_format(old_data)
-        
+
         assert migrated["plan_expiry"] == "2026-01-19"
         assert migrated["minutes_remaining"] == 200
 
 
 class TestSensorValueTypes:
     """Tests verifying sensor values are correct types for Home Assistant."""
-    
+
     def test_data_remaining_is_float(self):
         """Verify data_remaining is float for device_class: data_size."""
         parser = MockBalanceSMSParser()
         message = "You have 200.00 MB of High Speed Data Remaining"
-        
+
         result = parser.parse_balance_sms(message)
-        
+
         assert isinstance(result["data_remaining"], float)
-    
+
     def test_account_balance_is_float(self):
         """Verify account_balance is float for device_class: monetary."""
         parser = MockBalanceSMSParser()
         message = "You have balance of $3.00"
-        
+
         result = parser.parse_balance_sms(message)
-        
+
         assert isinstance(result["account_balance"], float)
-    
+
     def test_minutes_remaining_is_int(self):
         """Verify minutes_remaining is int for device_class: duration."""
         parser = MockBalanceSMSParser()
         message = "You have 200 Minutes remaining"
-        
+
         result = parser.parse_balance_sms(message)
-        
+
         assert isinstance(result["minutes_remaining"], int)
-    
+
     def test_messages_remaining_is_int(self):
         """Verify messages_remaining is int."""
         parser = MockBalanceSMSParser()
         message = "You have 991 Messages remaining"
-        
+
         result = parser.parse_balance_sms(message)
-        
+
         assert isinstance(result["messages_remaining"], int)
-    
+
     def test_plan_expiry_is_string(self):
         """Verify plan_expiry is string for device_class: date."""
         parser = MockBalanceSMSParser()
         message = "Your plan expires on 2026-01-19"
-        
+
         result = parser.parse_balance_sms(message)
-        
+
         assert isinstance(result["plan_expiry"], str)
         assert result["plan_expiry"] == "2026-01-19"
 
 
 class TestEdgeCases:
     """Tests for edge cases and unusual inputs."""
-    
+
     def test_empty_message(self):
         """Test parsing empty message."""
         parser = MockBalanceSMSParser()
         message = ""
-        
+
         result = parser.parse_balance_sms(message)
-        
+
         assert result["data_remaining"] is None
         assert result["minutes_remaining"] is None
         assert result["messages_remaining"] is None
         assert result["account_balance"] is None
         assert result["plan_expiry"] is None
-    
+
     def test_unrelated_message(self):
         """Test parsing message without balance info."""
         parser = MockBalanceSMSParser()
         message = "Thank you for your payment. Have a nice day!"
-        
+
         result = parser.parse_balance_sms(message)
-        
+
         assert result["data_remaining"] is None
         assert result["account_balance"] is None
-    
+
     def test_decimal_precision(self):
         """Test parsing preserves decimal precision."""
         parser = MockBalanceSMSParser()
         message = "You have 123.45 MB of Data and balance of $67.89"
-        
+
         result = parser.parse_balance_sms(message)
-        
+
         assert result["data_remaining"] == 123.45
         assert result["account_balance"] == 67.89
-    
+
     def test_case_insensitive_parsing(self):
         """Test that parsing is case-insensitive."""
         parser = MockBalanceSMSParser()
         message = "you have 100 mb of high speed data REMAINING 50 MINUTES"
-        
+
         result = parser.parse_balance_sms(message)
-        
+
         assert result["data_remaining"] == 100.0
         assert result["minutes_remaining"] == 50
-    
+
     def test_multiple_parse_calls_accumulate(self):
         """Test that multiple parse calls update the same data object."""
         parser = MockBalanceSMSParser()
-        
+
         # First message with data
         parser.parse_balance_sms("You have 200 MB of Data Remaining")
-        
+
         # Second message with balance
         result = parser.parse_balance_sms("Your balance is balance of $5.00")
-        
+
         # Both should be present
         assert result["data_remaining"] == 200.0
         assert result["account_balance"] == 5.0

--- a/addon-gsm-gateway/tests/test_device_connectivity.py
+++ b/addon-gsm-gateway/tests/test_device_connectivity.py
@@ -7,9 +7,11 @@ These tests verify the modem offline detection and auto-restart functionality:
 - Restart timer persists through status polls when in hard_offline state
 - Configurable hard_offline_restart_timeout works correctly
 """
+
 import json
 import threading
 import time
+
 import pytest
 
 
@@ -30,7 +32,7 @@ class MockDeviceTracker:
             self.last_success_time = time.time()
 
             if self.hard_offline:
-                is_sms_operation = operation_name and 'sms' in operation_name.lower()
+                is_sms_operation = operation_name and "sms" in operation_name.lower()
                 is_same_operation = operation_name == self.hard_offline_operation
 
                 if is_sms_operation or is_same_operation:
@@ -88,7 +90,8 @@ class MockMQTTPublisher:
         failure_duration = current_time - self.failure_start_time
         is_hard_offline = self.device_tracker.hard_offline
         effective_timeout = (
-            self.hard_offline_restart_timeout if is_hard_offline 
+            self.hard_offline_restart_timeout
+            if is_hard_offline
             else self.restart_timeout
         )
 
@@ -112,7 +115,7 @@ class MockMQTTPublisher:
         self.device_tracker.record_failure(
             f"{operation_name}: Python timeout (15s)",
             is_timeout=True,
-            operation_name=operation_name
+            operation_name=operation_name,
         )
         self._check_restart_timeout()
 
@@ -321,47 +324,49 @@ class TestIntegrationScenario:
     def test_repeated_sms_failures_trigger_restart(self):
         """
         THIS IS THE EXACT BUG SCENARIO from 2025-12-16:
-        
+
         Log showed:
         [15:58:01] WARNING: 🔴 Hard offline: retrieveAllSms timed out
         [15:58:01] INFO: ⏱️ Failure tracking started at 15:58:01
         [15:58:01] INFO: ⏱️ Modem failing for 0s (restart after 30s, hard offline)
-        
+
         Then 5+ minutes passed with NO restart because _check_restart_timeout()
         was only called once at the initial timeout, not on subsequent cycles.
-        
+
         This test verifies that repeated calls to _check_restart_timeout()
         (as would happen on each failed SMS monitoring cycle) will eventually
         trigger the restart.
         """
         pub = MockMQTTPublisher(hard_offline_restart_timeout=30)
-        
+
         # Initial timeout - sets failure_start_time
         pub.track_timeout("retrieveAllSms")
         assert pub.device_tracker.hard_offline is True
         assert pub.failure_start_time is not None
         initial_start_time = pub.failure_start_time
-        
+
         # Verify restart NOT triggered yet (0s elapsed)
         assert pub._would_restart is False
-        
+
         # Simulate SMS monitoring loop calling _check_restart_timeout
         # on each 10s cycle. This is what the fix adds.
         # After 4 cycles (40s total), restart should have triggered.
-        
+
         restart_triggered = False
         for cycle in range(1, 5):  # Cycles at 10s, 20s, 30s, 40s
             # Simulate time passing (10s per cycle)
             pub.failure_start_time = initial_start_time - (cycle * 10)
-            
+
             # This is what the SMS monitoring loop now does on each failure
             pub._check_restart_timeout()
-            
+
             if pub._would_restart:
                 restart_triggered = True
-                assert cycle == 3, f"Restart should trigger at cycle 3 (30s), not {cycle}"
+                assert (
+                    cycle == 3
+                ), f"Restart should trigger at cycle 3 (30s), not {cycle}"
                 break
-        
+
         assert restart_triggered, (
             "CRITICAL BUG: Restart never triggered after 40s of failures! "
             "The _check_restart_timeout() must be called on each failed cycle."
@@ -370,11 +375,11 @@ class TestIntegrationScenario:
 
 class TestLockRaceCondition:
     """Tests for the lock race condition fix (v2.15.3).
-    
+
     The bug: Thread A checks hard_offline=False, then waits at gammu_lock.
     Thread B times out, sets hard_offline=True, releases lock.
     Thread A acquires lock and proceeds even though hard_offline is now True.
-    
+
     The fix: Check hard_offline AFTER acquiring the lock, inside track_gammu_operation.
     """
 
@@ -388,7 +393,7 @@ class TestLockRaceCondition:
         pub = MockMQTTPublisher()
         lock = threading.Lock()
         operation_executed = threading.Event()
-        
+
         def simulate_track_gammu_operation():
             """Simulates the fixed track_gammu_operation logic."""
             with lock:
@@ -400,26 +405,26 @@ class TestLockRaceCondition:
                 else:
                     operation_executed.set()
                     return "executed"
-        
+
         # Initially hard_offline is False
         assert pub.device_tracker.hard_offline is False
-        
+
         # Thread A: Check hard_offline (False), then wait at lock
         # Simulate this by having Thread A acquire lock first
         lock.acquire()
-        
+
         # Now simulate Thread B setting hard_offline while Thread A holds lock
         # (In reality, Thread A would be waiting, but we're testing the check)
         pub.device_tracker.hard_offline = True
         pub.device_tracker.hard_offline_operation = "retrieveAllSms"
         pub.failure_start_time = time.time()
-        
+
         # Release lock - now the "next thread" should check hard_offline
         lock.release()
-        
+
         # Thread C comes in after hard_offline is set
         result = simulate_track_gammu_operation()
-        
+
         # The operation should be SKIPPED because hard_offline is True
         assert result == "skipped"
         assert not operation_executed.is_set()
@@ -433,7 +438,7 @@ class TestLockRaceCondition:
         lock = threading.Lock()
         skipped_count = 0
         executed_count = 0
-        
+
         def simulate_operation():
             nonlocal skipped_count, executed_count
             with lock:
@@ -444,22 +449,19 @@ class TestLockRaceCondition:
                 # Simulate operation
                 time.sleep(0.01)
                 executed_count += 1
-        
+
         # Set hard_offline
         pub.device_tracker.hard_offline = True
         pub.failure_start_time = time.time() - 10  # 10s ago
-        
+
         # Simulate multiple operations trying to run
-        threads = [
-            threading.Thread(target=simulate_operation)
-            for _ in range(5)
-        ]
-        
+        threads = [threading.Thread(target=simulate_operation) for _ in range(5)]
+
         for t in threads:
             t.start()
         for t in threads:
             t.join()
-        
+
         # All operations should have been skipped
         assert skipped_count == 5
         assert executed_count == 0

--- a/addon-gsm-gateway/tests/test_get_endpoint.py
+++ b/addon-gsm-gateway/tests/test_get_endpoint.py
@@ -8,6 +8,7 @@ These tests verify the GET endpoint implementation:
 - Configuration default values
 - Path parsing for /sms/{PHONE}&{MESSAGE} format
 """
+
 import ipaddress
 import time
 from urllib.parse import unquote_plus
@@ -15,12 +16,12 @@ from urllib.parse import unquote_plus
 
 class TestIPWhitelist:
     """Test IP address whitelisting with CIDR notation."""
-    
+
     def test_ip_in_private_network(self):
         """Test that private network IPs are allowed."""
         client_ip = "192.168.1.100"
         allowed_networks = ["192.168.0.0/16", "10.0.0.0/8", "172.16.0.0/12"]
-        
+
         client = ipaddress.ip_address(client_ip)
         allowed = False
         for network_str in allowed_networks:
@@ -28,14 +29,14 @@ class TestIPWhitelist:
             if client in network:
                 allowed = True
                 break
-        
+
         assert allowed is True, "Private IP should be allowed"
-    
+
     def test_ip_outside_private_network(self):
         """Test that public IPs are blocked."""
         client_ip = "8.8.8.8"
         allowed_networks = ["192.168.0.0/16", "10.0.0.0/8", "172.16.0.0/12"]
-        
+
         client = ipaddress.ip_address(client_ip)
         allowed = False
         for network_str in allowed_networks:
@@ -43,14 +44,14 @@ class TestIPWhitelist:
             if client in network:
                 allowed = True
                 break
-        
+
         assert allowed is False, "Public IP should be blocked"
-    
+
     def test_localhost_allowed(self):
         """Test that localhost is allowed."""
         client_ip = "127.0.0.1"
         allowed_networks = ["127.0.0.1"]
-        
+
         client = ipaddress.ip_address(client_ip)
         allowed = False
         for network_str in allowed_networks:
@@ -58,38 +59,38 @@ class TestIPWhitelist:
             if client in network:
                 allowed = True
                 break
-        
+
         assert allowed is True, "Localhost should be allowed"
-    
+
     def test_empty_whitelist_allows_all(self):
         """Test that empty whitelist allows all IPs."""
         allowed_networks = []
-        
+
         # When list is empty, IP check should be skipped
         assert not allowed_networks, "Empty list should be falsy"
 
 
 class TestURLDecoding:
     """Test URL decoding for phone numbers and messages."""
-    
+
     def test_plus_to_space(self):
         """Test that + signs are decoded to spaces."""
         encoded = "Hello+World"
         decoded = unquote_plus(encoded)
         assert decoded == "Hello World", "Plus should decode to space"
-    
+
     def test_percent20_to_space(self):
         """Test that %20 is decoded to spaces."""
         encoded = "Hello%20World"
         decoded = unquote_plus(encoded)
         assert decoded == "Hello World", "%20 should decode to space"
-    
+
     def test_mixed_encoding(self):
         """Test mixed encoding formats."""
         encoded = "Test+Message%20Here"
         decoded = unquote_plus(encoded)
         assert decoded == "Test Message Here", "Mixed encoding should work"
-    
+
     def test_phone_number_with_plus(self):
         """Test phone number with + prefix."""
         encoded = "%2B15555551234"
@@ -99,126 +100,125 @@ class TestURLDecoding:
 
 class TestPathParsing:
     """Test path parsing for GET endpoint."""
-    
+
     def test_split_on_first_ampersand(self):
         """Test that path is split on first & only."""
         path = "5555551234&Hello&World"
-        parts = path.split('&', 1)
-        
+        parts = path.split("&", 1)
+
         assert len(parts) == 2, "Should split into 2 parts"
         assert parts[0] == "5555551234", "First part should be phone"
         assert parts[1] == "Hello&World", "Second part should be rest of message"
-    
+
     def test_path_without_ampersand(self):
         """Test that path without & is handled."""
         path = "5555551234"
-        parts = path.split('&', 1)
-        
+        parts = path.split("&", 1)
+
         assert len(parts) == 1, "Should have 1 part only"
-    
+
     def test_path_with_decoded_content(self):
         """Test path parsing with URL decoding."""
         path = "5555551234&Test+Message"
-        parts = path.split('&', 1)
+        parts = path.split("&", 1)
         phone = unquote_plus(parts[0])
         message = unquote_plus(parts[1])
-        
+
         assert phone == "5555551234", "Phone should be decoded"
         assert message == "Test Message", "Message should be decoded"
 
 
 class TestDeduplication:
     """Test SMS deduplication logic."""
-    
+
     def test_duplicate_detection_within_window(self):
         """Test that duplicates within 15s window are detected."""
         cache = {}
         window = 15
-        
+
         # First request
         key1 = "5555551234|Test message"
         time1 = time.time()
         cache[key1] = time1
-        
+
         # Duplicate request 1 second later
         time2 = time1 + 1
         is_duplicate = key1 in cache and (time2 - cache[key1] < window)
-        
+
         assert is_duplicate is True, "Should detect duplicate within window"
-    
+
     def test_duplicate_detection_outside_window(self):
         """Test that requests outside window are not duplicates."""
         cache = {}
         window = 15
-        
+
         # First request
         key1 = "5555551234|Test message"
         time1 = time.time()
         cache[key1] = time1
-        
+
         # Request 20 seconds later
         time2 = time1 + 20
         is_duplicate = key1 in cache and (time2 - cache[key1] < window)
-        
+
         assert is_duplicate is False, "Should not detect duplicate outside window"
-    
+
     def test_cache_cleanup(self):
         """Test that old cache entries are removed."""
         cache = {
             "key1|msg1": time.time() - 20,  # 20 seconds old
-            "key2|msg2": time.time() - 5,   # 5 seconds old
+            "key2|msg2": time.time() - 5,  # 5 seconds old
         }
         window = 15
         current_time = time.time()
-        
+
         # Clean cache
-        cleaned = {k: v for k, v in cache.items() 
-                   if current_time - v < window}
-        
+        cleaned = {k: v for k, v in cache.items() if current_time - v < window}
+
         assert "key1|msg1" not in cleaned, "Old entry should be removed"
         assert "key2|msg2" in cleaned, "Recent entry should remain"
-    
+
     def test_different_message_not_duplicate(self):
         """Test that different messages are not duplicates."""
         key1 = "5555551234|Message 1"
         key2 = "5555551234|Message 2"
-        
+
         assert key1 != key2, "Different messages should have different keys"
-    
+
     def test_different_number_not_duplicate(self):
         """Test that different numbers are not duplicates."""
         key1 = "5555551234|Test message"
         key2 = "9999999999|Test message"
-        
+
         assert key1 != key2, "Different numbers should have different keys"
 
 
 class TestConfigDefaults:
     """Test configuration default values."""
-    
+
     def test_auth_defaults_to_false(self):
         """Test that auth_required defaults to False."""
         config = {}
-        auth_required = config.get('get_endpoint_auth_required', False)
+        auth_required = config.get("get_endpoint_auth_required", False)
         assert auth_required is False, "Auth should default to False"
-    
+
     def test_allowed_ips_defaults_to_empty(self):
         """Test that allowed_ips defaults to empty list."""
         config = {}
-        allowed_ips = config.get('get_endpoint_allowed_ips', [])
+        allowed_ips = config.get("get_endpoint_allowed_ips", [])
         assert allowed_ips == [], "Allowed IPs should default to []"
-    
+
     def test_deduplication_defaults_to_true(self):
         """Test that deduplication defaults to True."""
         config = {}
-        dedup_enabled = config.get('get_endpoint_deduplication_enabled', True)
+        dedup_enabled = config.get("get_endpoint_deduplication_enabled", True)
         assert dedup_enabled is True, "Deduplication should default to True"
-    
+
     def test_empty_list_is_falsy(self):
         """Test that empty IP list is falsy (disables IP check)."""
         allowed_ips = []
         assert not allowed_ips, "Empty list should be falsy"
-    
+
     def test_nonempty_list_is_truthy(self):
         """Test that non-empty IP list is truthy (enables IP check)."""
         allowed_ips = ["192.168.0.0/16"]

--- a/addon-gsm-gateway/tests/test_route_order.py
+++ b/addon-gsm-gateway/tests/test_route_order.py
@@ -2,9 +2,11 @@
 Test to verify Flask-RESTX route registration order
 Ensures endpoints appear in the correct order in Swagger UI
 """
-import pytest
-import sys
+
 import os
+import sys
+
+import pytest
 
 # Add parent directory to path to import run.py
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
@@ -12,50 +14,62 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 
 def test_route_definitions_exist():
     """Verify all SMS routes are properly defined in run.py"""
-    with open(os.path.join(os.path.dirname(__file__), '..', 'run.py'), 'r') as f:
+    with open(os.path.join(os.path.dirname(__file__), "..", "run.py"), "r") as f:
         content = f.read()
-    
+
     # Check all routes exist
-    assert "@ns_sms.route('')" in content, "POST /sms route not found"
-    assert "@ns_sms.route('/add/<path:sms_data>')" in content, "GET /sms/add/{sms_data} route not found"
-    assert "@ns_sms.route('/<path:sms_data>')" in content, "GET /sms/{sms_data} route not found"
-    assert "@ns_sms.route('/getsms')" in content, "GET /sms/getsms route not found"
-    assert "@ns_sms.route('/deleteall')" in content, "DELETE /sms/deleteall route not found"
-    assert "@ns_sms.route('/<int:id>')" in content, "GET/DELETE /sms/{id} route not found"
+    assert '@ns_sms.route("")' in content, "POST /sms route not found"
+    assert (
+        '@ns_sms.route("/add/<path:sms_data>")' in content
+    ), "GET /sms/add/{sms_data} route not found"
+    assert (
+        '@ns_sms.route("/<path:sms_data>")' in content
+    ), "GET /sms/{sms_data} route not found"
+    assert '@ns_sms.route("/getsms")' in content, "GET /sms/getsms route not found"
+    assert (
+        '@ns_sms.route("/deleteall")' in content
+    ), "DELETE /sms/deleteall route not found"
+    assert (
+        '@ns_sms.route("/<int:id>")' in content
+    ), "GET/DELETE /sms/{id} route not found"
 
 
 def test_route_order():
     """Verify routes are defined in the correct order for Swagger UI"""
-    with open(os.path.join(os.path.dirname(__file__), '..', 'run.py'), 'r') as f:
+    with open(os.path.join(os.path.dirname(__file__), "..", "run.py"), "r") as f:
         lines = f.readlines()
-    
+
     # Find line numbers for each route
     route_lines = {}
     for i, line in enumerate(lines, 1):
-        if "@ns_sms.route('')" in line:
-            route_lines['post_sms'] = i
-        elif "@ns_sms.route('/<path:sms_data>')" in line:
-            route_lines['get_sms_path'] = i
-        elif "@ns_sms.route('/getsms')" in line:
-            route_lines['get_sms_list'] = i
-        elif "@ns_sms.route('/deleteall')" in line:
-            route_lines['delete_all'] = i
-        elif "@ns_sms.route('/<int:id>')" in line:
-            route_lines['sms_by_id'] = i
-    
+        if '@ns_sms.route("")' in line:
+            route_lines["post_sms"] = i
+        elif '@ns_sms.route("/<path:sms_data>")' in line:
+            route_lines["get_sms_path"] = i
+        elif '@ns_sms.route("/getsms")' in line:
+            route_lines["get_sms_list"] = i
+        elif '@ns_sms.route("/deleteall")' in line:
+            route_lines["delete_all"] = i
+        elif '@ns_sms.route("/<int:id>")' in line:
+            route_lines["sms_by_id"] = i
+
     # Verify all routes found
     assert len(route_lines) == 5, f"Expected 5 routes, found {len(route_lines)}"
-    
+
     # Verify order: POST /sms → GET /sms/{sms_data} → GET /getsms → DELETE /deleteall → /{id}
-    assert route_lines['post_sms'] < route_lines['get_sms_path'], \
-        "POST /sms should come before GET /sms/{sms_data}"
-    assert route_lines['get_sms_path'] < route_lines['get_sms_list'], \
-        "GET /sms/{sms_data} should come before GET /getsms"
-    assert route_lines['get_sms_list'] < route_lines['delete_all'], \
-        "GET /getsms should come before DELETE /deleteall"
-    assert route_lines['delete_all'] < route_lines['sms_by_id'], \
-        "DELETE /deleteall should come before /{id}"
-    
+    assert (
+        route_lines["post_sms"] < route_lines["get_sms_path"]
+    ), "POST /sms should come before GET /sms/{sms_data}"
+    assert (
+        route_lines["get_sms_path"] < route_lines["get_sms_list"]
+    ), "GET /sms/{sms_data} should come before GET /getsms"
+    assert (
+        route_lines["get_sms_list"] < route_lines["delete_all"]
+    ), "GET /getsms should come before DELETE /deleteall"
+    assert (
+        route_lines["delete_all"] < route_lines["sms_by_id"]
+    ), "DELETE /deleteall should come before /{id}"
+
     print(f"\n✅ Route order correct:")
     print(f"  1. POST /sms (line {route_lines['post_sms']})")
     print(f"  2. GET /sms/{{sms_data}} (line {route_lines['get_sms_path']})")
@@ -66,25 +80,25 @@ def test_route_order():
 
 def test_no_duplicate_classes():
     """Verify there are no duplicate class definitions"""
-    with open(os.path.join(os.path.dirname(__file__), '..', 'run.py'), 'r') as f:
+    with open(os.path.join(os.path.dirname(__file__), "..", "run.py"), "r") as f:
         content = f.read()
-    
+
     # Check for duplicate class definitions
-    classes = ['SmsCollection', 'SmsGet', 'GetSms', 'DeleteAllSms', 'SmsItem']
+    classes = ["SmsCollection", "SmsGet", "GetSms", "DeleteAllSms", "SmsItem"]
     for cls in classes:
-        count = content.count(f'class {cls}(Resource)')
+        count = content.count(f"class {cls}(Resource)")
         assert count == 1, f"Class {cls} defined {count} times (expected 1)"
 
 
 def test_deduplication_cache_defined():
     """Verify deduplication cache is properly defined"""
-    with open(os.path.join(os.path.dirname(__file__), '..', 'run.py'), 'r') as f:
+    with open(os.path.join(os.path.dirname(__file__), "..", "run.py"), "r") as f:
         content = f.read()
-    
-    assert '_sms_dedup_cache = {}' in content, "Deduplication cache not initialized"
-    assert '_sms_dedup_window = 15' in content, "Deduplication window not set"
-    assert 'global _sms_dedup_cache' in content, "Cache not declared as global"
+
+    assert "_sms_dedup_cache = {}" in content, "Deduplication cache not initialized"
+    assert "_sms_dedup_window = 15" in content, "Deduplication window not set"
+    assert "global _sms_dedup_cache" in content, "Cache not declared as global"
 
 
-if __name__ == '__main__':
-    pytest.main([__file__, '-v'])
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/addon-standalone/rootfs/usr/bin/gsm_sms_service.py
+++ b/addon-standalone/rootfs/usr/bin/gsm_sms_service.py
@@ -7,17 +7,17 @@ issue. SMS reception will need to be implemented via unsolicited +CMTI
 notifications in a future update. SMS sending functionality works fine.
 """
 
+from datetime import datetime
+from http.server import BaseHTTPRequestHandler, HTTPServer
 import json
 import logging
 import os
 import sys
+from threading import Lock, Thread
 import time
-from datetime import datetime
-from threading import Thread, Lock
-from http.server import HTTPServer, BaseHTTPRequestHandler
 
-import serial  # type: ignore[import-not-found]
 import requests
+import serial  # type: ignore[import-not-found]
 
 # Configure logging
 LOG_LEVELS = {
@@ -32,8 +32,8 @@ log_level = LOG_LEVELS.get(log_level_str, logging.INFO)
 
 logging.basicConfig(
     level=log_level,
-    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
-    handlers=[logging.StreamHandler(sys.stdout)]
+    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    handlers=[logging.StreamHandler(sys.stdout)],
 )
 
 _LOGGER = logging.getLogger("gsm_sms_service")
@@ -49,7 +49,7 @@ GSM7_ALPHABET = (
 
 class GSMModem:
     """Handle GSM modem communication via serial port."""
-    
+
     def __init__(self, device, baudrate=115200):
         """Initialize modem connection."""
         self.device = device
@@ -63,11 +63,11 @@ class GSMModem:
         self.prompt_received = False
         self.response_lines = []
         self.sms_list = []
-        self.last_sms_text = b''
+        self.last_sms_text = b""
         self.recording_sms = False
-        
+
         _LOGGER.info(f"GSM Modem initialized for device: {device}")
-    
+
     def open(self):
         """Open serial connection to modem."""
         try:
@@ -82,14 +82,14 @@ class GSMModem:
             self.serial.rtscts = False
             self.serial.dsrdtr = False
             self.serial.timeout = 1
-            
+
             self.serial.open()
-            
+
             if self.serial.is_open:
                 self.opened = True
                 self.serial.flush()
                 _LOGGER.info(f"Device opened successfully on {self.device}")
-                
+
                 # Start read thread
                 self.read_thread = Thread(target=self._read_loop, daemon=True)
                 self.read_thread.start()
@@ -97,130 +97,130 @@ class GSMModem:
             else:
                 _LOGGER.error(f"Device failed to open: {self.device}")
                 return False
-                
+
         except Exception as e:
             _LOGGER.error(f"Exception opening device {self.device}: {e}")
             return False
-    
+
     def close(self):
         """Close serial connection."""
         if self.serial and self.serial.is_open:
             _LOGGER.info("Closing GSM device")
             self.serial.close()
             self.opened = False
-    
+
     def _read_loop(self):
         """Background thread to read from serial port."""
-        frame = b''
-        
+        frame = b""
+
         while self.opened and self.serial and self.serial.is_open:
             try:
                 if self.serial.in_waiting >= 1:
                     data = self.serial.read(1)
                     frame += data
-                    
+
                     # Check for prompt (> )
-                    if b'> ' in frame:
+                    if b"> " in frame:
                         self.ok_received = True
                         self.prompt_received = True
-                        frame = b''
-                    
+                        frame = b""
+
                     # Check for line ending
-                    elif b'\r\n' in frame:
-                        line = frame.decode('ascii', errors='ignore').strip()
-                        
+                    elif b"\r\n" in frame:
+                        line = frame.decode("ascii", errors="ignore").strip()
+
                         # Store non-empty response lines
-                        if line and line not in ['OK', 'ERROR']:
+                        if line and line not in ["OK", "ERROR"]:
                             self.response_lines.append(line)
-                        
-                        if 'OK' in line:
+
+                        if "OK" in line:
                             self.ok_received = True
                             if self.recording_sms:
                                 # Remove trailing CRLF from SMS text
-                                if self.last_sms_text.endswith(b'\r\n\r\n'):
+                                if self.last_sms_text.endswith(b"\r\n\r\n"):
                                     self.last_sms_text = self.last_sms_text[:-4]
                                 self.recording_sms = False
-                        
-                        elif '+CMGL:' in line:
+
+                        elif "+CMGL:" in line:
                             # SMS list entry
-                            parts = line.split(',')
+                            parts = line.split(",")
                             if len(parts) >= 3:
-                                msg_id = parts[0].split(':')[1].strip()
+                                msg_id = parts[0].split(":")[1].strip()
                                 status = parts[1].strip().strip('"')
                                 number = parts[2].strip().strip('"')
-                                self.sms_list.append({
-                                    'Id': msg_id,
-                                    'Number': number,
-                                    'Status': status
-                                })
-                        
-                        elif '+CMGR:' in line:
+                                self.sms_list.append(
+                                    {"Id": msg_id, "Number": number, "Status": status}
+                                )
+
+                        elif "+CMGR:" in line:
                             # Start recording SMS - save header line
                             self.recording_sms = True
-                            self.last_sms_text = (line + '\n').encode('utf-8')
-                        
-                        elif '+CME ERROR:' in line or 'ERROR' in line:
+                            self.last_sms_text = (line + "\n").encode("utf-8")
+
+                        elif "+CME ERROR:" in line or "ERROR" in line:
                             _LOGGER.debug(f"Modem error: {line}")
                             self.ok_received = True
-                        
-                        elif '+CMTI:' in line:
+
+                        elif "+CMTI:" in line:
                             # Incoming SMS notification: +CMTI: "SM",5
                             try:
-                                parts = line.split(',')
+                                parts = line.split(",")
                                 if len(parts) >= 2:
                                     index = int(parts[1].strip())
                                     self.pending_sms.append(index)
-                                    _LOGGER.info(f"Incoming SMS notification at index {index}")
+                                    _LOGGER.info(
+                                        f"Incoming SMS notification at index {index}"
+                                    )
                             except Exception as e:
                                 _LOGGER.error(f"Error parsing +CMTI: {e}")
-                        
+
                         elif self.recording_sms:
                             # This is SMS text content
                             self.last_sms_text += frame
-                        
-                        frame = b''
-                
+
+                        frame = b""
+
                 else:
                     time.sleep(0.001)
-                    
+
             except Exception as e:
                 _LOGGER.error(f"Error in read loop: {e}")
                 time.sleep(0.1)
-    
+
     def write_command(self, command, timeout=5):
         """Write AT command and wait for OK."""
         if not self.opened or not self.serial:
             return False
-        
+
         self.ok_received = False
-        cmd = command.encode('ascii') + b'\r'
-        
+        cmd = command.encode("ascii") + b"\r"
+
         _LOGGER.debug(f"Sending: {command}")
         try:
             self.serial.write(cmd)
         except Exception as e:
             _LOGGER.error(f"Failed to write command: {e}")
             return False
-        
+
         # Wait for OK response
         start = time.time()
         while not self.ok_received and (time.time() - start) < timeout:
             time.sleep(0.01)
-        
+
         if not self.ok_received:
             _LOGGER.warning(f"Command timeout: {command}")
-        
+
         return self.ok_received
-    
+
     def write_data(self, data):
         """Write raw data to serial port."""
         if self.opened and self.serial:
             self.serial.write(data)
-    
+
     def init_modem(self):
         """Initialize modem with AT commands."""
         _LOGGER.info("Initializing GSM modem...")
-        
+
         # Basic commands only - don't configure SMS storage which might hang
         commands = [
             ("ATZ", "Reset modem", 3),
@@ -229,15 +229,15 @@ class GSMModem:
             ("AT+CNMI=2,1,0,0,0", "Enable SMS notifications", 2),
             ("AT+CREG=2", "Enable network registration with location info", 2),
         ]
-        
+
         for cmd, desc, timeout in commands:
             _LOGGER.debug(f"{desc}: {cmd}")
             if not self.write_command(cmd, timeout=timeout):
                 _LOGGER.warning(f"Command may have failed: {cmd}")
             time.sleep(0.2)
-        
+
         _LOGGER.info("Modem initialization complete")
-    
+
     def get_imei(self):
         """Get IMEI number."""
         try:
@@ -250,7 +250,7 @@ class GSMModem:
         except Exception as e:
             _LOGGER.debug(f"Error getting IMEI: {e}")
         return None
-    
+
     def get_manufacturer(self):
         """Get manufacturer name."""
         try:
@@ -258,12 +258,12 @@ class GSMModem:
             if self.write_command("AT+CGMI", timeout=2):
                 time.sleep(0.3)
                 for line in self.response_lines:
-                    if line.strip() and line.strip() not in ['OK', 'ERROR']:
+                    if line.strip() and line.strip() not in ["OK", "ERROR"]:
                         return line.strip()
         except Exception as e:
             _LOGGER.debug(f"Error getting manufacturer: {e}")
         return None
-    
+
     def get_model(self):
         """Get model name."""
         try:
@@ -271,12 +271,12 @@ class GSMModem:
             if self.write_command("AT+CGMM", timeout=2):
                 time.sleep(0.3)
                 for line in self.response_lines:
-                    if line.strip() and line.strip() not in ['OK', 'ERROR']:
+                    if line.strip() and line.strip() not in ["OK", "ERROR"]:
                         return line.strip()
         except Exception as e:
             _LOGGER.debug(f"Error getting model: {e}")
         return None
-    
+
     def get_firmware(self):
         """Get firmware version."""
         try:
@@ -284,12 +284,12 @@ class GSMModem:
             if self.write_command("AT+CGMR", timeout=2):
                 time.sleep(0.3)
                 for line in self.response_lines:
-                    if line.strip() and line.strip() not in ['OK', 'ERROR']:
+                    if line.strip() and line.strip() not in ["OK", "ERROR"]:
                         return line.strip()
         except Exception as e:
             _LOGGER.debug(f"Error getting firmware: {e}")
         return None
-    
+
     def get_signal_strength(self):
         """Get signal strength - returns rssi and ber."""
         try:
@@ -298,16 +298,16 @@ class GSMModem:
                 time.sleep(0.3)
                 # Response format: +CSQ: <rssi>,<ber>
                 for line in self.response_lines:
-                    if '+CSQ:' in line:
-                        parts = line.split(':')[1].strip().split(',')
+                    if "+CSQ:" in line:
+                        parts = line.split(":")[1].strip().split(",")
                         if len(parts) >= 2:
                             rssi = int(parts[0].strip())
                             ber = int(parts[1].strip())
-                            return {'rssi': rssi, 'ber': ber}
+                            return {"rssi": rssi, "ber": ber}
         except Exception as e:
             _LOGGER.debug(f"Error getting signal strength: {e}")
         return None
-    
+
     def get_network_info(self):
         """Get network operator name."""
         try:
@@ -316,26 +316,21 @@ class GSMModem:
                 time.sleep(0.3)
                 # Response format: +COPS: <mode>,<format>,"<oper>",<act>
                 for line in self.response_lines:
-                    if '+COPS:' in line:
-                        parts = line.split(',')
+                    if "+COPS:" in line:
+                        parts = line.split(",")
                         if len(parts) >= 3:
                             operator = parts[2].strip().strip('"')
-                            return {'operator': operator}
+                            return {"operator": operator}
         except Exception as e:
             _LOGGER.debug(f"Error getting network info: {e}")
         return None
-    
+
     def get_network_registration(self):
         """Get network registration status including CID and LAC.
         Returns dict with State, NetworkCode, CID, LAC.
         """
-        result = {
-            'State': 'Unknown',
-            'NetworkCode': None,
-            'CID': None,
-            'LAC': None
-        }
-        
+        result = {"State": "Unknown", "NetworkCode": None, "CID": None, "LAC": None}
+
         try:
             # Get registration status with location info
             # AT+CREG=2 enables network registration and location info URC
@@ -346,28 +341,28 @@ class GSMModem:
                 # Response format: +CREG: <n>,<stat>[,<lac>,<ci>[,<AcT>]]
                 # stat: 0=not registered, 1=registered home, 2=searching, 3=denied, 4=unknown, 5=registered roaming
                 for line in self.response_lines:
-                    if '+CREG:' in line:
-                        parts = line.split(':')[1].strip().split(',')
+                    if "+CREG:" in line:
+                        parts = line.split(":")[1].strip().split(",")
                         if len(parts) >= 2:
                             stat = int(parts[1].strip())
                             state_map = {
-                                0: 'Not Registered',
-                                1: 'Registered (Home)',
-                                2: 'Searching',
-                                3: 'Registration Denied',
-                                4: 'Unknown',
-                                5: 'Registered (Roaming)'
+                                0: "Not Registered",
+                                1: "Registered (Home)",
+                                2: "Searching",
+                                3: "Registration Denied",
+                                4: "Unknown",
+                                5: "Registered (Roaming)",
                             }
-                            result['State'] = state_map.get(stat, 'Unknown')
-                            
+                            result["State"] = state_map.get(stat, "Unknown")
+
                             # LAC and CID are in hex format
                             if len(parts) >= 4:
                                 try:
-                                    result['LAC'] = int(parts[2].strip().strip('"'), 16)
-                                    result['CID'] = int(parts[3].strip().strip('"'), 16)
+                                    result["LAC"] = int(parts[2].strip().strip('"'), 16)
+                                    result["CID"] = int(parts[3].strip().strip('"'), 16)
                                 except (ValueError, IndexError):
                                     pass
-            
+
             # Get network code (MCC+MNC) in numeric format
             self.response_lines = []
             if self.write_command("AT+COPS?", timeout=2):
@@ -375,136 +370,138 @@ class GSMModem:
                 # Response format: +COPS: <mode>,<format>,"<oper>",<act>
                 # We need format=2 for numeric code
                 for line in self.response_lines:
-                    if '+COPS:' in line:
-                        parts = line.split(',')
+                    if "+COPS:" in line:
+                        parts = line.split(",")
                         if len(parts) >= 3:
                             # Check if already in numeric format
                             network_code = parts[2].strip().strip('"')
                             if network_code.isdigit():
-                                result['NetworkCode'] = network_code
-            
+                                result["NetworkCode"] = network_code
+
             # If we didn't get numeric code, try to query it explicitly
-            if not result['NetworkCode']:
+            if not result["NetworkCode"]:
                 self.response_lines = []
-                if self.write_command("AT+COPS=3,2", timeout=2):  # Set format to numeric
+                if self.write_command(
+                    "AT+COPS=3,2", timeout=2
+                ):  # Set format to numeric
                     time.sleep(0.3)
                     self.response_lines = []
                     if self.write_command("AT+COPS?", timeout=2):
                         time.sleep(0.3)
                         for line in self.response_lines:
-                            if '+COPS:' in line:
-                                parts = line.split(',')
+                            if "+COPS:" in line:
+                                parts = line.split(",")
                                 if len(parts) >= 3:
-                                    result['NetworkCode'] = parts[2].strip().strip('"')
+                                    result["NetworkCode"] = parts[2].strip().strip('"')
                     # Restore format to alphanumeric
                     self.write_command("AT+COPS=3,0", timeout=2)
-                    
+
         except Exception as e:
             _LOGGER.debug(f"Error getting network registration: {e}")
-        
+
         return result
-    
+
     def send_sms(self, number, message):
         """Send SMS message."""
         _LOGGER.info(f"Sending SMS to {number}")
-        
+
         # Set up send command
         self.prompt_received = False
         if not self.write_command(f'AT+CMGS="{number}"'):
             _LOGGER.error("Failed to start SMS send")
             return False
-        
+
         # Wait for prompt
         timeout = 10
         start = time.time()
         while not self.prompt_received and (time.time() - start) < timeout:
             time.sleep(0.01)
-        
+
         if not self.prompt_received:
             _LOGGER.error("Did not receive prompt for SMS text")
             return False
-        
+
         # Send message text with Ctrl-Z terminator
         _LOGGER.debug(f"Sending message text: {message}")
-        message_data = message.encode('ascii', errors='ignore') + b'\x1A'
+        message_data = message.encode("ascii", errors="ignore") + b"\x1a"
         self.write_data(message_data)
-        
+
         # Wait for OK
         timeout = 30
         start = time.time()
         self.ok_received = False
         while not self.ok_received and (time.time() - start) < timeout:
             time.sleep(0.01)
-        
+
         if self.ok_received:
             _LOGGER.info("SMS sent successfully")
             return True
         else:
             _LOGGER.error("SMS send timeout")
             return False
-    
+
     def read_sms_by_index(self, index):
         """Read a specific SMS by index."""
         try:
             _LOGGER.info(f"Reading SMS at index {index}")
-            
+
             # Read the SMS
             cmd = f"AT+CMGR={index}"
             self.recording_sms = False
-            self.last_sms_text = b''
-            
+            self.last_sms_text = b""
+
             if not self.write_command(cmd, timeout=5):
-                _LOGGER.warning(f"Failed to read SMS at index {index} - command timeout")
+                _LOGGER.warning(
+                    f"Failed to read SMS at index {index} - command timeout"
+                )
                 return None
-            
+
             # Give time for response
             time.sleep(0.5)
-            
-            _LOGGER.debug(f"SMS response received, length: {len(self.last_sms_text)} bytes")
-            
+
+            _LOGGER.debug(
+                f"SMS response received, length: {len(self.last_sms_text)} bytes"
+            )
+
             # Parse response - format is:
             # +CMGR: "REC UNREAD","+1234567890","","24/11/18,12:34:56+00"
             # Message text
-            
+
             if self.last_sms_text:
-                response_text = self.last_sms_text.decode('utf-8', errors='ignore')
+                response_text = self.last_sms_text.decode("utf-8", errors="ignore")
                 _LOGGER.debug(f"SMS response text: {repr(response_text)}")
-                lines = response_text.split('\n')
+                lines = response_text.split("\n")
                 _LOGGER.debug(f"SMS response has {len(lines)} lines")
-                
-                if len(lines) >= 2 and '+CMGR:' in lines[0]:
+
+                if len(lines) >= 2 and "+CMGR:" in lines[0]:
                     _LOGGER.debug(f"Found +CMGR header: {lines[0]}")
                     # Parse header
-                    header_parts = lines[0].split(',')
+                    header_parts = lines[0].split(",")
                     if len(header_parts) >= 2:
                         # Extract phone number (remove quotes)
                         number = header_parts[1].strip().strip('"')
                         # Message text is on subsequent lines
-                        message = '\n'.join(lines[1:]).strip()
-                        
+                        message = "\n".join(lines[1:]).strip()
+
                         # Delete the message
                         self.write_command(f"AT+CMGD={index}", timeout=2)
-                        
-                        return {
-                            'number': number,
-                            'message': message,
-                            'index': index
-                        }
+
+                        return {"number": number, "message": message, "index": index}
                 else:
                     _LOGGER.warning(f"SMS response format unexpected: {lines}")
             else:
                 _LOGGER.warning(f"No SMS text captured for index {index}")
-            
+
             return None
-            
+
         except Exception as e:
             _LOGGER.error(f"Error reading SMS at index {index}: {e}", exc_info=True)
             return None
-    
+
     def read_sms(self):
         """Read all SMS messages - simplified to avoid modem hangs."""
         _LOGGER.debug("Checking for SMS messages")
-        
+
         # Skip SMS reading for now to prevent modem crashes
         # This is a known issue with some modems where AT+CMGL hangs
         # We'll implement SMS reception via unsolicited +CMTI notifications instead
@@ -513,26 +510,26 @@ class GSMModem:
 
 class SMSRequestHandler(BaseHTTPRequestHandler):
     """HTTP request handler for SMS sending."""
-    
+
     service = None  # Will be set to the GSMSMSService instance
-    
+
     def do_POST(self):
         """Handle POST requests to send SMS."""
-        if self.path == '/send_sms':
+        if self.path == "/send_sms":
             try:
-                content_length = int(self.headers['Content-Length'])
+                content_length = int(self.headers["Content-Length"])
                 post_data = self.rfile.read(content_length)
-                data = json.loads(post_data.decode('utf-8'))
-                
-                number = data.get('number')
-                message = data.get('message')
-                
+                data = json.loads(post_data.decode("utf-8"))
+
+                number = data.get("number")
+                message = data.get("message")
+
                 if not number or not message:
                     self.send_response(400)
                     self.end_headers()
                     self.wfile.write(b'{"error": "Missing number or message"}')
                     return
-                
+
                 _LOGGER.info(f"HTTP API: Received SMS request to {number}")
                 if self.service and self.service.modem:
                     self.service.send_sms_message(number, message)
@@ -543,7 +540,7 @@ class SMSRequestHandler(BaseHTTPRequestHandler):
                     self.send_response(503)
                     self.end_headers()
                     self.wfile.write(b'{"error": "Modem not ready"}')
-                    
+
             except Exception as e:
                 _LOGGER.error(f"HTTP API error: {e}", exc_info=True)
                 self.send_response(500)
@@ -552,7 +549,7 @@ class SMSRequestHandler(BaseHTTPRequestHandler):
         else:
             self.send_response(404)
             self.end_headers()
-    
+
     def log_message(self, format, *args):
         """Suppress default HTTP logging."""
         pass
@@ -560,7 +557,7 @@ class SMSRequestHandler(BaseHTTPRequestHandler):
 
 class GSMSMSService:
     """Service that manages GSM SMS operations and Home Assistant integration."""
-    
+
     def __init__(self, device_path, baud_speed=115200, scan_interval=30):
         """Initialize the GSM SMS service."""
         self.device_path = device_path
@@ -570,64 +567,71 @@ class GSMSMSService:
         self.modem = None
         self.connected = False
         self.signal_strength = None
-        
+
         # Device information
         self.imei = None
         self.manufacturer = None
         self.model = None
         self.firmware = None
-        
+
         # Home Assistant API configuration
         self.ha_url = "http://supervisor/core/api"
-        self.ha_token = os.environ.get('SUPERVISOR_TOKEN', '')
+        self.ha_token = os.environ.get("SUPERVISOR_TOKEN", "")
         self.ha_headers = {
-            'Authorization': f'Bearer {self.ha_token}',
-            'Content-Type': 'application/json'
+            "Authorization": f"Bearer {self.ha_token}",
+            "Content-Type": "application/json",
         }
         self.headers = self.ha_headers  # Alias for compatibility
-        
+
         # Service registration status
         self.service_registered = False
-        
+
         # HTTP server for API
         self.http_server = None
         self.http_thread = None
-        
-        _LOGGER.info(f"Initialized with device: {self.device_path}, baud: {self.baud_speed}")
+
+        _LOGGER.info(
+            f"Initialized with device: {self.device_path}, baud: {self.baud_speed}"
+        )
 
     def connect(self):
         """Connect to the GSM modem."""
         try:
             self.modem = GSMModem(self.device, self.baud_speed)
-            
+
             if not self.modem.open():
                 raise Exception("Failed to open modem")
-            
+
             # Initialize modem
             self.modem.init_modem()
-            
+
             # Get device information
             _LOGGER.info("Getting device information...")
             self.imei = self.modem.get_imei()
             self.manufacturer = self.modem.get_manufacturer()
             self.model = self.modem.get_model()
             self.firmware = self.modem.get_firmware()
-            
-            _LOGGER.info(f"Device Info - IMEI: {self.imei}, Manufacturer: {self.manufacturer}, Model: {self.model}, Firmware: {self.firmware}")
-            
+
+            _LOGGER.info(
+                f"Device Info - IMEI: {self.imei}, Manufacturer: {self.manufacturer}, Model: {self.model}, Firmware: {self.firmware}"
+            )
+
             # Get signal strength
             self.signal_strength = self.modem.get_signal_strength()
-            
+
             self.connected = True
             _LOGGER.info("Successfully connected to modem")
-            
+
             # Update HA sensor
-            self.update_sensor("connected", {
-                "signal_strength": self.signal_strength,
-            })
-            
+            self.update_sensor(
+                "connected",
+                {
+                    "signal_strength": self.signal_strength,
+                },
+            )
+
             return True
-            
+
         except Exception as e:
             _LOGGER.error(f"Failed to connect to modem: {e}")
             self.connected = False
@@ -646,14 +650,14 @@ class GSMSMSService:
         if rssi == 99:
             return None  # Unknown
         return -113 + (rssi * 2)
-    
+
     def rssi_to_percent(self, rssi):
         """Convert RSSI to percentage."""
         if rssi == 99:
             return None  # Unknown
         # RSSI ranges from 0 to 31
         return round((rssi / 31) * 100)
-    
+
     def ber_to_percent(self, ber):
         """Convert BER to percentage.
         Note: BER is RXQUAL value (0-7) where lower is better.
@@ -670,24 +674,39 @@ class GSMSMSService:
         # Return the raw RXQUAL value (0-7) or 99 for unknown
         # The "percentage" unit in HACS is somewhat misleading - it's actually just the RXQUAL index
         return ber
-    
-    def create_sensor(self, entity_id, state, attributes=None, device_class=None, unit=None, icon=None, friendly_name=None):
+
+    def create_sensor(
+        self,
+        entity_id,
+        state,
+        attributes=None,
+        device_class=None,
+        unit=None,
+        icon=None,
+        friendly_name=None,
+    ):
         """Create or update a sensor entity."""
         try:
             data = {
                 "state": state,
                 "attributes": attributes or {},
             }
-            
+
             # Add unique_id based on entity_id for UI management
             # Extract sensor key from entity_id (e.g., "signal_strength" from "sensor.gsm_123_signal_strength")
-            sensor_key = entity_id.split('.')[-1]
-            data["attributes"]["unique_id"] = f"gsm_{self.imei}_{sensor_key.replace(f'{self.imei}_', '')}" if self.imei else sensor_key
-            
+            sensor_key = entity_id.split(".")[-1]
+            data["attributes"]["unique_id"] = (
+                f"gsm_{self.imei}_{sensor_key.replace(f'{self.imei}_', '')}"
+                if self.imei
+                else sensor_key
+            )
+
             # Add friendly name with common prefix for easy identification
             if friendly_name:
-                data["attributes"]["friendly_name"] = f"Legacy GSM Modem Add-on {friendly_name}"
-            
+                data["attributes"][
+                    "friendly_name"
+                ] = f"Legacy GSM Modem Add-on {friendly_name}"
+
             # Add device info if we have IMEI
             if self.imei:
                 data["attributes"]["device"] = {
@@ -695,9 +714,9 @@ class GSMSMSService:
                     "name": "Legacy GSM Modem Add-on",
                     "manufacturer": self.manufacturer,
                     "model": self.model,
-                    "sw_version": self.firmware
+                    "sw_version": self.firmware,
                 }
-            
+
             # Add device class and unit if provided
             if device_class:
                 data["attributes"]["device_class"] = device_class
@@ -705,31 +724,33 @@ class GSMSMSService:
                 data["attributes"]["unit_of_measurement"] = unit
             if icon:
                 data["attributes"]["icon"] = icon
-            
+
             url = f"{self.ha_url}/states/{entity_id}"
             response = requests.post(url, headers=self.headers, json=data, timeout=5)
-            
+
             if response.status_code not in [200, 201]:
-                _LOGGER.debug(f"Failed to update sensor {entity_id}: {response.status_code}")
-                
+                _LOGGER.debug(
+                    f"Failed to update sensor {entity_id}: {response.status_code}"
+                )
+
         except Exception as e:
             _LOGGER.debug(f"Could not update sensor {entity_id}: {e}")
-    
+
     def update_all_sensors(self):
         """Update all sensor entities."""
         if not self.connected or not self.modem:
             return
-        
+
         # Get current signal strength
         signal_data = self.modem.get_signal_strength()
         network_data = self.modem.get_network_info()
         network_reg = self.modem.get_network_registration()
-        
+
         # Signal strength sensors
         if signal_data:
-            rssi = signal_data.get('rssi', 99)
-            ber = signal_data.get('ber', 99)
-            
+            rssi = signal_data.get("rssi", 99)
+            ber = signal_data.get("ber", 99)
+
             # Signal strength in dBm (matches HACS SignalStrength)
             signal_dbm = self.rssi_to_dbm(rssi)
             if signal_dbm is not None:
@@ -740,9 +761,9 @@ class GSMSMSService:
                     device_class="signal_strength",
                     unit="dBm",
                     icon="mdi:signal",
-                    friendly_name="Signal Strength"
+                    friendly_name="Signal Strength",
                 )
-            
+
             # Signal percent (matches HACS SignalPercent)
             signal_percent = self.rssi_to_percent(rssi)
             if signal_percent is not None:
@@ -752,9 +773,9 @@ class GSMSMSService:
                     {"rssi": rssi},
                     unit="%",
                     icon="mdi:signal",
-                    friendly_name="Signal Percent"
+                    friendly_name="Signal Percent",
                 )
-            
+
             # Bit error rate (matches HACS BitErrorRate)
             ber_percent = self.ber_to_percent(ber)
             # Show "unknown" instead of 99 to avoid confusion
@@ -762,27 +783,30 @@ class GSMSMSService:
             self.create_sensor(
                 f"sensor.gsm_{self.imei}_bit_error_rate",
                 ber_state,
-                {"raw_ber": ber, "note": "0-7 = RXQUAL (lower is better), 99 = not detectable"},
+                {
+                    "raw_ber": ber,
+                    "note": "0-7 = RXQUAL (lower is better), 99 = not detectable",
+                },
                 unit="%" if ber != 99 else None,
                 icon="mdi:alert-circle",
-                friendly_name="Bit Error Rate"
+                friendly_name="Bit Error Rate",
             )
-        
+
         # Network name (matches HACS NetworkName)
         if network_data:
-            operator = network_data.get('operator', 'Unknown')
+            operator = network_data.get("operator", "Unknown")
             self.create_sensor(
                 f"sensor.gsm_{self.imei}_network_name",
                 operator,
                 {},
                 icon="mdi:network",
-                friendly_name="Network Name"
+                friendly_name="Network Name",
             )
-        
+
         # Network registration sensors
         if network_reg:
             # State (matches HACS State)
-            state = network_reg.get('State', 'Unknown')
+            state = network_reg.get("State", "Unknown")
             self.create_sensor(
                 f"sensor.gsm_{self.imei}_state",
                 state,
@@ -790,45 +814,49 @@ class GSMSMSService:
                     "imei": self.imei,
                     "manufacturer": self.manufacturer,
                     "model": self.model,
-                    "firmware": self.firmware
+                    "firmware": self.firmware,
                 },
-                icon="mdi:cellphone-check" if "Registered" in state else "mdi:cellphone-off",
-                friendly_name="State"
+                icon=(
+                    "mdi:cellphone-check"
+                    if "Registered" in state
+                    else "mdi:cellphone-off"
+                ),
+                friendly_name="State",
             )
-            
+
             # Network code (matches HACS NetworkCode)
-            network_code = network_reg.get('NetworkCode')
+            network_code = network_reg.get("NetworkCode")
             if network_code:
                 self.create_sensor(
                     f"sensor.gsm_{self.imei}_network_code",
                     network_code,
                     {},
                     icon="mdi:network",
-                    friendly_name="Network Code"
+                    friendly_name="Network Code",
                 )
-            
+
             # CID - Cell ID (matches HACS CID)
-            cid = network_reg.get('CID')
+            cid = network_reg.get("CID")
             if cid is not None:
                 self.create_sensor(
                     f"sensor.gsm_{self.imei}_cid",
                     cid,
                     {},
                     icon="mdi:radio-tower",
-                    friendly_name="CID"
+                    friendly_name="CID",
                 )
-            
+
             # LAC - Location Area Code (matches HACS LAC)
-            lac = network_reg.get('LAC')
+            lac = network_reg.get("LAC")
             if lac is not None:
                 self.create_sensor(
                     f"sensor.gsm_{self.imei}_lac",
                     lac,
                     {},
                     icon="mdi:map-marker",
-                    friendly_name="LAC"
+                    friendly_name="LAC",
                 )
-    
+
     def update_sensor(self, state, attributes=None):
         """Update Home Assistant sensor (legacy single sensor)."""
         try:
@@ -836,14 +864,14 @@ class GSMSMSService:
                 "state": state,
                 "attributes": attributes or {},
             }
-            
+
             # Use state API - correct URL format
             url = f"{self.ha_url}/states/sensor.gsm_modem_status"
             response = requests.post(url, headers=self.headers, json=data, timeout=5)
-            
+
             if response.status_code not in [200, 201]:
                 _LOGGER.warning(f"Failed to update sensor: {response.status_code}")
-                
+
         except Exception as e:
             _LOGGER.debug(f"Could not update sensor: {e}")
 
@@ -851,11 +879,13 @@ class GSMSMSService:
         """Fire a Home Assistant event."""
         try:
             url = f"{self.ha_url}/events/{event_type}"
-            response = requests.post(url, headers=self.headers, json=event_data, timeout=5)
-            
+            response = requests.post(
+                url, headers=self.headers, json=event_data, timeout=5
+            )
+
             if response.status_code not in [200, 201]:
                 _LOGGER.warning(f"Failed to fire event: {response.status_code}")
-                
+
         except Exception as e:
             _LOGGER.debug(f"Could not fire event: {e}")
 
@@ -864,50 +894,59 @@ class GSMSMSService:
         if not self.connected or not self.modem:
             _LOGGER.error("Cannot send SMS - modem not connected")
             return False
-        
+
         try:
             result = self.modem.send_sms(number, message)
             if result:
                 # Fire success event
-                self.fire_event("legacy_gsm_sms_sent", {
-                    "recipient": number,
-                    "message": message,
-                    "timestamp": datetime.now().isoformat(),
-                    "status": "success"
-                })
+                self.fire_event(
+                    "legacy_gsm_sms_sent",
+                    {
+                        "recipient": number,
+                        "message": message,
+                        "timestamp": datetime.now().isoformat(),
+                        "status": "success",
+                    },
+                )
             return result
         except Exception as e:
             _LOGGER.error(f"Error sending SMS: {e}")
-            self.fire_event("legacy_gsm_sms_sent", {
-                "recipient": number,
-                "message": message,
-                "timestamp": datetime.now().isoformat(),
-                "status": "failed",
-                "error": str(e)
-            })
+            self.fire_event(
+                "legacy_gsm_sms_sent",
+                {
+                    "recipient": number,
+                    "message": message,
+                    "timestamp": datetime.now().isoformat(),
+                    "status": "failed",
+                    "error": str(e),
+                },
+            )
             return False
-    
+
     def check_sms(self):
         """Check for new SMS messages."""
         if not self.connected or not self.modem:
             return
-        
+
         try:
             messages = self.modem.read_sms()
-            
+
             for msg in messages:
                 _LOGGER.info(f"Received SMS from {msg['Number']}: {msg['Text']}")
-                
+
                 # Fire event
-                self.fire_event("legacy_gsm_sms_received", {
-                    "sender": msg['Number'],
-                    "message": msg['Text'],
-                    "timestamp": datetime.now().isoformat(),
-                })
-                
+                self.fire_event(
+                    "legacy_gsm_sms_received",
+                    {
+                        "sender": msg["Number"],
+                        "message": msg["Text"],
+                        "timestamp": datetime.now().isoformat(),
+                    },
+                )
+
         except Exception as e:
             _LOGGER.error(f"Error checking SMS: {e}")
-    
+
     def register_service(self):
         """Display service setup instructions."""
         try:
@@ -919,7 +958,9 @@ class GSMSMSService:
             _LOGGER.info("")
             _LOGGER.info("shell_command:")
             _LOGGER.info("  send_sms: >")
-            _LOGGER.info("    echo '{\"action\":\"send_sms\",\"number\":\"{{ number }}\",\"message\":\"{{ message }}\"}' > /share/gsm_sms_queue.json")
+            _LOGGER.info(
+                '    echo \'{"action":"send_sms","number":"{{ number }}","message":"{{ message }}"}\' > /share/gsm_sms_queue.json'
+            )
             _LOGGER.info("")
             _LOGGER.info("Then reload shell_command and use in automations:")
             _LOGGER.info("")
@@ -930,42 +971,44 @@ class GSMSMSService:
             _LOGGER.info("")
             _LOGGER.info("Note: /config/share is accessible as /share in the addon")
             _LOGGER.info("=" * 60)
-            
+
             self.service_registered = True
             return True
-                
+
         except Exception as e:
             _LOGGER.error(f"Error displaying instructions: {e}")
             return False
-    
+
     def check_for_events(self):
         """Check for SMS send requests via file queue."""
         # Use file-based queue as primary method since event polling doesn't work in addons
         self.check_queue_fallback()
-            
+
     def check_queue_fallback(self):
         """Fallback: Check file-based queue for SMS send requests."""
         # Use /share which is accessible from both HA and the addon
-        queue_file = '/share/gsm_sms_queue.json'
-        
+        queue_file = "/share/gsm_sms_queue.json"
+
         try:
             if os.path.exists(queue_file):
-                with open(queue_file, 'r') as f:
+                with open(queue_file, "r") as f:
                     command = json.load(f)
-                
+
                 # Remove the file immediately
                 os.remove(queue_file)
-                
-                if command.get('action') == 'send_sms':
-                    number = command.get('number')
-                    message = command.get('message')
-                    
+
+                if command.get("action") == "send_sms":
+                    number = command.get("number")
+                    message = command.get("message")
+
                     if number and message:
                         _LOGGER.info(f"Processing queued SMS send request to {number}")
                         self.send_sms_message(number, message)
                     else:
-                        _LOGGER.warning("Invalid SMS command - missing number or message")
-                        
+                        _LOGGER.warning(
+                            "Invalid SMS command - missing number or message"
+                        )
+
         except json.JSONDecodeError:
             _LOGGER.error(f"Invalid JSON in queue file")
             try:
@@ -979,8 +1022,10 @@ class GSMSMSService:
         """Start HTTP server for API endpoint."""
         try:
             SMSRequestHandler.service = self
-            self.http_server = HTTPServer(('0.0.0.0', 8099), SMSRequestHandler)
-            self.http_thread = Thread(target=self.http_server.serve_forever, daemon=True)
+            self.http_server = HTTPServer(("0.0.0.0", 8099), SMSRequestHandler)
+            self.http_thread = Thread(
+                target=self.http_server.serve_forever, daemon=True
+            )
             self.http_thread.start()
             _LOGGER.info("HTTP API server started on port 8099")
             _LOGGER.info("=" * 60)
@@ -994,69 +1039,75 @@ class GSMSMSService:
     def run(self):
         """Run the service main loop."""
         _LOGGER.info("GSM SMS Service starting...")
-        
+
         # Connect with retries
         max_retries = 5
         retry_count = 0
-        
+
         while retry_count < max_retries:
             if self.connect():
                 break
-            
+
             retry_count += 1
             if retry_count < max_retries:
-                _LOGGER.warning(f"Connection attempt {retry_count}/{max_retries} failed, retrying in 10 seconds...")
+                _LOGGER.warning(
+                    f"Connection attempt {retry_count}/{max_retries} failed, retrying in 10 seconds..."
+                )
                 time.sleep(10)
-        
+
         if not self.connected:
             _LOGGER.error("Failed to connect to modem after all retries. Exiting.")
             return
-        
+
         # Create initial sensors
         _LOGGER.info("Creating sensor entities...")
         self.update_all_sensors()
-        
+
         # Start HTTP API server
         self.start_http_server()
-        
+
         # Main loop
-        _LOGGER.info(f"Entering main loop (scanning every {self.scan_interval} seconds)")
-        
+        _LOGGER.info(
+            f"Entering main loop (scanning every {self.scan_interval} seconds)"
+        )
+
         try:
             last_check = 0
             while True:
                 current_time = time.time()
-                
+
                 # Check for events and queue (fast check every second)
                 self.check_for_events()
-                
+
                 # Process incoming SMS notifications from +CMTI
                 while self.modem.pending_sms:
                     sms_index = self.modem.pending_sms.pop(0)
                     _LOGGER.info(f"Processing incoming SMS at index {sms_index}")
                     sms_data = self.modem.read_sms_by_index(sms_index)
                     if sms_data:
-                        _LOGGER.info(f"Received SMS from {sms_data['number']}: {sms_data['message']}")
+                        _LOGGER.info(
+                            f"Received SMS from {sms_data['number']}: {sms_data['message']}"
+                        )
                         # Fire Home Assistant event
                         event_data = {
-                            'phone': sms_data['number'],
-                            'message': sms_data['message'],
-                            'date': datetime.now().isoformat()
+                            "phone": sms_data["number"],
+                            "message": sms_data["message"],
+                            "date": datetime.now().isoformat(),
                         }
-                        self.fire_event('legacy_gsm_sms_received', event_data)
-                
+                        self.fire_event("legacy_gsm_sms_received", event_data)
+
                 # Check for incoming SMS (slower, based on scan_interval)
                 if current_time - last_check >= self.scan_interval:
                     self.check_sms()
-                    
+
                     # Update all sensors
                     self.update_all_sensors()
-                    
+
                     last_check = current_time
-                
+
                 # Sleep briefly
                 time.sleep(1)
-                
+
         except KeyboardInterrupt:
             _LOGGER.info("Service interrupted by user")
         except Exception as e:
@@ -1068,10 +1119,16 @@ class GSMSMSService:
 if __name__ == "__main__":
     # Get configuration from environment variables
     device = os.environ.get("DEVICE", "/dev/ttyUSB0")
-    baud_speed = int(os.environ.get("BAUD_SPEED", "115200")) if os.environ.get("BAUD_SPEED", "0") != "0" else 115200
+    baud_speed = (
+        int(os.environ.get("BAUD_SPEED", "115200"))
+        if os.environ.get("BAUD_SPEED", "0") != "0"
+        else 115200
+    )
     scan_interval = int(os.environ.get("SCAN_INTERVAL", "30"))
-    
-    _LOGGER.info(f"Starting GSM SMS Service with device={device}, baud={baud_speed}, interval={scan_interval}")
-    
+
+    _LOGGER.info(
+        f"Starting GSM SMS Service with device={device}, baud={baud_speed}, interval={scan_interval}"
+    )
+
     service = GSMSMSService(device, baud_speed, scan_interval)
     service.run()

--- a/addon-test-current/mqtt_publisher.py
+++ b/addon-test-current/mqtt_publisher.py
@@ -10,25 +10,27 @@ Credits:
 Licensed under Apache License 2.0
 """
 
+import concurrent.futures
 import json
-import time
 import logging
-import threading
 import os
 import sys
-import requests
-from typing import Optional, Dict, Any
+import threading
+import time
+from typing import Any, Dict, Optional
+
 import paho.mqtt.client as mqtt
-import concurrent.futures
+import requests
+
 from network_codes import get_network_name
 
 logger = logging.getLogger(__name__)
 
 # SMS counter persistence file
-SMS_COUNTER_FILE = '/data/sms_counter.json'
+SMS_COUNTER_FILE = "/data/sms_counter.json"
 
 # Pending SMS queue persistence file
-SMS_QUEUE_FILE = '/data/pending_sms.json'
+SMS_QUEUE_FILE = "/data/pending_sms.json"
 
 # Default queue expiry time (1 hour)
 SMS_QUEUE_EXPIRY_SECONDS = 3600
@@ -37,7 +39,11 @@ SMS_QUEUE_EXPIRY_SECONDS = 3600
 class SMSQueue:
     """Manages pending SMS queue with persistence for retry after modem recovery"""
 
-    def __init__(self, queue_file: str = SMS_QUEUE_FILE, expiry_seconds: int = SMS_QUEUE_EXPIRY_SECONDS):
+    def __init__(
+        self,
+        queue_file: str = SMS_QUEUE_FILE,
+        expiry_seconds: int = SMS_QUEUE_EXPIRY_SECONDS,
+    ):
         self.queue_file = queue_file
         self.expiry_seconds = expiry_seconds
         self.pending = []
@@ -48,13 +54,15 @@ class SMSQueue:
         """Load pending SMS queue from JSON file"""
         try:
             if os.path.exists(self.queue_file):
-                with open(self.queue_file, 'r') as f:
+                with open(self.queue_file, "r") as f:
                     data = json.load(f)
-                    self.pending = data.get('pending', [])
+                    self.pending = data.get("pending", [])
                     # Clear expired messages on load
                     self._clear_expired()
                     if self.pending:
-                        logger.info(f"📥 Loaded {len(self.pending)} pending SMS from queue")
+                        logger.info(
+                            f"📥 Loaded {len(self.pending)} pending SMS from queue"
+                        )
                     else:
                         logger.info("📥 SMS queue is empty")
             else:
@@ -69,8 +77,8 @@ class SMSQueue:
             # Ensure /data directory exists
             os.makedirs(os.path.dirname(self.queue_file), exist_ok=True)
 
-            data = {'pending': self.pending}
-            with open(self.queue_file, 'w') as f:
+            data = {"pending": self.pending}
+            with open(self.queue_file, "w") as f:
                 json.dump(data, f, indent=2)
             logger.debug(f"📥 Saved SMS queue: {len(self.pending)} pending")
         except Exception as e:
@@ -80,12 +88,13 @@ class SMSQueue:
         """Remove expired messages from queue"""
         if not self.pending:
             return
-        
+
         current_time = time.time()
         before_count = len(self.pending)
         self.pending = [
-            msg for msg in self.pending
-            if current_time - msg.get('queued_at', 0) < self.expiry_seconds
+            msg
+            for msg in self.pending
+            if current_time - msg.get("queued_at", 0) < self.expiry_seconds
         ]
         expired_count = before_count - len(self.pending)
         if expired_count > 0:
@@ -97,32 +106,38 @@ class SMSQueue:
         with self._lock:
             # Check if same message already queued (prevent duplicates)
             for msg in self.pending:
-                if msg.get('number') == number and msg.get('text') == text:
-                    logger.debug(f"📥 SMS already queued for {number}, skipping duplicate")
+                if msg.get("number") == number and msg.get("text") == text:
+                    logger.debug(
+                        f"📥 SMS already queued for {number}, skipping duplicate"
+                    )
                     return False
-            
+
             message = {
-                'number': number,
-                'text': text,
-                'smsc': smsc,
-                'queued_at': time.time(),
-                'attempts': 0
+                "number": number,
+                "text": text,
+                "smsc": smsc,
+                "queued_at": time.time(),
+                "attempts": 0,
             }
             self.pending.append(message)
             self._save()
-            logger.info(f"📥 SMS queued for retry: {number} "
-                       f"({len(self.pending)} total in queue)")
+            logger.info(
+                f"📥 SMS queued for retry: {number} "
+                f"({len(self.pending)} total in queue)"
+            )
             return True
 
     def remove(self, number: str, text: str) -> bool:
         """Remove SMS from queue (after successful send) (thread-safe)"""
         with self._lock:
             for i, msg in enumerate(self.pending):
-                if msg.get('number') == number and msg.get('text') == text:
+                if msg.get("number") == number and msg.get("text") == text:
                     self.pending.pop(i)
                     self._save()
-                    logger.info(f"📥 SMS removed from queue: {number} "
-                               f"({len(self.pending)} remaining)")
+                    logger.info(
+                        f"📥 SMS removed from queue: {number} "
+                        f"({len(self.pending)} remaining)"
+                    )
                     return True
             return False
 
@@ -130,10 +145,10 @@ class SMSQueue:
         """Increment attempt counter for a message (thread-safe)"""
         with self._lock:
             for msg in self.pending:
-                if msg.get('number') == number and msg.get('text') == text:
-                    msg['attempts'] = msg.get('attempts', 0) + 1
+                if msg.get("number") == number and msg.get("text") == text:
+                    msg["attempts"] = msg.get("attempts", 0) + 1
                     self._save()
-                    return msg['attempts']
+                    return msg["attempts"]
             return 0
 
     def get_pending(self) -> list:
@@ -158,10 +173,11 @@ class SMSQueue:
 def detect_unicode_needed(text: str) -> bool:
     """Detect if text contains non-ASCII characters requiring Unicode encoding"""
     try:
-        text.encode('ascii')
+        text.encode("ascii")
         return False
     except UnicodeEncodeError:
         return True
+
 
 class SMSCounter:
     """Tracks sent and received SMS counts with persistent storage (thread-safe)"""
@@ -177,11 +193,13 @@ class SMSCounter:
         """Load counter from JSON file"""
         try:
             if os.path.exists(self.counter_file):
-                with open(self.counter_file, 'r') as f:
+                with open(self.counter_file, "r") as f:
                     data = json.load(f)
-                    self.sent_count = data.get('sent_count', 0)
-                    self.received_count = data.get('received_count', 0)
-                    logger.info(f"📊 Loaded SMS counters from file: sent={self.sent_count}, received={self.received_count}")
+                    self.sent_count = data.get("sent_count", 0)
+                    self.received_count = data.get("received_count", 0)
+                    logger.info(
+                        f"📊 Loaded SMS counters from file: sent={self.sent_count}, received={self.received_count}"
+                    )
             else:
                 logger.info("📊 SMS counter file not found, starting from 0")
         except Exception as e:
@@ -196,12 +214,14 @@ class SMSCounter:
             os.makedirs(os.path.dirname(self.counter_file), exist_ok=True)
 
             data = {
-                'sent_count': self.sent_count,
-                'received_count': self.received_count
+                "sent_count": self.sent_count,
+                "received_count": self.received_count,
             }
-            with open(self.counter_file, 'w') as f:
+            with open(self.counter_file, "w") as f:
                 json.dump(data, f)
-            logger.debug(f"📊 Saved SMS counters to file: sent={self.sent_count}, received={self.received_count}")
+            logger.debug(
+                f"📊 Saved SMS counters to file: sent={self.sent_count}, received={self.received_count}"
+            )
         except Exception as e:
             logger.error(f"Error saving SMS counter: {e}")
 
@@ -258,10 +278,11 @@ class SMSCounter:
         with self._lock:
             return self.sent_count
 
+
 class SMSHistory:
     """Tracks received SMS history with persistent storage (thread-safe)"""
 
-    def __init__(self, history_file='/data/sms_history.json', max_messages=10):
+    def __init__(self, history_file="/data/sms_history.json", max_messages=10):
         self.history_file = history_file
         self.max_messages = max_messages
         self.messages = []
@@ -272,11 +293,11 @@ class SMSHistory:
         """Load history from JSON file"""
         try:
             if os.path.exists(self.history_file):
-                with open(self.history_file, 'r') as f:
+                with open(self.history_file, "r") as f:
                     data = json.load(f)
-                    self.messages = data.get('messages', [])
+                    self.messages = data.get("messages", [])
                     # Keep only max_messages
-                    self.messages = self.messages[-self.max_messages:]
+                    self.messages = self.messages[-self.max_messages :]
                     logger.info(f"📜 Loaded SMS history: {len(self.messages)} messages")
             else:
                 logger.info("📜 SMS history file not found, starting fresh")
@@ -290,8 +311,8 @@ class SMSHistory:
             # Ensure /data directory exists
             os.makedirs(os.path.dirname(self.history_file), exist_ok=True)
 
-            data = {'messages': self.messages}
-            with open(self.history_file, 'w') as f:
+            data = {"messages": self.messages}
+            with open(self.history_file, "w") as f:
                 json.dump(data, f, indent=2)
             logger.debug(f"📜 Saved SMS history: {len(self.messages)} messages")
         except Exception as e:
@@ -302,19 +323,19 @@ class SMSHistory:
         with self._lock:
             if timestamp is None:
                 timestamp = time.strftime("%Y-%m-%d %H:%M:%S")
-            
+
             message = {
                 "number": number,
                 "text": text,  # Store full message text
-                "timestamp": timestamp
+                "timestamp": timestamp,
             }
-            
+
             self.messages.append(message)
-            
+
             # Keep only last max_messages
             if len(self.messages) > self.max_messages:
-                self.messages = self.messages[-self.max_messages:]
-            
+                self.messages = self.messages[-self.max_messages :]
+
             self._save()
             logger.debug(f"📜 Added message to history from {number}")
             return self.messages.copy()
@@ -331,10 +352,11 @@ class SMSHistory:
             self._save()
             logger.info("📜 SMS history cleared")
 
+
 class SMSDeliveryTracker:
     """Tracks SMS delivery status and reports (thread-safe)"""
 
-    def __init__(self, delivery_file='/data/sms_delivery.json', max_tracked=50):
+    def __init__(self, delivery_file="/data/sms_delivery.json", max_tracked=50):
         self.delivery_file = delivery_file
         self.max_tracked = max_tracked
         self.pending_deliveries = {}  # message_ref -> delivery info
@@ -345,10 +367,12 @@ class SMSDeliveryTracker:
         """Load delivery tracking from JSON file"""
         try:
             if os.path.exists(self.delivery_file):
-                with open(self.delivery_file, 'r') as f:
+                with open(self.delivery_file, "r") as f:
                     data = json.load(f)
-                    self.pending_deliveries = data.get('pending', {})
-                    logger.info(f"📬 Loaded delivery tracking: {len(self.pending_deliveries)} pending")
+                    self.pending_deliveries = data.get("pending", {})
+                    logger.info(
+                        f"📬 Loaded delivery tracking: {len(self.pending_deliveries)} pending"
+                    )
             else:
                 logger.info("📬 Delivery tracking file not found, starting fresh")
         except Exception as e:
@@ -359,20 +383,22 @@ class SMSDeliveryTracker:
         """Save delivery tracking to JSON file"""
         try:
             os.makedirs(os.path.dirname(self.delivery_file), exist_ok=True)
-            
+
             # Keep only max_tracked most recent entries
             if len(self.pending_deliveries) > self.max_tracked:
                 sorted_items = sorted(
                     self.pending_deliveries.items(),
-                    key=lambda x: x[1].get('sent_timestamp', ''),
-                    reverse=True
+                    key=lambda x: x[1].get("sent_timestamp", ""),
+                    reverse=True,
                 )
-                self.pending_deliveries = dict(sorted_items[:self.max_tracked])
-            
-            data = {'pending': self.pending_deliveries}
-            with open(self.delivery_file, 'w') as f:
+                self.pending_deliveries = dict(sorted_items[: self.max_tracked])
+
+            data = {"pending": self.pending_deliveries}
+            with open(self.delivery_file, "w") as f:
                 json.dump(data, f, indent=2)
-            logger.debug(f"📬 Saved delivery tracking: {len(self.pending_deliveries)} pending")
+            logger.debug(
+                f"📬 Saved delivery tracking: {len(self.pending_deliveries)} pending"
+            )
         except Exception as e:
             logger.error(f"Error saving delivery tracking: {e}")
 
@@ -384,12 +410,10 @@ class SMSDeliveryTracker:
                     "number": number,
                     "text_preview": text_preview[:50],
                     "sent_timestamp": time.strftime("%Y-%m-%d %H:%M:%S"),
-                    "status": "sent"
+                    "status": "sent",
                 }
                 self._save()
-                logger.info(
-                    f"📬 Tracking delivery for ref {message_ref} to {number}"
-                )
+                logger.info(f"📬 Tracking delivery for ref {message_ref} to {number}")
 
     def update_delivery_status(self, message_ref, status, timestamp=None):
         """Update delivery status for a message"""
@@ -409,10 +433,13 @@ class SMSDeliveryTracker:
     def get_pending_count(self):
         """Get count of messages awaiting delivery report"""
         with self._lock:
-            return len([
-                d for d in self.pending_deliveries.values()
-                if d.get('status') == 'sent'
-            ])
+            return len(
+                [
+                    d
+                    for d in self.pending_deliveries.values()
+                    if d.get("status") == "sent"
+                ]
+            )
 
     def get_all_deliveries(self):
         """Get all tracked deliveries"""
@@ -425,13 +452,13 @@ class SMSDeliveryTracker:
             count = len(self.pending_deliveries)
             self.pending_deliveries = {}
             self._save()
-            
+
             # Verify the file was actually cleared
             try:
                 if os.path.exists(self.delivery_file):
-                    with open(self.delivery_file, 'r') as f:
+                    with open(self.delivery_file, "r") as f:
                         data = json.load(f)
-                        remaining = len(data.get('pending', {}))
+                        remaining = len(data.get("pending", {}))
                         if remaining > 0:
                             logger.error(
                                 f"📬 WARNING: File still contains {remaining} "
@@ -444,14 +471,14 @@ class SMSDeliveryTracker:
                             )
             except Exception as e:
                 logger.error(f"📬 Error verifying clear operation: {e}")
-            
+
             return count
 
 
 class MissedCallTracker:
     """Tracks missed call history with persistent storage (thread-safe)"""
 
-    def __init__(self, calls_file='/data/missed_calls.json', max_calls=10):
+    def __init__(self, calls_file="/data/missed_calls.json", max_calls=10):
         self.calls_file = calls_file
         self.max_calls = max_calls
         self.calls = []
@@ -463,12 +490,12 @@ class MissedCallTracker:
         """Load missed calls from JSON file"""
         try:
             if os.path.exists(self.calls_file):
-                with open(self.calls_file, 'r') as f:
+                with open(self.calls_file, "r") as f:
                     data = json.load(f)
-                    self.calls = data.get('calls', [])
-                    self.last_call = data.get('last_call', None)
+                    self.calls = data.get("calls", [])
+                    self.last_call = data.get("last_call", None)
                     # Keep only max_calls
-                    self.calls = self.calls[-self.max_calls:]
+                    self.calls = self.calls[-self.max_calls :]
                     logger.info(
                         f"📞 Loaded missed call history: {len(self.calls)} calls"
                     )
@@ -485,11 +512,8 @@ class MissedCallTracker:
             # Ensure /data directory exists
             os.makedirs(os.path.dirname(self.calls_file), exist_ok=True)
 
-            data = {
-                'calls': self.calls,
-                'last_call': self.last_call
-            }
-            with open(self.calls_file, 'w') as f:
+            data = {"calls": self.calls, "last_call": self.last_call}
+            with open(self.calls_file, "w") as f:
                 json.dump(data, f, indent=2)
             logger.debug(f"📞 Saved missed call history: {len(self.calls)} calls")
         except Exception as e:
@@ -501,13 +525,13 @@ class MissedCallTracker:
             # Store the call
             self.calls.append(call_data)
             self.last_call = call_data
-            
+
             # Keep only last max_calls
             if len(self.calls) > self.max_calls:
-                self.calls = self.calls[-self.max_calls:]
-            
+                self.calls = self.calls[-self.max_calls :]
+
             self._save()
-            number = call_data.get('Number', 'Unknown')
+            number = call_data.get("Number", "Unknown")
             logger.debug(f"📞 Added missed call to history from {number}")
             return call_data
 
@@ -532,8 +556,8 @@ class MissedCallTracker:
 
 class BalanceSMSParser:
     """Parses SMS messages from network providers to extract account balance information"""
-    
-    def __init__(self, balance_file='/data/balance_data.json', currency='USD'):
+
+    def __init__(self, balance_file="/data/balance_data.json", currency="USD"):
         self.balance_file = balance_file
         self.currency = currency
         self.balance_data = {
@@ -545,49 +569,53 @@ class BalanceSMSParser:
             "messages_remaining": None,
             "plan_expiry": None,
             "last_updated": None,
-            "raw_message": None
+            "raw_message": None,
         }
         self._load()
-    
+
     def _migrate_old_format(self, data: Dict[str, Any]) -> Dict[str, Any]:
         """Migrate old string-based format to new numeric format"""
         migrated = False
-        
+
         # Migrate data_remaining from "200.00 MB" to 200.0
-        if isinstance(data.get('data_remaining'), str):
+        if isinstance(data.get("data_remaining"), str):
             import re
-            match = re.match(r'([\d.]+)\s*(MB|GB)?', data['data_remaining'])
+
+            match = re.match(r"([\d.]+)\s*(MB|GB)?", data["data_remaining"])
             if match:
                 value = float(match.group(1))
-                unit = match.group(2) or 'MB'
-                if unit.upper() == 'GB':
+                unit = match.group(2) or "MB"
+                if unit.upper() == "GB":
                     value *= 1024
-                data['data_remaining'] = value
-                data['data_remaining_unit'] = 'MB'
+                data["data_remaining"] = value
+                data["data_remaining_unit"] = "MB"
                 migrated = True
                 logger.info(f"💰 Migrated data_remaining to numeric: {value}")
-        
+
         # Migrate account_balance from "$3.00" to 3.0
-        if isinstance(data.get('account_balance'), str):
+        if isinstance(data.get("account_balance"), str):
             import re
-            match = re.match(r'[\$€£]?([\d.]+)', data['account_balance'])
+
+            match = re.match(r"[\$€£]?([\d.]+)", data["account_balance"])
             if match:
                 value = float(match.group(1))
-                data['account_balance'] = value
-                data['account_balance_currency'] = self.currency
+                data["account_balance"] = value
+                data["account_balance_currency"] = self.currency
                 migrated = True
                 logger.info(f"💰 Migrated account_balance to numeric: {value}")
-        
+
         if migrated:
-            logger.info("💰 Migrated balance data from old format to new numeric format")
-        
+            logger.info(
+                "💰 Migrated balance data from old format to new numeric format"
+            )
+
         return data
-    
+
     def _load(self):
         """Load saved balance data from JSON file"""
         try:
             if os.path.exists(self.balance_file):
-                with open(self.balance_file, 'r') as f:
+                with open(self.balance_file, "r") as f:
                     data = json.load(f)
                     # Migrate old format if needed
                     original_data = data.copy()
@@ -600,37 +628,38 @@ class BalanceSMSParser:
                     logger.info(f"💰 Loaded balance data from {self.balance_file}")
         except Exception as e:
             logger.error(f"Error loading balance data: {e}")
-    
+
     def _save(self):
         """Save balance data to JSON file"""
         try:
-            with open(self.balance_file, 'w') as f:
+            with open(self.balance_file, "w") as f:
                 json.dump(self.balance_data, f, indent=2)
             logger.debug(f"💰 Saved balance data")
         except Exception as e:
             logger.error(f"Error saving balance data: {e}")
-    
+
     def parse_balance_sms(self, message_text: str) -> Dict[str, Any]:
         """Parse balance information from SMS text
-        
+
         Example messages:
         - "You have 200.00 MB of High Speed Data Remaining 200 Minutes & 934 Messages."
         - "Your plan expires on 2025-12-20. You have balance of $3.00"
-        
+
         Values are stored as numeric types for proper Home Assistant device classes:
         - data_remaining: float (in MB)
         - account_balance: float
         """
         import re
-        
+
         updated = False
-        self.balance_data["last_updated"] = time.strftime('%Y-%m-%d %H:%M:%S')
+        self.balance_data["last_updated"] = time.strftime("%Y-%m-%d %H:%M:%S")
         self.balance_data["raw_message"] = message_text
-        
+
         # Parse data remaining (MB or GB) - store as numeric MB
         data_match = re.search(
-            r'([\d.]+)\s*(MB|GB)\s*(?:of\s*)?(?:High\s*Speed\s*)?Data',
-            message_text, re.IGNORECASE
+            r"([\d.]+)\s*(MB|GB)\s*(?:of\s*)?(?:High\s*Speed\s*)?Data",
+            message_text,
+            re.IGNORECASE,
         )
         if data_match:
             amount = float(data_match.group(1))
@@ -642,26 +671,26 @@ class BalanceSMSParser:
             self.balance_data["data_remaining_unit"] = "MB"
             updated = True
             logger.info(f"💰 Parsed data: {amount} MB")
-        
+
         # Parse minutes remaining
-        minutes_match = re.search(r'([\d,]+)\s*Minutes', message_text, re.IGNORECASE)
+        minutes_match = re.search(r"([\d,]+)\s*Minutes", message_text, re.IGNORECASE)
         if minutes_match:
-            minutes = int(minutes_match.group(1).replace(',', ''))
+            minutes = int(minutes_match.group(1).replace(",", ""))
             self.balance_data["minutes_remaining"] = minutes
             updated = True
             logger.info(f"💰 Parsed minutes: {minutes}")
-        
+
         # Parse messages remaining
-        messages_match = re.search(r'([\d,]+)\s*Messages', message_text, re.IGNORECASE)
+        messages_match = re.search(r"([\d,]+)\s*Messages", message_text, re.IGNORECASE)
         if messages_match:
-            messages = int(messages_match.group(1).replace(',', ''))
+            messages = int(messages_match.group(1).replace(",", ""))
             self.balance_data["messages_remaining"] = messages
             updated = True
             logger.info(f"💰 Parsed messages: {messages}")
-        
+
         # Parse account balance (dollar amount) - store as numeric
         balance_match = re.search(
-            r'balance\s*of\s*\$?([\d.]+)', message_text, re.IGNORECASE
+            r"balance\s*of\s*\$?([\d.]+)", message_text, re.IGNORECASE
         )
         if balance_match:
             balance = float(balance_match.group(1))
@@ -669,26 +698,27 @@ class BalanceSMSParser:
             self.balance_data["account_balance_currency"] = self.currency
             updated = True
             logger.info(f"💰 Parsed account balance: {balance} {self.currency}")
-        
+
         # Parse plan expiry date
         expiry_match = re.search(
-            r'expires?\s*on\s*([\d-]+)', message_text, re.IGNORECASE
+            r"expires?\s*on\s*([\d-]+)", message_text, re.IGNORECASE
         )
         if expiry_match:
             expiry_date = expiry_match.group(1)
             self.balance_data["plan_expiry"] = expiry_date
             updated = True
             logger.info(f"💰 Parsed expiry: {expiry_date}")
-        
+
         if updated:
             self._save()
             logger.info("💰 Balance data updated from SMS")
-        
+
         return self.balance_data
-    
+
     def get_balance_data(self) -> Dict[str, Any]:
         """Get current balance data"""
         return self.balance_data
+
 
 class DeviceConnectivityTracker:
     """Tracks USB GSM device connectivity status (thread-safe)"""
@@ -717,9 +747,11 @@ class DeviceConnectivityTracker:
             # 2. An SMS operation succeeds (critical path)
             # This prevents GetSignalQuality from clearing offline state when retrieveAllSms is failing
             if self.hard_offline:
-                is_sms_operation = operation_name and 'sms' in operation_name.lower()
-                is_same_operation = operation_name and operation_name == self.hard_offline_operation
-                
+                is_sms_operation = operation_name and "sms" in operation_name.lower()
+                is_same_operation = (
+                    operation_name and operation_name == self.hard_offline_operation
+                )
+
                 if is_sms_operation or is_same_operation:
                     logger.info(
                         f"✅ Device recovery from hard offline: {operation_name} succeeded "
@@ -748,6 +780,7 @@ class DeviceConnectivityTracker:
 
                 try:
                     from support import invalidate_network_type_cache
+
                     invalidate_network_type_cache()
                 except:
                     pass
@@ -765,7 +798,7 @@ class DeviceConnectivityTracker:
                 str(error_message) if error_message else "Communication failed"
             )
             self.total_operations += 1
-            
+
             # Timeout errors are critical - mark hard offline immediately
             # This ensures status polling can't incorrectly clear the offline state
             if is_timeout:
@@ -787,7 +820,7 @@ class DeviceConnectivityTracker:
 
             if self.consecutive_failures >= 2:
                 return "offline"
-            
+
             # Hard offline takes precedence (timeout occurred)
             if self.hard_offline:
                 return "offline"
@@ -809,9 +842,9 @@ class DeviceConnectivityTracker:
                 "total_operations": self.total_operations,
                 "successful_operations": self.successful_operations,
                 "last_error": self.last_error,
-                "hard_offline": self.hard_offline
+                "hard_offline": self.hard_offline,
             }
-            
+
             # Include which operation caused hard offline
             if self.hard_offline and self.hard_offline_operation:
                 data["hard_offline_operation"] = self.hard_offline_operation
@@ -839,7 +872,7 @@ class DeviceConnectivityTracker:
 
         if self.consecutive_failures >= 2:
             return "offline"
-        
+
         # Hard offline takes precedence (timeout occurred)
         if self.hard_offline:
             return "offline"
@@ -862,42 +895,56 @@ class MQTTPublisher:
         self.client: Optional[mqtt.Client] = None
         self.connected = False
         self.disconnecting = False  # Flag to prevent multiple disconnect calls
-        self.topic_prefix = config.get('mqtt_topic_prefix', 'homeassistant/sensor/sms_gateway')
-        self.availability_topic = f"{self.topic_prefix}/availability"  # Shared availability for all entities
+        self.topic_prefix = config.get(
+            "mqtt_topic_prefix", "homeassistant/sensor/sms_gateway"
+        )
+        self.availability_topic = (
+            f"{self.topic_prefix}/availability"  # Shared availability for all entities
+        )
         self.gammu_machine = None  # Will be set externally
-        self.gammu_lock = threading.Lock()  # Serialize all Gammu operations to prevent race conditions
+        self.gammu_lock = (
+            threading.Lock()
+        )  # Serialize all Gammu operations to prevent race conditions
         self.current_phone_number = ""  # Current phone number from text input
         self.current_message_text = ""  # Current message text from text input
         self.current_ussd_code = ""  # Current USSD code from text input
-        self.device_tracker = DeviceConnectivityTracker()  # USB device connectivity tracking
+        self.device_tracker = (
+            DeviceConnectivityTracker()
+        )  # USB device connectivity tracking
         self.sms_counter = SMSCounter()  # SMS counter with persistence
-        self.log_level = config.get('log_level', 'normal')  # Store log level for conditional logging
-        
+        self.log_level = config.get(
+            "log_level", "normal"
+        )  # Store log level for conditional logging
+
         # Reconnection settings
-        self.auto_recovery = config.get('auto_recovery', True)
+        self.auto_recovery = config.get("auto_recovery", True)
         self.consecutive_failures = 0
         self.reconnect_threshold = 5  # Try to reconnect after 5 consecutive failures
         self.last_reconnect_attempt = 0
         self.reconnect_cooldown = 60  # Wait 60 seconds between reconnect attempts
-        
+
         # Initialize SMS history with configurable max messages (default: 10)
-        max_history = config.get('sms_history_max_messages', 10)
-        self.sms_history = SMSHistory(max_messages=max_history)  # SMS history with persistence
-        
+        max_history = config.get("sms_history_max_messages", 10)
+        self.sms_history = SMSHistory(
+            max_messages=max_history
+        )  # SMS history with persistence
+
         # Initialize delivery tracking
         self.delivery_tracker = SMSDeliveryTracker()  # SMS delivery report tracking
-        
+
         # Initialize missed call tracking
-        max_missed_calls = config.get('missed_calls_max_history', 10)
+        max_missed_calls = config.get("missed_calls_max_history", 10)
         self.missed_call_tracker = MissedCallTracker(max_calls=max_missed_calls)
-        
+
         # Initialize balance SMS parser if enabled
         self.balance_parser = None
-        if config.get('balance_sms_enabled', False):
-            balance_currency = config.get('balance_currency', 'USD')
+        if config.get("balance_sms_enabled", False):
+            balance_currency = config.get("balance_currency", "USD")
             self.balance_parser = BalanceSMSParser(currency=balance_currency)
-            logger.info(f"💰 Balance SMS parsing enabled (currency: {balance_currency})")
-        
+            logger.info(
+                f"💰 Balance SMS parsing enabled (currency: {balance_currency})"
+            )
+
         # SMSC caching for reliable SMS sending
         self.cached_smsc = None
         self.smsc_cache_time = None
@@ -905,69 +952,82 @@ class MQTTPublisher:
 
         # SMS queue for retry after modem recovery
         self.sms_queue = SMSQueue()
-        
+
         # Auto-restart settings for persistent modem failures
-        self.auto_restart_on_failure = config.get('auto_restart_on_failure', True)
+        self.auto_restart_on_failure = config.get("auto_restart_on_failure", True)
         self.failure_start_time = None  # When continuous failures started
         self.restart_timeout = 120  # Restart after 2 min of continuous failure
         # Shorter timeout for hard offline (modem timed out completely)
         self.hard_offline_restart_timeout = config.get(
-            'hard_offline_restart_timeout', 30
+            "hard_offline_restart_timeout", 30
         )
-        
+
         # Modem operation delay - helps prevent buffer overflows and crashes
         # Configurable: 0.1 to 5.0 seconds (default 0.3s)
-        self.modem_operation_delay = config.get('modem_operation_delay', 0.3)
+        self.modem_operation_delay = config.get("modem_operation_delay", 0.3)
         logger.info(f"⏱️ Modem operation delay: {self.modem_operation_delay}s")
 
         # Call monitoring (real-time via Gammu callbacks)
         self.call_monitoring_enabled = False
-        self.call_queue = []  # [{'number': str, 'ring_start': datetime, 'ring_count': int}, ...]
+        self.call_queue = (
+            []
+        )  # [{'number': str, 'ring_start': datetime, 'ring_count': int}, ...]
         self.MAX_CALL_QUEUE_SIZE = 5  # Maximum number of concurrent calls in queue
         self._read_device_thread = None
-        self._call_auto_reset_timer = None  # Timer for auto-resetting stuck incoming call state
+        self._call_auto_reset_timer = (
+            None  # Timer for auto-resetting stuck incoming call state
+        )
         self._call_ended_at = None  # Timestamp when call ended (for cooldown)
-        self.CALL_COOLDOWN_SECONDS = 10  # Wait this long after call before resuming polls
+        self.CALL_COOLDOWN_SECONDS = (
+            10  # Wait this long after call before resuming polls
+        )
         self._post_call_reinit_needed = False  # Request modem reinit after cooldown
-        self._reinit_in_progress = False  # Lock to prevent concurrent modem access during reinit
+        self._reinit_in_progress = (
+            False  # Lock to prevent concurrent modem access during reinit
+        )
 
         # SMS callback (faster delivery, polling as fallback)
         self.sms_callback_enabled = False
         self._sms_callback_pending = False  # Flag that SMS arrived
-        self._sms_callback_timer = None     # Debounce timer
+        self._sms_callback_timer = None  # Debounce timer
 
-        if config.get('mqtt_enabled', False):
+        if config.get("mqtt_enabled", False):
             self._setup_client()
-    
+
     def set_gammu_machine(self, machine):
         """Set gammu machine for SMS sending"""
         self.gammu_machine = machine
         logger.info("Gammu machine set for MQTT SMS sending")
-    
+
     def _setup_client(self):
         """Setup MQTT client with configuration"""
         try:
             # Create client with unique ID for better connection tracking
             import socket
+
             client_id = f"sms_gateway_{socket.gethostname()}"
             self.client = mqtt.Client(client_id=client_id, clean_session=True)
 
             # Set credentials ONLY if username is provided and not empty
-            username = self.config.get('mqtt_username', '')
-            password = self.config.get('mqtt_password', '')
+            username = self.config.get("mqtt_username", "")
+            password = self.config.get("mqtt_password", "")
 
             # Ensure username is a string and strip whitespace
             if username is None:
-                username = ''
+                username = ""
             username = str(username).strip()
 
             # Only set credentials if username has actual content
-            if username and username != '':
+            if username and username != "":
                 self.client.username_pw_set(username, password)
-                logger.info(f"MQTT: Client ID: {client_id}, Using authentication with username: '{username}'")
+                logger.info(
+                    f"MQTT: Client ID: {client_id}, Using authentication with username: '{username}'"
+                )
             else:
-                logger.info(f"MQTT: Client ID: {client_id}, Connecting without authentication (local broker mode)")
-            
+                logger.info(
+                    f"MQTT: Client ID: {client_id}, Connecting without authentication (local broker mode)"
+                )
+
             # Set callbacks
             self.client.on_connect = self._on_connect
             self.client.on_disconnect = self._on_disconnect
@@ -977,19 +1037,21 @@ class MQTTPublisher:
             # Set Last Will and Testament - published if connection lost unexpectedly
             # This makes ALL entities unavailable in HA when addon crashes/stops
             self.client.will_set(self.availability_topic, "offline", qos=1, retain=True)
-            logger.info("📡 MQTT Last Will set: all entities will be unavailable if connection lost")
+            logger.info(
+                "📡 MQTT Last Will set: all entities will be unavailable if connection lost"
+            )
 
             # Connect to broker
-            host = self.config.get('mqtt_host', 'core-mosquitto')
-            port = self.config.get('mqtt_port', 1883)
+            host = self.config.get("mqtt_host", "core-mosquitto")
+            port = self.config.get("mqtt_port", 1883)
 
             logger.info(f"Connecting to MQTT broker: {host}:{port}")
             self.client.connect(host, port, 60)
             self.client.loop_start()
-            
+
         except Exception as e:
             logger.error(f"Failed to setup MQTT client: {e}")
-    
+
     def _on_connect(self, client, userdata, flags, rc):
         """Callback for MQTT connection"""
         if rc == 0:
@@ -1025,12 +1087,18 @@ class MQTTPublisher:
             # Subscribe to reset sent counter button
             reset_counter_topic = f"{self.topic_prefix}/reset_counter_button"
             client.subscribe(reset_counter_topic)
-            logger.info(f"Subscribed to reset sent counter topic: {reset_counter_topic}")
+            logger.info(
+                f"Subscribed to reset sent counter topic: {reset_counter_topic}"
+            )
 
             # Subscribe to reset received counter button
-            reset_received_counter_topic = f"{self.topic_prefix}/reset_received_counter_button"
+            reset_received_counter_topic = (
+                f"{self.topic_prefix}/reset_received_counter_button"
+            )
             client.subscribe(reset_received_counter_topic)
-            logger.info(f"Subscribed to reset received counter topic: {reset_received_counter_topic}")
+            logger.info(
+                f"Subscribed to reset received counter topic: {reset_received_counter_topic}"
+            )
 
             # Subscribe to delete all SMS button
             delete_all_sms_topic = f"{self.topic_prefix}/delete_all_sms_button"
@@ -1038,9 +1106,13 @@ class MQTTPublisher:
             logger.info(f"Subscribed to delete all SMS topic: {delete_all_sms_topic}")
 
             # Subscribe to clear delivery reports button
-            clear_delivery_reports_topic = f"{self.topic_prefix}/clear_delivery_reports_button"
+            clear_delivery_reports_topic = (
+                f"{self.topic_prefix}/clear_delivery_reports_button"
+            )
             client.subscribe(clear_delivery_reports_topic)
-            logger.info(f"Subscribed to clear delivery reports topic: {clear_delivery_reports_topic}")
+            logger.info(
+                f"Subscribed to clear delivery reports topic: {clear_delivery_reports_topic}"
+            )
 
             # Subscribe to text input topics
             phone_topic = f"{self.topic_prefix}/phone_number/set"
@@ -1052,7 +1124,9 @@ class MQTTPublisher:
             client.subscribe(message_topic)
             client.subscribe(phone_state_topic)  # Subscribe to state topics too
             client.subscribe(message_state_topic)
-            logger.info(f"Subscribed to text input topics: {phone_topic}, {message_topic}, {phone_state_topic}, {message_state_topic}")
+            logger.info(
+                f"Subscribed to text input topics: {phone_topic}, {message_topic}, {phone_state_topic}, {message_state_topic}"
+            )
 
             # Subscribe to USSD topics
             ussd_code_topic = f"{self.topic_prefix}/ussd_code/set"
@@ -1062,24 +1136,26 @@ class MQTTPublisher:
             client.subscribe(ussd_code_topic)
             client.subscribe(ussd_code_state_topic)
             client.subscribe(ussd_button_topic)
-            logger.info(f"Subscribed to USSD topics: {ussd_code_topic}, {ussd_code_state_topic}, {ussd_button_topic}")
+            logger.info(
+                f"Subscribed to USSD topics: {ussd_code_topic}, {ussd_code_state_topic}, {ussd_button_topic}"
+            )
         else:
             logger.error(f"Failed to connect to MQTT broker: {rc}")
-    
+
     def _on_disconnect(self, client, userdata, rc):
         """Callback for MQTT disconnection"""
         self.connected = False
         logger.warning("Disconnected from MQTT broker")
-    
+
     def _on_publish(self, client, userdata, mid):
         """Callback for published messages"""
         pass
-    
+
     def _on_message(self, client, userdata, msg):
         """Callback for received MQTT messages"""
         try:
             topic = msg.topic
-            payload = msg.payload.decode('utf-8')
+            payload = msg.payload.decode("utf-8")
             logger.info(f"Received MQTT message on topic {topic}: {payload}")
 
             # Check message topic and handle accordingly
@@ -1088,9 +1164,13 @@ class MQTTPublisher:
             button_topic = f"{self.topic_prefix}/send_button"
             flash_button_topic = f"{self.topic_prefix}/send_flash_button"
             reset_counter_topic = f"{self.topic_prefix}/reset_counter_button"
-            reset_received_counter_topic = f"{self.topic_prefix}/reset_received_counter_button"
+            reset_received_counter_topic = (
+                f"{self.topic_prefix}/reset_received_counter_button"
+            )
             delete_all_sms_topic = f"{self.topic_prefix}/delete_all_sms_button"
-            clear_delivery_reports_topic = f"{self.topic_prefix}/clear_delivery_reports_button"
+            clear_delivery_reports_topic = (
+                f"{self.topic_prefix}/clear_delivery_reports_button"
+            )
             phone_topic = f"{self.topic_prefix}/phone_number/set"
             message_topic = f"{self.topic_prefix}/message_text/set"
             phone_state_topic = f"{self.topic_prefix}/phone_number/state"
@@ -1163,35 +1243,39 @@ class MQTTPublisher:
                         "status": "error",
                         "message": f"Command processing failed: {str(e)}",
                         "topic": msg.topic,
-                        "timestamp": time.strftime("%Y-%m-%d %H:%M:%S")
+                        "timestamp": time.strftime("%Y-%m-%d %H:%M:%S"),
                     }
-                    self.client.publish(status_topic, json.dumps(status_data), retain=False)
+                    self.client.publish(
+                        status_topic, json.dumps(status_data), retain=False
+                    )
                 except Exception as pub_err:
                     logger.error(f"Failed to publish error status: {pub_err}")
-    
+
     def _handle_sms_send_command(self, payload):
         """Handle SMS send command from MQTT"""
         try:
             # Parse JSON payload
             data = json.loads(payload)
-            number = data.get('number')
-            text = data.get('text')
+            number = data.get("number")
+            text = data.get("text")
             # If 'unicode' is explicitly provided, use it; otherwise use None for auto-detection
-            unicode_mode = data.get('unicode') if 'unicode' in data else None
-            flash_mode = data.get('flash', False)
+            unicode_mode = data.get("unicode") if "unicode" in data else None
+            flash_mode = data.get("flash", False)
 
             if not number or not text:
                 logger.error("SMS send command missing required fields: number or text")
                 return
 
-            logger.info(f"Processing SMS send command: {number} -> {text} (unicode: {unicode_mode if unicode_mode is not None else 'auto'}, flash: {flash_mode})")
+            logger.info(
+                f"Processing SMS send command: {number} -> {text} (unicode: {unicode_mode if unicode_mode is not None else 'auto'}, flash: {flash_mode})"
+            )
 
             # Send SMS via gammu machine (will be set externally)
-            if hasattr(self, 'gammu_machine') and self.gammu_machine:
+            if hasattr(self, "gammu_machine") and self.gammu_machine:
                 self._send_sms_via_gammu(number, text, unicode_mode, flash_mode)
             else:
                 logger.error("Gammu machine not available for SMS sending")
-                
+
         except json.JSONDecodeError as e:
             logger.error(f"Invalid JSON in SMS send command: {e}")
         except Exception as e:
@@ -1199,60 +1283,60 @@ class MQTTPublisher:
 
     def _handle_queued_sms_from_mqtt(self, payload, topic):
         """Handle SMS from persistent MQTT queue topic (survives addon restarts)
-        
+
         This topic uses retained messages so SMS requests persist in the MQTT broker
         even when the addon is down. When the addon starts, it receives the retained
         message and adds it to the local queue for processing.
-        
+
         Args:
             payload: JSON payload with 'number' and 'text' fields
             topic: The MQTT topic to clear after processing
         """
         try:
             # Skip empty payloads (cleared retained messages)
-            if not payload or payload.strip() == '':
+            if not payload or payload.strip() == "":
                 logger.debug("Empty queue_sms payload received, skipping")
                 return
-            
+
             # Parse JSON payload
             data = json.loads(payload)
-            number = data.get('number')
-            text = data.get('text')
-            smsc = data.get('smsc')  # Optional SMSC
-            
+            number = data.get("number")
+            text = data.get("text")
+            smsc = data.get("smsc")  # Optional SMSC
+
             if not number or not text:
                 logger.error("Queued SMS missing required fields: number or text")
                 # Clear the invalid retained message
-                self.client.publish(topic, '', retain=True)
+                self.client.publish(topic, "", retain=True)
                 return
-            
+
             logger.info(f"📥 Received SMS from MQTT queue: {number}")
-            
+
             # Clear the retained message immediately to prevent re-processing
-            self.client.publish(topic, '', retain=True)
+            self.client.publish(topic, "", retain=True)
             logger.info(f"📤 Cleared retained message from {topic}")
-            
+
             # Add to local queue for processing
             added = self.sms_queue.add(number, text, smsc)
             if added:
                 logger.info(f"📥 SMS added to local queue from MQTT: {number}")
             else:
                 logger.info(f"📥 SMS already in queue (duplicate): {number}")
-            
+
             # If gammu machine is ready, trigger immediate processing
-            if hasattr(self, 'gammu_machine') and self.gammu_machine:
+            if hasattr(self, "gammu_machine") and self.gammu_machine:
                 logger.info("📤 Triggering immediate queue processing...")
                 self.process_pending_sms()
             else:
                 logger.info("⏳ Gammu not ready, SMS will be sent when modem connects")
-                
+
         except json.JSONDecodeError as e:
             logger.error(f"Invalid JSON in queued SMS: {e}")
             # Clear invalid retained message
-            self.client.publish(topic, '', retain=True)
+            self.client.publish(topic, "", retain=True)
         except Exception as e:
             logger.error(f"Error handling queued SMS from MQTT: {e}")
-    
+
     def _send_ussd_via_gammu(self, ussd_code):
         """Send USSD code using gammu machine and return response
 
@@ -1264,46 +1348,50 @@ class MQTTPublisher:
         """
         try:
             logger.info(f"📱 Sending USSD code: {ussd_code}")
-            
+
             # Use DialService to send USSD and get response
             # DialService returns the USSD response as text (or dict with Text key)
-            response = self.track_gammu_operation("DialService", self.gammu_machine.DialService, ussd_code)
-            
+            response = self.track_gammu_operation(
+                "DialService", self.gammu_machine.DialService, ussd_code
+            )
+
             # Handle response - may be string or dict depending on Gammu version
             if isinstance(response, dict):
-                response_text = response.get('Text', str(response))
+                response_text = response.get("Text", str(response))
             else:
                 response_text = str(response) if response else "No response"
-            
+
             logger.info(f"✅ USSD Response received: {response_text}")
-            
+
             # Publish USSD response to MQTT
             if self.connected:
                 response_topic = f"{self.topic_prefix}/ussd_response/state"
                 response_data = {
                     "response": response_text,
                     "code": ussd_code,
-                    "timestamp": time.strftime("%Y-%m-%d %H:%M:%S")
+                    "timestamp": time.strftime("%Y-%m-%d %H:%M:%S"),
                 }
-                self.client.publish(response_topic, json.dumps(response_data), retain=True)
+                self.client.publish(
+                    response_topic, json.dumps(response_data), retain=True
+                )
                 logger.info(f"📤 Published USSD response to {response_topic}")
-            
+
             return response_text
 
         except Exception as e:
             error_msg = f"Failed to send USSD code: {str(e)}"
             logger.error(f"❌ {error_msg}")
-            
+
             # Publish error to USSD response sensor
             if self.connected:
                 response_topic = f"{self.topic_prefix}/ussd_response/state"
                 error_data = {
                     "response": f"ERROR: {str(e)}",
                     "code": ussd_code,
-                    "timestamp": time.strftime("%Y-%m-%d %H:%M:%S")
+                    "timestamp": time.strftime("%Y-%m-%d %H:%M:%S"),
                 }
                 self.client.publish(response_topic, json.dumps(error_data), retain=True)
-            
+
             raise
 
     def _send_sms_via_gammu(self, number, text, unicode_mode=None, flash_mode=False):
@@ -1323,12 +1411,16 @@ class MQTTPublisher:
             if unicode_mode is None:
                 unicode_mode = detect_unicode_needed(text)
                 if unicode_mode:
-                    logger.info(f"🔤 Auto-detected non-ASCII characters, using Unicode mode")
+                    logger.info(
+                        f"🔤 Auto-detected non-ASCII characters, using Unicode mode"
+                    )
 
             # Determine SMS class based on flash_mode
             sms_class = 0 if flash_mode else -1
             if flash_mode:
-                logger.info("⚡ Sending Flash SMS (will display on screen without saving)")
+                logger.info(
+                    "⚡ Sending Flash SMS (will display on screen without saving)"
+                )
 
             # Prepare SMS info
             smsinfo = {
@@ -1343,7 +1435,7 @@ class MQTTPublisher:
             }
 
             # Support multiple recipients (comma-separated)
-            recipients = [r.strip() for r in number.split(',')]
+            recipients = [r.strip() for r in number.split(",")]
             all_message_refs = []
             sent_count = 0
 
@@ -1356,29 +1448,33 @@ class MQTTPublisher:
                 message_refs = []
                 for message in messages:
                     # Use same SMSC logic as REST API
-                    config_smsc = self.config.get('smsc_number', '').strip()
+                    config_smsc = self.config.get("smsc_number", "").strip()
                     if config_smsc:
-                        message["SMSC"] = {'Number': config_smsc}
+                        message["SMSC"] = {"Number": config_smsc}
                         logger.info(f"Using configured SMSC: {config_smsc}")
                     else:
                         # Use Location 1 (same as REST API when no SMSC provided)
-                        message["SMSC"] = {'Location': 1}
+                        message["SMSC"] = {"Location": 1}
                         logger.info("Using SMSC from Location 1 (same as REST API)")
 
                     message["Number"] = recipient
-                    
+
                     # Request delivery report if enabled in config
-                    if self.config.get('sms_delivery_reports', False):
+                    if self.config.get("sms_delivery_reports", False):
                         message["DeliveryReport"] = "yes"
-                    
-                    result = self.track_gammu_operation("SendSMS", self.gammu_machine.SendSMS, message)
+
+                    result = self.track_gammu_operation(
+                        "SendSMS", self.gammu_machine.SendSMS, message
+                    )
                     logger.info(f"SMS sent successfully to {recipient}: {result}")
-                    
+
                     # Track delivery - result is the message reference
-                    if result and self.config.get('sms_delivery_reports', False):
+                    if result and self.config.get("sms_delivery_reports", False):
                         message_refs.append(result)
                         self.delivery_tracker.track_sent_sms(result, recipient, text)
-                        logger.info(f"📬 Delivery report requested for message ref: {result}")
+                        logger.info(
+                            f"📬 Delivery report requested for message ref: {result}"
+                        )
 
                 all_message_refs.extend(message_refs)
                 sent_count += 1
@@ -1387,7 +1483,9 @@ class MQTTPublisher:
             for _ in range(sent_count):
                 self.sms_counter.increment()
             self.publish_sms_counter()
-            logger.info(f"📊 SMS counter incremented by {sent_count} to: {self.sms_counter.get_count()}")
+            logger.info(
+                f"📊 SMS counter incremented by {sent_count} to: {self.sms_counter.get_count()}"
+            )
 
             # Publish confirmation with message references
             if self.connected:
@@ -1398,14 +1496,14 @@ class MQTTPublisher:
                     "text": text,
                     "message_refs": all_message_refs,
                     "pending_delivery_reports": len(all_message_refs),
-                    "timestamp": time.strftime("%Y-%m-%d %H:%M:%S")
+                    "timestamp": time.strftime("%Y-%m-%d %H:%M:%S"),
                 }
                 self.client.publish(status_topic, json.dumps(status_data), retain=False)
-                
+
                 # Publish initial delivery status if enabled
-                if self.config.get('sms_delivery_reports', False) and all_message_refs:
+                if self.config.get("sms_delivery_reports", False) and all_message_refs:
                     self.publish_delivery_pending(all_message_refs, number)
-                
+
         except Exception as e:
             error_msg = str(e)
             # Try to extract useful error message from gammu error
@@ -1417,7 +1515,7 @@ class MQTTPublisher:
                 user_error = "SMSC number not found - configure SMS center number in SIM settings"
             else:
                 user_error = f"SMS sending error: {error_msg}"
-            
+
             logger.error(f"Failed to send SMS via gammu: {error_msg}")
             # Publish error status with user-friendly message
             if self.connected:
@@ -1427,33 +1525,44 @@ class MQTTPublisher:
                     "error": user_error,
                     "number": number,
                     "text": text,
-                    "timestamp": time.strftime("%Y-%m-%d %H:%M:%S")
+                    "timestamp": time.strftime("%Y-%m-%d %H:%M:%S"),
                 }
                 self.client.publish(status_topic, json.dumps(status_data), retain=False)
-    
+
     def _handle_button_sms_send(self):
         """Handle SMS send when button is pressed using current text inputs"""
         # Log current state for debugging
-        logger.info(f"Button pressed - current state: phone='{self.current_phone_number}', message='{self.current_message_text}'")
+        logger.info(
+            f"Button pressed - current state: phone='{self.current_phone_number}', message='{self.current_message_text}'"
+        )
 
-        if not self.current_phone_number.strip() or not self.current_message_text.strip():
+        if (
+            not self.current_phone_number.strip()
+            or not self.current_message_text.strip()
+        ):
             # If fields are empty, show instruction
             if self.connected:
                 status_topic = f"{self.topic_prefix}/send_status"
                 status_data = {
                     "status": "missing_fields",
                     "message": f"Please fill in phone number and message text first. Current: phone='{self.current_phone_number}', message='{self.current_message_text}'",
-                    "timestamp": time.strftime("%Y-%m-%d %H:%M:%S")
+                    "timestamp": time.strftime("%Y-%m-%d %H:%M:%S"),
                 }
                 self.client.publish(status_topic, json.dumps(status_data), retain=False)
-            logger.warning(f"Button pressed but fields empty: phone='{self.current_phone_number}', message='{self.current_message_text}'")
+            logger.warning(
+                f"Button pressed but fields empty: phone='{self.current_phone_number}', message='{self.current_message_text}'"
+            )
             return
 
         # Send SMS using current values
-        logger.info(f"Button SMS send: {self.current_phone_number} -> {self.current_message_text}")
-        if hasattr(self, 'gammu_machine') and self.gammu_machine:
+        logger.info(
+            f"Button SMS send: {self.current_phone_number} -> {self.current_message_text}"
+        )
+        if hasattr(self, "gammu_machine") and self.gammu_machine:
             # Use unicode_mode=None for auto-detection
-            self._send_sms_via_gammu(self.current_phone_number, self.current_message_text, unicode_mode=None)
+            self._send_sms_via_gammu(
+                self.current_phone_number, self.current_message_text, unicode_mode=None
+            )
             # Always clear fields after send attempt (success or failure)
             self._clear_text_fields()
         else:
@@ -1463,23 +1572,35 @@ class MQTTPublisher:
 
     def _handle_flash_button_sms_send(self):
         """Handle Flash SMS send when button is pressed using current text inputs"""
-        logger.info(f"Flash button pressed - phone='{self.current_phone_number}', message='{self.current_message_text}'")
+        logger.info(
+            f"Flash button pressed - phone='{self.current_phone_number}', message='{self.current_message_text}'"
+        )
 
-        if not self.current_phone_number.strip() or not self.current_message_text.strip():
+        if (
+            not self.current_phone_number.strip()
+            or not self.current_message_text.strip()
+        ):
             if self.connected:
                 status_topic = f"{self.topic_prefix}/send_status"
                 status_data = {
                     "status": "missing_fields",
                     "message": "Please fill in phone number and message text first",
-                    "timestamp": time.strftime("%Y-%m-%d %H:%M:%S")
+                    "timestamp": time.strftime("%Y-%m-%d %H:%M:%S"),
                 }
                 self.client.publish(status_topic, json.dumps(status_data), retain=False)
             logger.warning("Flash button pressed but fields empty")
             return
 
-        logger.info(f"Flash SMS send: {self.current_phone_number} -> {self.current_message_text}")
-        if hasattr(self, 'gammu_machine') and self.gammu_machine:
-            self._send_sms_via_gammu(self.current_phone_number, self.current_message_text, unicode_mode=None, flash_mode=True)
+        logger.info(
+            f"Flash SMS send: {self.current_phone_number} -> {self.current_message_text}"
+        )
+        if hasattr(self, "gammu_machine") and self.gammu_machine:
+            self._send_sms_via_gammu(
+                self.current_phone_number,
+                self.current_message_text,
+                unicode_mode=None,
+                flash_mode=True,
+            )
             self._clear_text_fields()
         else:
             logger.error("Gammu machine not available for SMS sending")
@@ -1496,15 +1617,17 @@ class MQTTPublisher:
                 response_data = {
                     "response": "ERROR: Please enter a USSD code first (e.g., *#100#)",
                     "code": "",
-                    "timestamp": time.strftime("%Y-%m-%d %H:%M:%S")
+                    "timestamp": time.strftime("%Y-%m-%d %H:%M:%S"),
                 }
-                self.client.publish(response_topic, json.dumps(response_data), retain=True)
+                self.client.publish(
+                    response_topic, json.dumps(response_data), retain=True
+                )
             logger.warning(f"USSD button pressed but code field is empty")
             return
 
         # Send USSD using current value
         logger.info(f"Sending USSD code: {self.current_ussd_code}")
-        if hasattr(self, 'gammu_machine') and self.gammu_machine:
+        if hasattr(self, "gammu_machine") and self.gammu_machine:
             try:
                 response = self._send_ussd_via_gammu(self.current_ussd_code)
                 logger.info(f"✅ USSD sent successfully, response: {response}")
@@ -1515,7 +1638,7 @@ class MQTTPublisher:
                 logger.error(f"❌ USSD send failed: {e}")
         else:
             logger.error("Gammu machine not available for USSD sending")
-    
+
     def _handle_reset_counter(self):
         """Handle reset sent counter button press"""
         logger.info("🔄 Reset sent counter button pressed")
@@ -1535,7 +1658,7 @@ class MQTTPublisher:
         logger.info("📬 Clear delivery reports button pressed")
         try:
             count = self.delivery_tracker.clear_pending_deliveries()
-            
+
             # Publish updated status
             if self.connected:
                 status_topic = f"{self.topic_prefix}/delivery_status"
@@ -1543,7 +1666,7 @@ class MQTTPublisher:
                     "status": "cleared",
                     "message": f"Cleared {count} pending delivery reports",
                     "pending_count": 0,
-                    "timestamp": time.strftime("%Y-%m-%d %H:%M:%S")
+                    "timestamp": time.strftime("%Y-%m-%d %H:%M:%S"),
                 }
                 self.client.publish(status_topic, json.dumps(status_data), retain=False)
                 logger.info(f"✅ Cleared {count} pending delivery reports")
@@ -1554,7 +1677,7 @@ class MQTTPublisher:
                 status_data = {
                     "status": "error",
                     "message": f"Failed to clear delivery reports: {str(e)}",
-                    "timestamp": time.strftime("%Y-%m-%d %H:%M:%S")
+                    "timestamp": time.strftime("%Y-%m-%d %H:%M:%S"),
                 }
                 self.client.publish(status_topic, json.dumps(status_data), retain=False)
 
@@ -1562,14 +1685,16 @@ class MQTTPublisher:
         """Handle delete all SMS button press - with fallback for corrupted SMS"""
         logger.info("🗑️ Delete all SMS button pressed")
         try:
-            if hasattr(self, 'gammu_machine') and self.gammu_machine:
-                from support import retrieveAllSms, deleteSms
+            if hasattr(self, "gammu_machine") and self.gammu_machine:
+                from support import deleteSms, retrieveAllSms
 
                 deleted_count = 0
 
                 # Try method 1: Retrieve and delete SMS one by one
                 try:
-                    all_sms = self.track_gammu_operation("retrieveAllSms", retrieveAllSms, self.gammu_machine)
+                    all_sms = self.track_gammu_operation(
+                        "retrieveAllSms", retrieveAllSms, self.gammu_machine
+                    )
                     count = len(all_sms)
 
                     logger.info(f"📋 Found {count} SMS to delete")
@@ -1577,12 +1702,18 @@ class MQTTPublisher:
                     # Delete each SMS
                     for sms in all_sms:
                         try:
-                            self.track_gammu_operation("deleteSms", deleteSms, self.gammu_machine, sms)
+                            self.track_gammu_operation(
+                                "deleteSms", deleteSms, self.gammu_machine, sms
+                            )
                             deleted_count += 1
                         except Exception as e:
-                            logger.warning(f"Could not delete SMS at location {sms.get('Location', 'unknown')}: {e}")
+                            logger.warning(
+                                f"Could not delete SMS at location {sms.get('Location', 'unknown')}: {e}"
+                            )
 
-                    logger.info(f"✅ Method 1: Deleted {deleted_count}/{count} SMS messages")
+                    logger.info(
+                        f"✅ Method 1: Deleted {deleted_count}/{count} SMS messages"
+                    )
 
                 except Exception as e:
                     # Method 1 failed (likely corrupted SMS) - try method 2
@@ -1591,10 +1722,14 @@ class MQTTPublisher:
 
                     # Method 2: Get SMS capacity and delete by location
                     try:
-                        capacity = self.track_gammu_operation("GetSMSStatus", self.gammu_machine.GetSMSStatus)
-                        sim_size = capacity.get('SIMSize', 50)  # Default 50 if unknown
+                        capacity = self.track_gammu_operation(
+                            "GetSMSStatus", self.gammu_machine.GetSMSStatus
+                        )
+                        sim_size = capacity.get("SIMSize", 50)  # Default 50 if unknown
 
-                        logger.info(f"📋 Attempting to delete SMS from {sim_size} locations")
+                        logger.info(
+                            f"📋 Attempting to delete SMS from {sim_size} locations"
+                        )
 
                         # Try to delete each location (even corrupted ones)
                         # Use multiple folder IDs to catch SMS in different folders
@@ -1607,33 +1742,52 @@ class MQTTPublisher:
                                     self.gammu_machine.DeleteSMS(folder, location)
                                     deleted_count += 1
                                     deleted_this_location = True
-                                    logger.info(f"✅ Deleted SMS at folder={folder}, location={location}")
+                                    logger.info(
+                                        f"✅ Deleted SMS at folder={folder}, location={location}"
+                                    )
                                     break  # Success - don't try other folders for this location
                                 except Exception as loc_err:
                                     error_msg = str(loc_err)
                                     # Only log if it's not just "empty location"
-                                    if "Empty" not in error_msg and "InvalidLocation" not in error_msg:
-                                        logger.debug(f"Folder {folder}, Location {location}: {error_msg}")
+                                    if (
+                                        "Empty" not in error_msg
+                                        and "InvalidLocation" not in error_msg
+                                    ):
+                                        logger.debug(
+                                            f"Folder {folder}, Location {location}: {error_msg}"
+                                        )
 
                             if not deleted_this_location:
-                                logger.debug(f"Location {location}: no SMS found in any folder")
+                                logger.debug(
+                                    f"Location {location}: no SMS found in any folder"
+                                )
 
-                        logger.info(f"✅ Method 2: Processed {sim_size} locations, deleted {deleted_count} SMS")
+                        logger.info(
+                            f"✅ Method 2: Processed {sim_size} locations, deleted {deleted_count} SMS"
+                        )
 
                     except Exception as capacity_err:
                         logger.error(f"Method 2 also failed: {capacity_err}")
-                        raise Exception(f"Both deletion methods failed. Last error: {capacity_err}")
+                        raise Exception(
+                            f"Both deletion methods failed. Last error: {capacity_err}"
+                        )
 
                 # Give modem time to process bulk deletion (prevents Code 27 errors)
                 if deleted_count > 0:
-                    logger.info("⏳ Waiting for modem to stabilize after bulk deletion...")
+                    logger.info(
+                        "⏳ Waiting for modem to stabilize after bulk deletion..."
+                    )
                     time.sleep(3)  # 3 second pause
 
                 # Update SMS capacity after deletion
                 try:
-                    capacity = self.track_gammu_operation("GetSMSStatus", self.gammu_machine.GetSMSStatus)
+                    capacity = self.track_gammu_operation(
+                        "GetSMSStatus", self.gammu_machine.GetSMSStatus
+                    )
                     self.publish_sms_capacity(capacity)
-                    logger.info(f"📊 Updated SMS capacity: {capacity.get('SIMUsed', 0)}/{capacity.get('SIMSize', 0)}")
+                    logger.info(
+                        f"📊 Updated SMS capacity: {capacity.get('SIMUsed', 0)}/{capacity.get('SIMSize', 0)}"
+                    )
                 except Exception as e:
                     logger.warning(f"Could not update SMS capacity: {e}")
 
@@ -1644,9 +1798,11 @@ class MQTTPublisher:
                         "status": "success",
                         "deleted_count": deleted_count,
                         "message": f"Deleted {deleted_count} SMS messages from SIM",
-                        "timestamp": time.strftime("%Y-%m-%d %H:%M:%S")
+                        "timestamp": time.strftime("%Y-%m-%d %H:%M:%S"),
                     }
-                    self.client.publish(status_topic, json.dumps(status_data), retain=False)
+                    self.client.publish(
+                        status_topic, json.dumps(status_data), retain=False
+                    )
             else:
                 logger.error("Gammu machine not available for deleting SMS")
         except Exception as e:
@@ -1656,7 +1812,7 @@ class MQTTPublisher:
                 status_data = {
                     "status": "error",
                     "error": str(e),
-                    "timestamp": time.strftime("%Y-%m-%d %H:%M:%S")
+                    "timestamp": time.strftime("%Y-%m-%d %H:%M:%S"),
                 }
                 self.client.publish(status_topic, json.dumps(status_data), retain=False)
 
@@ -1676,12 +1832,14 @@ class MQTTPublisher:
                 self.client.publish(phone_state_topic, "", retain=True, qos=1)
                 self.client.publish(message_state_topic, "", retain=True, qos=1)
 
-                logger.info("🧹 Cleared both phone and message text fields after sending SMS")
+                logger.info(
+                    "🧹 Cleared both phone and message text fields after sending SMS"
+                )
             except Exception as e:
                 logger.warning(f"Could not clear text fields in UI: {e}")
         else:
             logger.info("🧹 Cleared both text fields (internal state only)")
-    
+
     def _publish_phone_state(self, value):
         """Publish phone number state"""
         if self.connected:
@@ -1699,7 +1857,7 @@ class MQTTPublisher:
         if self.connected:
             state_topic = f"{self.topic_prefix}/ussd_code/state"
             self.client.publish(state_topic, value, retain=True, qos=1)
-    
+
     def _publish_discovery_configs(self):
         """Publish Home Assistant auto-discovery configurations"""
         if not self.connected:
@@ -1710,14 +1868,14 @@ class MQTTPublisher:
             "identifiers": ["sms_gateway"],
             "name": "SMS Gateway",
             "model": "GSM Modem",
-            "manufacturer": "Gammu Gateway"
+            "manufacturer": "Gammu Gateway",
         }
 
         # Common availability config - all entities share same availability topic
         AVAILABILITY_CONFIG = {
             "availability_topic": self.availability_topic,
             "payload_available": "online",
-            "payload_not_available": "offline"
+            "payload_not_available": "offline",
         }
 
         # Signal strength sensor (original from PavelVe)
@@ -1730,9 +1888,9 @@ class MQTTPublisher:
             "icon": "mdi:signal-cellular-3",
             "state_class": "measurement",
             "device": DEVICE_CONFIG,
-            **AVAILABILITY_CONFIG
+            **AVAILABILITY_CONFIG,
         }
-        
+
         # Signal strength dBm sensor (diagnostic - shows actual dBm value, not percent)
         signal_dbm_config = {
             "name": "GSM Signal Strength (dBm)",
@@ -1745,9 +1903,9 @@ class MQTTPublisher:
             "icon": "mdi:signal",
             "state_class": "measurement",
             "device": DEVICE_CONFIG,
-            **AVAILABILITY_CONFIG
+            **AVAILABILITY_CONFIG,
         }
-        
+
         # Bit Error Rate sensor (diagnostic)
         ber_config = {
             "name": "GSM Bit Error Rate",
@@ -1759,9 +1917,9 @@ class MQTTPublisher:
             "icon": "mdi:gauge",
             "state_class": "measurement",
             "device": DEVICE_CONFIG,
-            **AVAILABILITY_CONFIG
+            **AVAILABILITY_CONFIG,
         }
-        
+
         # Network info sensor (original from PavelVe)
         network_config = {
             "name": "GSM Network",
@@ -1770,9 +1928,9 @@ class MQTTPublisher:
             "value_template": "{{ value_json.NetworkName }}",
             "icon": "mdi:network",
             "device": DEVICE_CONFIG,
-            **AVAILABILITY_CONFIG
+            **AVAILABILITY_CONFIG,
         }
-        
+
         # Network registration state sensor (main display)
         network_state_config = {
             "name": "GSM Network State",
@@ -1781,9 +1939,9 @@ class MQTTPublisher:
             "value_template": "{{ value_json.State }}",
             "icon": "mdi:signal-variant",
             "device": DEVICE_CONFIG,
-            **AVAILABILITY_CONFIG
+            **AVAILABILITY_CONFIG,
         }
-        
+
         # Network code (MCC+MNC) sensor (diagnostic)
         network_code_config = {
             "name": "GSM Network Code",
@@ -1793,9 +1951,9 @@ class MQTTPublisher:
             "icon": "mdi:network",
             "entity_category": "diagnostic",
             "device": DEVICE_CONFIG,
-            **AVAILABILITY_CONFIG
+            **AVAILABILITY_CONFIG,
         }
-        
+
         # Cell ID sensor
         cid_config = {
             "name": "GSM Cell ID",
@@ -1805,9 +1963,9 @@ class MQTTPublisher:
             "icon": "mdi:radio-tower",
             "entity_category": "diagnostic",
             "device": DEVICE_CONFIG,
-            **AVAILABILITY_CONFIG
+            **AVAILABILITY_CONFIG,
         }
-        
+
         # Location Area Code sensor
         lac_config = {
             "name": "GSM Location Area Code",
@@ -1817,9 +1975,9 @@ class MQTTPublisher:
             "icon": "mdi:map-marker-radius",
             "entity_category": "diagnostic",
             "device": DEVICE_CONFIG,
-            **AVAILABILITY_CONFIG
+            **AVAILABILITY_CONFIG,
         }
-        
+
         # Packet Location Area Code sensor
         packet_lac_config = {
             "name": "GSM Packet Location Area Code",
@@ -1829,9 +1987,9 @@ class MQTTPublisher:
             "icon": "mdi:map-marker-radius",
             "entity_category": "diagnostic",
             "device": DEVICE_CONFIG,
-            **AVAILABILITY_CONFIG
+            **AVAILABILITY_CONFIG,
         }
-        
+
         # Network Type sensor (2G/3G/4G/LTE)
         network_type_config = {
             "name": "GSM Network Type",
@@ -1841,7 +1999,7 @@ class MQTTPublisher:
             "icon": "mdi:network",
             "entity_category": "diagnostic",
             "device": DEVICE_CONFIG,
-            **AVAILABILITY_CONFIG
+            **AVAILABILITY_CONFIG,
         }
 
         # Last SMS sensor
@@ -1854,7 +2012,7 @@ class MQTTPublisher:
             "json_attributes_template": "{{ {'Number': value_json.Number, 'timestamp': value_json.timestamp, 'history': value_json.history} | tojson }}",
             "icon": "mdi:message-text",
             "device": DEVICE_CONFIG,
-            **AVAILABILITY_CONFIG
+            **AVAILABILITY_CONFIG,
         }
 
         # Last SMS sender number sensor
@@ -1865,7 +2023,7 @@ class MQTTPublisher:
             "value_template": "{{ value_json.Number }}",
             "icon": "mdi:phone",
             "device": DEVICE_CONFIG,
-            **AVAILABILITY_CONFIG
+            **AVAILABILITY_CONFIG,
         }
 
         # SMS send status sensor
@@ -1877,7 +2035,7 @@ class MQTTPublisher:
             "json_attributes_topic": f"{self.topic_prefix}/send_status",
             "icon": "mdi:send",
             "device": DEVICE_CONFIG,
-            **AVAILABILITY_CONFIG
+            **AVAILABILITY_CONFIG,
         }
 
         # SMS delete status sensor
@@ -1889,7 +2047,7 @@ class MQTTPublisher:
             "json_attributes_topic": f"{self.topic_prefix}/delete_sms_status",
             "icon": "mdi:delete-sweep",
             "device": DEVICE_CONFIG,
-            **AVAILABILITY_CONFIG
+            **AVAILABILITY_CONFIG,
         }
 
         # SMS delivery report sensor (🆕 v2.1.0)
@@ -1901,7 +2059,7 @@ class MQTTPublisher:
             "json_attributes_topic": f"{self.topic_prefix}/delivery_status",
             "icon": "mdi:email-check",
             "device": DEVICE_CONFIG,
-            **AVAILABILITY_CONFIG
+            **AVAILABILITY_CONFIG,
         }
 
         # SMS send button
@@ -1912,7 +2070,7 @@ class MQTTPublisher:
             "payload_press": "PRESS",
             "icon": "mdi:message-plus",
             "device": DEVICE_CONFIG,
-            **AVAILABILITY_CONFIG
+            **AVAILABILITY_CONFIG,
         }
 
         # Flash SMS send button
@@ -1923,7 +2081,7 @@ class MQTTPublisher:
             "payload_press": "PRESS",
             "icon": "mdi:message-flash",
             "device": DEVICE_CONFIG,
-            **AVAILABILITY_CONFIG
+            **AVAILABILITY_CONFIG,
         }
 
         # Phone number input text
@@ -1936,7 +2094,7 @@ class MQTTPublisher:
             "mode": "text",
             "pattern": r"^[\+\d\s\-\(\),]*$",  # Allow + anywhere for multiple international numbers
             "device": DEVICE_CONFIG,
-            **AVAILABILITY_CONFIG
+            **AVAILABILITY_CONFIG,
         }
 
         # Message input text
@@ -1949,7 +2107,7 @@ class MQTTPublisher:
             "mode": "text",
             "max": 255,  # HA text entity max length (Gammu will still split long messages into multiple SMS)
             "device": DEVICE_CONFIG,
-            **AVAILABILITY_CONFIG
+            **AVAILABILITY_CONFIG,
         }
 
         # USSD code input text
@@ -1962,7 +2120,7 @@ class MQTTPublisher:
             "mode": "text",
             "pattern": r"^\*[0-9#\*]+#?$",  # USSD codes start with * followed by digits/# (e.g., *225#, *#100#)
             "device": DEVICE_CONFIG,
-            **AVAILABILITY_CONFIG
+            **AVAILABILITY_CONFIG,
         }
 
         # USSD send button
@@ -1973,7 +2131,7 @@ class MQTTPublisher:
             "payload_press": "PRESS",
             "icon": "mdi:dialpad",
             "device": DEVICE_CONFIG,
-            **AVAILABILITY_CONFIG
+            **AVAILABILITY_CONFIG,
         }
 
         # USSD response sensor
@@ -1985,7 +2143,7 @@ class MQTTPublisher:
             "json_attributes_topic": f"{self.topic_prefix}/ussd_response/state",
             "icon": "mdi:message-reply-text",
             "device": DEVICE_CONFIG,
-            **AVAILABILITY_CONFIG
+            **AVAILABILITY_CONFIG,
         }
 
         # Modem Status sensor
@@ -2004,7 +2162,7 @@ class MQTTPublisher:
             "json_attributes_template": "{{ {'consecutive_failures': value_json.consecutive_failures, 'last_error': value_json.last_error, 'hard_offline': value_json.hard_offline, 'hard_offline_operation': value_json.hard_offline_operation | default(None), 'last_seen': value_json.last_seen} | tojson }}",
             "icon": "mdi:connection",
             "device": DEVICE_CONFIG,
-            **AVAILABILITY_CONFIG
+            **AVAILABILITY_CONFIG,
         }
 
         # SMS Sent Counter sensor
@@ -2017,7 +2175,7 @@ class MQTTPublisher:
             "state_class": "total_increasing",
             "unit_of_measurement": "messages",
             "device": DEVICE_CONFIG,
-            **AVAILABILITY_CONFIG
+            **AVAILABILITY_CONFIG,
         }
 
         # SMS Received Counter sensor
@@ -2030,11 +2188,11 @@ class MQTTPublisher:
             "state_class": "total_increasing",
             "unit_of_measurement": "messages",
             "device": DEVICE_CONFIG,
-            **AVAILABILITY_CONFIG
+            **AVAILABILITY_CONFIG,
         }
 
         # SMS Cost sensor (only if cost > 0)
-        sms_cost_per_message = self.config.get('sms_cost_per_message', 0.0)
+        sms_cost_per_message = self.config.get("sms_cost_per_message", 0.0)
 
         # Reset sent counter button
         reset_counter_button_config = {
@@ -2044,7 +2202,7 @@ class MQTTPublisher:
             "payload_press": "PRESS",
             "icon": "mdi:restart",
             "device": DEVICE_CONFIG,
-            **AVAILABILITY_CONFIG
+            **AVAILABILITY_CONFIG,
         }
 
         # Reset received counter button
@@ -2055,7 +2213,7 @@ class MQTTPublisher:
             "payload_press": "PRESS",
             "icon": "mdi:restart",
             "device": DEVICE_CONFIG,
-            **AVAILABILITY_CONFIG
+            **AVAILABILITY_CONFIG,
         }
 
         # Delete all SMS button
@@ -2066,7 +2224,7 @@ class MQTTPublisher:
             "payload_press": "PRESS",
             "icon": "mdi:delete-sweep",
             "device": DEVICE_CONFIG,
-            **AVAILABILITY_CONFIG
+            **AVAILABILITY_CONFIG,
         }
 
         # Clear delivery reports button
@@ -2077,7 +2235,7 @@ class MQTTPublisher:
             "payload_press": "PRESS",
             "icon": "mdi:email-remove",
             "device": DEVICE_CONFIG,
-            **AVAILABILITY_CONFIG
+            **AVAILABILITY_CONFIG,
         }
 
         # Modem IMEI sensor
@@ -2088,7 +2246,7 @@ class MQTTPublisher:
             "value_template": "{{ value_json.IMEI }}",
             "icon": "mdi:identifier",
             "device": DEVICE_CONFIG,
-            **AVAILABILITY_CONFIG
+            **AVAILABILITY_CONFIG,
         }
 
         # Modem Model sensor
@@ -2099,7 +2257,7 @@ class MQTTPublisher:
             "value_template": "{{ value_json.Manufacturer }} {{ value_json.Model }}",
             "icon": "mdi:cellphone",
             "device": DEVICE_CONFIG,
-            **AVAILABILITY_CONFIG
+            **AVAILABILITY_CONFIG,
         }
 
         # Modem Firmware sensor
@@ -2111,7 +2269,7 @@ class MQTTPublisher:
             "icon": "mdi:chip",
             "entity_category": "diagnostic",
             "device": DEVICE_CONFIG,
-            **AVAILABILITY_CONFIG
+            **AVAILABILITY_CONFIG,
         }
 
         # SIM IMSI sensor
@@ -2122,7 +2280,7 @@ class MQTTPublisher:
             "value_template": "{{ value_json.IMSI }}",
             "icon": "mdi:sim",
             "device": DEVICE_CONFIG,
-            **AVAILABILITY_CONFIG
+            **AVAILABILITY_CONFIG,
         }
 
         # SMS Capacity sensor
@@ -2136,12 +2294,12 @@ class MQTTPublisher:
             "icon": "mdi:email-multiple",
             "state_class": "measurement",
             "device": DEVICE_CONFIG,
-            **AVAILABILITY_CONFIG
+            **AVAILABILITY_CONFIG,
         }
 
         # Balance sensors (only added if balance_sms_enabled is true)
-        balance_currency = self.config.get('balance_currency', 'USD')
-        
+        balance_currency = self.config.get("balance_currency", "USD")
+
         balance_account_config = {
             "name": "Account Balance",
             "unique_id": "sms_gateway_account_balance",
@@ -2152,7 +2310,7 @@ class MQTTPublisher:
             "unit_of_measurement": balance_currency,
             "icon": "mdi:cash",
             "device": DEVICE_CONFIG,
-            **AVAILABILITY_CONFIG
+            **AVAILABILITY_CONFIG,
         }
 
         balance_data_config = {
@@ -2165,7 +2323,7 @@ class MQTTPublisher:
             "unit_of_measurement": "MB",
             "icon": "mdi:database",
             "device": DEVICE_CONFIG,
-            **AVAILABILITY_CONFIG
+            **AVAILABILITY_CONFIG,
         }
 
         balance_minutes_config = {
@@ -2178,7 +2336,7 @@ class MQTTPublisher:
             "icon": "mdi:phone",
             "state_class": "measurement",
             "device": DEVICE_CONFIG,
-            **AVAILABILITY_CONFIG
+            **AVAILABILITY_CONFIG,
         }
 
         balance_messages_config = {
@@ -2190,7 +2348,7 @@ class MQTTPublisher:
             "icon": "mdi:message-text",
             "state_class": "measurement",
             "device": DEVICE_CONFIG,
-            **AVAILABILITY_CONFIG
+            **AVAILABILITY_CONFIG,
         }
 
         balance_expiry_config = {
@@ -2201,7 +2359,7 @@ class MQTTPublisher:
             "device_class": "date",
             "icon": "mdi:calendar-end",
             "device": DEVICE_CONFIG,
-            **AVAILABILITY_CONFIG
+            **AVAILABILITY_CONFIG,
         }
 
         # Publish discovery configs - all using consistent node_id "sms_gateway" for proper grouping
@@ -2212,56 +2370,124 @@ class MQTTPublisher:
             ("homeassistant/sensor/sms_gateway/ber/config", ber_config),
             # Network sensors
             ("homeassistant/sensor/sms_gateway/network/config", network_config),
-            ("homeassistant/sensor/sms_gateway/network_state/config", network_state_config),
-            ("homeassistant/sensor/sms_gateway/network_code/config", network_code_config),
+            (
+                "homeassistant/sensor/sms_gateway/network_state/config",
+                network_state_config,
+            ),
+            (
+                "homeassistant/sensor/sms_gateway/network_code/config",
+                network_code_config,
+            ),
             ("homeassistant/sensor/sms_gateway/cid/config", cid_config),
             ("homeassistant/sensor/sms_gateway/lac/config", lac_config),
             ("homeassistant/sensor/sms_gateway/packet_lac/config", packet_lac_config),
-            ("homeassistant/sensor/sms_gateway/network_type/config", network_type_config),
+            (
+                "homeassistant/sensor/sms_gateway/network_type/config",
+                network_type_config,
+            ),
             # SMS sensors
             ("homeassistant/sensor/sms_gateway/last_sms/config", sms_config),
-            ("homeassistant/sensor/sms_gateway/last_sms_sender/config", sms_sender_config),
+            (
+                "homeassistant/sensor/sms_gateway/last_sms_sender/config",
+                sms_sender_config,
+            ),
             ("homeassistant/sensor/sms_gateway/send_status/config", send_status_config),
-            ("homeassistant/sensor/sms_gateway/delete_status/config", delete_status_config),
-            ("homeassistant/sensor/sms_gateway/delivery_status/config", delivery_report_config),
+            (
+                "homeassistant/sensor/sms_gateway/delete_status/config",
+                delete_status_config,
+            ),
+            (
+                "homeassistant/sensor/sms_gateway/delivery_status/config",
+                delivery_report_config,
+            ),
             ("homeassistant/sensor/sms_gateway/sent_count/config", sms_counter_config),
-            ("homeassistant/sensor/sms_gateway/received_count/config", sms_received_counter_config),
-            ("homeassistant/sensor/sms_gateway/sms_capacity/config", sms_capacity_config),
+            (
+                "homeassistant/sensor/sms_gateway/received_count/config",
+                sms_received_counter_config,
+            ),
+            (
+                "homeassistant/sensor/sms_gateway/sms_capacity/config",
+                sms_capacity_config,
+            ),
             # Modem/SIM sensors
-            ("homeassistant/sensor/sms_gateway/modem_status/config", device_status_config),
+            (
+                "homeassistant/sensor/sms_gateway/modem_status/config",
+                device_status_config,
+            ),
             ("homeassistant/sensor/sms_gateway/modem_imei/config", modem_imei_config),
             ("homeassistant/sensor/sms_gateway/modem_model/config", modem_model_config),
-            ("homeassistant/sensor/sms_gateway/modem_firmware/config", modem_firmware_config),
+            (
+                "homeassistant/sensor/sms_gateway/modem_firmware/config",
+                modem_firmware_config,
+            ),
             ("homeassistant/sensor/sms_gateway/sim_imsi/config", sim_imsi_config),
             # Controls
             ("homeassistant/button/sms_gateway/send_button/config", button_config),
-            ("homeassistant/button/sms_gateway/send_flash_button/config", flash_button_config),
-            ("homeassistant/button/sms_gateway/reset_counter/config", reset_counter_button_config),
-            ("homeassistant/button/sms_gateway/reset_received_counter/config", reset_received_counter_button_config),
-            ("homeassistant/button/sms_gateway/delete_all_sms/config", delete_all_sms_button_config),
-            ("homeassistant/button/sms_gateway/clear_delivery_reports/config", clear_delivery_reports_button_config),
-            ("homeassistant/button/sms_gateway/send_ussd_button/config", ussd_button_config),
+            (
+                "homeassistant/button/sms_gateway/send_flash_button/config",
+                flash_button_config,
+            ),
+            (
+                "homeassistant/button/sms_gateway/reset_counter/config",
+                reset_counter_button_config,
+            ),
+            (
+                "homeassistant/button/sms_gateway/reset_received_counter/config",
+                reset_received_counter_button_config,
+            ),
+            (
+                "homeassistant/button/sms_gateway/delete_all_sms/config",
+                delete_all_sms_button_config,
+            ),
+            (
+                "homeassistant/button/sms_gateway/clear_delivery_reports/config",
+                clear_delivery_reports_button_config,
+            ),
+            (
+                "homeassistant/button/sms_gateway/send_ussd_button/config",
+                ussd_button_config,
+            ),
             ("homeassistant/text/sms_gateway/phone_number/config", phone_text_config),
             ("homeassistant/text/sms_gateway/message_text/config", message_text_config),
             ("homeassistant/text/sms_gateway/ussd_code/config", ussd_code_text_config),
             # USSD response sensor
-            ("homeassistant/sensor/sms_gateway/ussd_response/config", ussd_response_config)
+            (
+                "homeassistant/sensor/sms_gateway/ussd_response/config",
+                ussd_response_config,
+            ),
         ]
 
         # Add balance sensors if enabled
-        if self.config.get('balance_sms_enabled', False):
-            discoveries.extend([
-                ("homeassistant/sensor/sms_gateway/account_balance/config", balance_account_config),
-                ("homeassistant/sensor/sms_gateway/data_remaining/config", balance_data_config),
-                ("homeassistant/sensor/sms_gateway/minutes_remaining/config", balance_minutes_config),
-                ("homeassistant/sensor/sms_gateway/messages_remaining/config", balance_messages_config),
-                ("homeassistant/sensor/sms_gateway/plan_expiry/config", balance_expiry_config),
-            ])
+        if self.config.get("balance_sms_enabled", False):
+            discoveries.extend(
+                [
+                    (
+                        "homeassistant/sensor/sms_gateway/account_balance/config",
+                        balance_account_config,
+                    ),
+                    (
+                        "homeassistant/sensor/sms_gateway/data_remaining/config",
+                        balance_data_config,
+                    ),
+                    (
+                        "homeassistant/sensor/sms_gateway/minutes_remaining/config",
+                        balance_minutes_config,
+                    ),
+                    (
+                        "homeassistant/sensor/sms_gateway/messages_remaining/config",
+                        balance_messages_config,
+                    ),
+                    (
+                        "homeassistant/sensor/sms_gateway/plan_expiry/config",
+                        balance_expiry_config,
+                    ),
+                ]
+            )
             logger.info("💰 Added balance sensors to Home Assistant discovery")
-        
+
         # Add cost sensor only if cost is configured (> 0)
         if sms_cost_per_message > 0:
-            sms_cost_currency = self.config.get('sms_cost_currency', 'CZK')
+            sms_cost_currency = self.config.get("sms_cost_currency", "CZK")
             sms_cost_config = {
                 "name": "SMS Total Cost",
                 "unique_id": "sms_gateway_total_cost",
@@ -2272,12 +2498,14 @@ class MQTTPublisher:
                 "device_class": "monetary",
                 "state_class": "total",
                 "device": DEVICE_CONFIG,
-                **AVAILABILITY_CONFIG
+                **AVAILABILITY_CONFIG,
             }
-            discoveries.append(("homeassistant/sensor/sms_gateway/total_cost/config", sms_cost_config))
+            discoveries.append(
+                ("homeassistant/sensor/sms_gateway/total_cost/config", sms_cost_config)
+            )
 
         # Add call monitoring sensors if enabled
-        if self.config.get('missed_calls_monitoring_enabled', False):
+        if self.config.get("missed_calls_monitoring_enabled", False):
             # Binary sensor - Incoming Call (real-time ringing detection)
             incoming_call_config = {
                 "name": "Incoming Call",
@@ -2290,7 +2518,7 @@ class MQTTPublisher:
                 "icon": "mdi:phone-ring",
                 "device_class": "sound",
                 "device": DEVICE_CONFIG,
-                **AVAILABILITY_CONFIG
+                **AVAILABILITY_CONFIG,
             }
 
             # Sensor - Last Missed Call (with extended attributes)
@@ -2302,207 +2530,252 @@ class MQTTPublisher:
                 "json_attributes_topic": f"{self.topic_prefix}/missed_call/state",
                 "icon": "mdi:phone-missed",
                 "device": DEVICE_CONFIG,
-                **AVAILABILITY_CONFIG
+                **AVAILABILITY_CONFIG,
             }
 
-            discoveries.extend([
-                ("homeassistant/binary_sensor/sms_gateway/incoming_call/config",
-                 incoming_call_config),
-                ("homeassistant/sensor/sms_gateway/last_missed_call/config",
-                 missed_call_config),
-            ])
+            discoveries.extend(
+                [
+                    (
+                        "homeassistant/binary_sensor/sms_gateway/incoming_call/config",
+                        incoming_call_config,
+                    ),
+                    (
+                        "homeassistant/sensor/sms_gateway/last_missed_call/config",
+                        missed_call_config,
+                    ),
+                ]
+            )
             logger.info("📞 Added call monitoring sensors to Home Assistant discovery")
 
         for topic, config in discoveries:
             self.client.publish(topic, json.dumps(config), retain=True, qos=1)
-        
+
         logger.info("Published MQTT discovery configurations including SMS send button")
-        
+
         # Publish initial states immediately after discovery
         self._publish_initial_states()
 
         # Give HA a moment to process discovery and send retained state messages back to us
         import time
+
         time.sleep(1)
-        
+
         # Now restore SMS history after HA has processed discovery
         self._restore_sms_history()
-        
+
         # Restore missed call history if call monitoring is enabled
         self._restore_missed_call_history()
-        
+
         # Restore balance data if balance parsing is enabled
         self._restore_balance_data()
-    
-    def publish_signal_strength(self, signal_data: Dict[str, Any], silent: bool = False):
+
+    def publish_signal_strength(
+        self, signal_data: Dict[str, Any], silent: bool = False
+    ):
         """Publish signal strength data"""
         if not self.connected:
             return
-            
+
         topic = f"{self.topic_prefix}/signal/state"
         self.client.publish(topic, json.dumps(signal_data), retain=True)
-        
+
         if not silent:
             # Normal logging: show both signal level sensors
-            signal_percent = signal_data.get('SignalPercent', 'N/A')
-            signal_dbm = signal_data.get('SignalStrength', 'N/A')
-            logger.info(f"📡 Published signal strength to MQTT: {signal_percent}% ({signal_dbm} dBm)")
-            
+            signal_percent = signal_data.get("SignalPercent", "N/A")
+            signal_dbm = signal_data.get("SignalStrength", "N/A")
+            logger.info(
+                f"📡 Published signal strength to MQTT: {signal_percent}% ({signal_dbm} dBm)"
+            )
+
             # Verbose/debug logging: show all sensor data
-            ber = signal_data.get('BitErrorRate', 'N/A')
-            logger.debug(f"   📊 Signal details: Percent={signal_percent}%, dBm={signal_dbm}, BER={ber}")
-    
+            ber = signal_data.get("BitErrorRate", "N/A")
+            logger.debug(
+                f"   📊 Signal details: Percent={signal_percent}%, dBm={signal_dbm}, BER={ber}"
+            )
+
     def publish_network_info(self, network_data: Dict[str, Any], silent: bool = False):
         """Publish network information"""
         if not self.connected:
             return
-        
+
         # Ensure NetworkType is included (default to Unknown if not present)
-        if 'NetworkType' not in network_data:
-            network_data['NetworkType'] = 'Unknown'
-            
+        if "NetworkType" not in network_data:
+            network_data["NetworkType"] = "Unknown"
+
         topic = f"{self.topic_prefix}/network/state"
         self.client.publish(topic, json.dumps(network_data), retain=True)
-        
+
         if not silent:
-            network_type = network_data.get('NetworkType', 'Unknown')
-            network_name = network_data.get('NetworkName', 'Unknown')
-            logger.info(f"📡 Published network info to MQTT: {network_name} ({network_type})")
-            
+            network_type = network_data.get("NetworkType", "Unknown")
+            network_name = network_data.get("NetworkName", "Unknown")
+            logger.info(
+                f"📡 Published network info to MQTT: {network_name} ({network_type})"
+            )
+
             # Verbose/debug logging: show all network sensor data
-            network_code = network_data.get('NetworkCode', 'N/A')
-            state = network_data.get('State', 'N/A')
-            lac = network_data.get('LAC', 'N/A')
-            packet_lac = network_data.get('PacketLAC', 'N/A')
-            cell_id = network_data.get('CID', 'N/A')
-            logger.debug(f"   📡 Network details: Code={network_code}, State={state}, Type={network_type}, LAC={lac}, PacketLAC={packet_lac}, CID={cell_id}")
-    
-    def publish_status_combined(self, signal_data: Dict[str, Any], network_data: Dict[str, Any]):
+            network_code = network_data.get("NetworkCode", "N/A")
+            state = network_data.get("State", "N/A")
+            lac = network_data.get("LAC", "N/A")
+            packet_lac = network_data.get("PacketLAC", "N/A")
+            cell_id = network_data.get("CID", "N/A")
+            logger.debug(
+                f"   📡 Network details: Code={network_code}, State={state}, Type={network_type}, LAC={lac}, PacketLAC={packet_lac}, CID={cell_id}"
+            )
+
+    def publish_status_combined(
+        self, signal_data: Dict[str, Any], network_data: Dict[str, Any]
+    ):
         """Publish both signal strength and network info with combined logging"""
         if not self.connected:
             return
-        
+
         # Publish both silently
         self.publish_signal_strength(signal_data, silent=True)
         self.publish_network_info(network_data, silent=True)
-        
+
         # Combined log message
-        signal_percent = signal_data.get('SignalPercent', 'N/A')
-        signal_dbm = signal_data.get('SignalStrength', 'N/A')
-        network_name = network_data.get('NetworkName', 'Unknown')
-        network_type = network_data.get('NetworkType', 'Unknown')
-        logger.info(f"📡 Status update: {signal_percent}% ({signal_dbm} dBm) | {network_name} ({network_type})")
-        
+        signal_percent = signal_data.get("SignalPercent", "N/A")
+        signal_dbm = signal_data.get("SignalStrength", "N/A")
+        network_name = network_data.get("NetworkName", "Unknown")
+        network_type = network_data.get("NetworkType", "Unknown")
+        logger.info(
+            f"📡 Status update: {signal_percent}% ({signal_dbm} dBm) | {network_name} ({network_type})"
+        )
+
         # Verbose/debug logging: show all sensor details
-        ber = signal_data.get('BitErrorRate', 'N/A')
-        network_code = network_data.get('NetworkCode', 'N/A')
-        state = network_data.get('State', 'N/A')
-        lac = network_data.get('LAC', 'N/A')
-        packet_lac = network_data.get('PacketLAC', 'N/A')
-        cell_id = network_data.get('CID', 'N/A')
-        logger.debug(f"   📊 Signal: Percent={signal_percent}%, dBm={signal_dbm}, BER={ber}")
-        logger.debug(f"   📡 Network: Code={network_code}, State={state}, Type={network_type}, LAC={lac}, PacketLAC={packet_lac}, CID={cell_id}")
-    
+        ber = signal_data.get("BitErrorRate", "N/A")
+        network_code = network_data.get("NetworkCode", "N/A")
+        state = network_data.get("State", "N/A")
+        lac = network_data.get("LAC", "N/A")
+        packet_lac = network_data.get("PacketLAC", "N/A")
+        cell_id = network_data.get("CID", "N/A")
+        logger.debug(
+            f"   📊 Signal: Percent={signal_percent}%, dBm={signal_dbm}, BER={ber}"
+        )
+        logger.debug(
+            f"   📡 Network: Code={network_code}, State={state}, Type={network_type}, LAC={lac}, PacketLAC={packet_lac}, CID={cell_id}"
+        )
+
     def publish_sms_received(self, sms_data: Dict[str, Any]):
         """Publish received SMS data and fire Home Assistant event"""
         if not self.connected:
             return
-            
+
         # Add timestamp
-        timestamp = time.strftime('%Y-%m-%d %H:%M:%S')
-        sms_data['timestamp'] = timestamp
-        
+        timestamp = time.strftime("%Y-%m-%d %H:%M:%S")
+        sms_data["timestamp"] = timestamp
+
         # Increment received counter
         new_count = self.sms_counter.increment_received()
         self.publish_sms_received_counter()
         logger.debug(f"📊 SMS received counter incremented to {new_count}")
-        
+
         # Check if this is a balance SMS and parse it
         if self.balance_parser:
-            sender = sms_data.get('Number', '')
-            message_text = sms_data.get('Text', '')
-            expected_sender = self.config.get('balance_sms_sender', '7069')
-            balance_keywords = self.config.get('balance_keywords', ['Balance', 'balance'])
-            
+            sender = sms_data.get("Number", "")
+            message_text = sms_data.get("Text", "")
+            expected_sender = self.config.get("balance_sms_sender", "7069")
+            balance_keywords = self.config.get(
+                "balance_keywords", ["Balance", "balance"]
+            )
+
             # Check if SMS is from balance sender and contains balance keywords
-            if sender == expected_sender and any(keyword in message_text for keyword in balance_keywords):
+            if sender == expected_sender and any(
+                keyword in message_text for keyword in balance_keywords
+            ):
                 logger.info(f"💰 Detected balance SMS from {sender}")
                 balance_data = self.balance_parser.parse_balance_sms(message_text)
                 # Publish balance data immediately
                 self.publish_balance_info(balance_data)
-        
+
         # Add message to history
         self.sms_history.add_message(
-            number=sms_data.get('Number', 'Unknown'),
-            text=sms_data.get('Text', ''),
-            timestamp=timestamp
+            number=sms_data.get("Number", "Unknown"),
+            text=sms_data.get("Text", ""),
+            timestamp=timestamp,
         )
-        
+
         # Include history in published data
-        sms_data['history'] = self.sms_history.get_history()
-        
+        sms_data["history"] = self.sms_history.get_history()
+
         topic = f"{self.topic_prefix}/sms/state"
         self.client.publish(topic, json.dumps(sms_data), qos=1, retain=True)
-        
+
         # Fire Home Assistant event for reliable automation triggering
         self.fire_ha_event(sms_data)
-        
-        logger.info(f"📡 Published SMS to MQTT: {sms_data.get('Number', 'Unknown')} -> {sms_data.get('Text', '')}")
-    
+
+        logger.info(
+            f"📡 Published SMS to MQTT: {sms_data.get('Number', 'Unknown')} -> {sms_data.get('Text', '')}"
+        )
+
     def fire_ha_event(self, sms_data: Dict[str, Any]):
         """Fire a Home Assistant event for received SMS using HTTP API"""
         # Prepare event data - field names match deprecated legacy_gsm_sms integration
         # for backwards compatibility: phone, text, date (+ timestamp, state for extra info)
         event_data = {
-            "phone": sms_data.get('Number', 'Unknown'),  # Matches deprecated integration
-            "text": sms_data.get('Text', ''),            # Matches deprecated integration
-            "date": sms_data.get('Date', ''),            # Matches deprecated integration
-            "timestamp": sms_data.get('timestamp', ''),  # Additional field for unix timestamp
-            "state": sms_data.get('State', 'UnRead')     # Additional field for SMS state
+            "phone": sms_data.get(
+                "Number", "Unknown"
+            ),  # Matches deprecated integration
+            "text": sms_data.get("Text", ""),  # Matches deprecated integration
+            "date": sms_data.get("Date", ""),  # Matches deprecated integration
+            "timestamp": sms_data.get(
+                "timestamp", ""
+            ),  # Additional field for unix timestamp
+            "state": sms_data.get("State", "UnRead"),  # Additional field for SMS state
         }
-        
-        logger.info(f"🔔 Attempting to fire HA event for SMS from {event_data['phone']}")
-        
+
+        logger.info(
+            f"🔔 Attempting to fire HA event for SMS from {event_data['phone']}"
+        )
+
         try:
             # Use Home Assistant API - requires homeassistant_api: true in config.yaml
-            ha_token = os.environ.get('SUPERVISOR_TOKEN', '')
+            ha_token = os.environ.get("SUPERVISOR_TOKEN", "")
             if not ha_token:
                 logger.error("❌ No SUPERVISOR_TOKEN found - cannot fire HA event")
                 return
-            
+
             # Use supervisor proxy to HA Core API (same as standalone addon)
             ha_url = "http://supervisor/core/api"
             url = f"{ha_url}/events/sms_gateway_message_received"
             headers = {
-                'Authorization': f'Bearer {ha_token}',
-                'Content-Type': 'application/json'
+                "Authorization": f"Bearer {ha_token}",
+                "Content-Type": "application/json",
             }
-            
+
             logger.debug(f"Posting to {url} with token length: {len(ha_token)}")
             response = requests.post(url, headers=headers, json=event_data, timeout=5)
-            
+
             if response.status_code in [200, 201]:
-                logger.info(f"✅ Successfully fired Home Assistant event: sms_gateway_message_received from {event_data['phone']}")
+                logger.info(
+                    f"✅ Successfully fired Home Assistant event: sms_gateway_message_received from {event_data['phone']}"
+                )
             else:
-                logger.error(f"❌ Failed to fire HA event: HTTP {response.status_code} - {response.text}")
-                
+                logger.error(
+                    f"❌ Failed to fire HA event: HTTP {response.status_code} - {response.text}"
+                )
+
         except requests.exceptions.RequestException as e:
             logger.error(f"❌ Network error firing HA event: {e}")
         except Exception as e:
             logger.error(f"❌ Unexpected error firing HA event: {e}", exc_info=True)
-    
+
     def publish_device_status(self):
         """Publish USB device connectivity status"""
         status_data = self.device_tracker.get_status_data()
-        status = status_data.get('status')
+        status = status_data.get("status")
 
         # Always log status changes, even if MQTT is disconnected
-        if hasattr(self, '_last_device_status') and self._last_device_status != status:
-            if status == 'online':
-                logger.info(f"📶 Modem: ONLINE (after {status_data.get('consecutive_failures', 0)} failures)")
-            elif status == 'offline':
-                logger.warning(f"❌ Modem: OFFLINE (no response for {status_data.get('seconds_since_last_success', 0)}s)")
-            elif status == 'unknown':
+        if hasattr(self, "_last_device_status") and self._last_device_status != status:
+            if status == "online":
+                logger.info(
+                    f"📶 Modem: ONLINE (after {status_data.get('consecutive_failures', 0)} failures)"
+                )
+            elif status == "offline":
+                logger.warning(
+                    f"❌ Modem: OFFLINE (no response for {status_data.get('seconds_since_last_success', 0)}s)"
+                )
+            elif status == "unknown":
                 logger.info("❓ Modem: UNKNOWN (no communication attempts yet)")
 
         self._last_device_status = status
@@ -2513,42 +2786,60 @@ class MQTTPublisher:
         # - total_operations / successful_operations: increment every successful operation
         # - last_seen: updates every successful operation
         # Only publish when event-driven fields change (status, failures, errors, hard_offline)
-        _volatile_fields = {'seconds_since_last_success', 'total_operations', 'successful_operations', 'last_seen'}
-        stable_data = {k: v for k, v in status_data.items() if k not in _volatile_fields}
-        if hasattr(self, '_last_published_stable_data') and self._last_published_stable_data == stable_data:
-            logger.debug("Device status data unchanged (excluding volatile fields), skipping redundant MQTT publish")
+        _volatile_fields = {
+            "seconds_since_last_success",
+            "total_operations",
+            "successful_operations",
+            "last_seen",
+        }
+        stable_data = {
+            k: v for k, v in status_data.items() if k not in _volatile_fields
+        }
+        if (
+            hasattr(self, "_last_published_stable_data")
+            and self._last_published_stable_data == stable_data
+        ):
+            logger.debug(
+                "Device status data unchanged (excluding volatile fields), skipping redundant MQTT publish"
+            )
             return
 
         # Publish to MQTT if connected
         if self.connected:
             topic = f"{self.topic_prefix}/device_status/state"
             self.client.publish(topic, json.dumps(status_data), retain=True, qos=1)
-            self._last_published_stable_data = stable_data.copy()  # Cache stable fields for dedup
+            self._last_published_stable_data = (
+                stable_data.copy()
+            )  # Cache stable fields for dedup
             logger.debug(f"📡 Published device status to MQTT: {status}")
         else:
-            logger.debug("Device status changed but MQTT not connected, skipping publish")
-    
+            logger.debug(
+                "Device status changed but MQTT not connected, skipping publish"
+            )
+
     def cache_smsc(self):
         """Cache SMSC number from modem for reliable SMS sending"""
         if not self.gammu_machine:
             return False
-        
+
         try:
             smsc_info = self.gammu_machine.GetSMSC(Location=1)
-            if smsc_info and smsc_info.get('Number'):
-                self.cached_smsc = smsc_info['Number']
+            if smsc_info and smsc_info.get("Number"):
+                self.cached_smsc = smsc_info["Number"]
                 self.smsc_cache_time = time.time()
                 logger.info(f"📞 Cached SMSC: {self.cached_smsc}")
                 return True
         except Exception as e:
             logger.warning(f"⚠️ Failed to cache SMSC: {e}")
         return False
-    
+
     def get_cached_smsc(self):
         """Get cached SMSC, refresh if expired"""
-        if (self.cached_smsc is None or 
-            self.smsc_cache_time is None or
-            time.time() - self.smsc_cache_time > self.smsc_cache_ttl):
+        if (
+            self.cached_smsc is None
+            or self.smsc_cache_time is None
+            or time.time() - self.smsc_cache_time > self.smsc_cache_ttl
+        ):
             self.cache_smsc()
         return self.cached_smsc
 
@@ -2565,70 +2856,68 @@ class MQTTPublisher:
         if not pending:
             logger.info("📥 No pending SMS to process")
             return
-        
+
         logger.info(f"📥 Processing {len(pending)} pending SMS from queue...")
-        
+
         for msg in pending:
-            number = msg.get('number')
-            text = msg.get('text')
-            smsc = msg.get('smsc')
-            attempts = msg.get('attempts', 0)
-            
-            logger.info(f"📤 Attempting to send queued SMS to {number} "
-                        f"(attempt #{attempts + 1})")
-            
+            number = msg.get("number")
+            text = msg.get("text")
+            smsc = msg.get("smsc")
+            attempts = msg.get("attempts", 0)
+
+            logger.info(
+                f"📤 Attempting to send queued SMS to {number} "
+                f"(attempt #{attempts + 1})"
+            )
+
             try:
                 from gammu import EncodeSMS
-                
+
                 # Build SMS message
                 smsinfo = {
-                    'Class': -1,
-                    'Unicode': False,
-                    'Entries': [
-                        {'ID': 'ConcatenatedTextLong', 'Buffer': text}
-                    ]
+                    "Class": -1,
+                    "Unicode": False,
+                    "Entries": [{"ID": "ConcatenatedTextLong", "Buffer": text}],
                 }
-                
+
                 # Detect if unicode needed
                 if detect_unicode_needed(text):
-                    smsinfo['Unicode'] = True
-                
+                    smsinfo["Unicode"] = True
+
                 # Encode and send
                 messages = EncodeSMS(smsinfo)
                 success = True
-                
+
                 for message in messages:
                     if smsc:
-                        message['SMSC'] = {'Number': smsc}
+                        message["SMSC"] = {"Number": smsc}
                     elif self.cached_smsc:
-                        message['SMSC'] = {'Number': self.cached_smsc}
+                        message["SMSC"] = {"Number": self.cached_smsc}
                     else:
-                        message['SMSC'] = {'Location': 1}
-                    
-                    message['Number'] = number
-                    
+                        message["SMSC"] = {"Location": 1}
+
+                    message["Number"] = number
+
                     try:
                         self.track_gammu_operation(
-                            "SendSMS",
-                            self.gammu_machine.SendSMS,
-                            message
+                            "SendSMS", self.gammu_machine.SendSMS, message
                         )
                     except Exception as e:
                         logger.error(f"❌ Failed to send queued SMS to {number}: {e}")
                         self.sms_queue.increment_attempts(number, text)
                         success = False
                         break
-                
+
                 if success:
                     # Successfully sent - remove from queue
                     self.sms_queue.remove(number, text)
                     self.sms_counter.increment()
                     logger.info(f"✅ Queued SMS sent successfully to {number}")
-                    
+
             except Exception as e:
                 logger.error(f"❌ Error processing queued SMS for {number}: {e}")
                 self.sms_queue.increment_attempts(number, text)
-        
+
         # Publish updated counter after processing queue
         self.publish_sms_counter()
         remaining = self.sms_queue.get_count()
@@ -2641,13 +2930,10 @@ class MQTTPublisher:
             return
 
         count = self.sms_counter.get_sent_count()
-        sms_cost_per_message = self.config.get('sms_cost_per_message', 0.0)
+        sms_cost_per_message = self.config.get("sms_cost_per_message", 0.0)
         total_cost = count * sms_cost_per_message
 
-        counter_data = {
-            "count": count,
-            "cost": round(total_cost, 2)
-        }
+        counter_data = {"count": count, "cost": round(total_cost, 2)}
 
         topic = f"{self.topic_prefix}/sms_counter/state"
         self.client.publish(topic, json.dumps(counter_data), retain=True)
@@ -2660,9 +2946,7 @@ class MQTTPublisher:
 
         count = self.sms_counter.get_received_count()
 
-        counter_data = {
-            "count": count
-        }
+        counter_data = {"count": count}
 
         topic = f"{self.topic_prefix}/sms_received_counter/state"
         self.client.publish(topic, json.dumps(counter_data), retain=True)
@@ -2675,7 +2959,9 @@ class MQTTPublisher:
 
         topic = f"{self.topic_prefix}/modem_info/state"
         self.client.publish(topic, json.dumps(modem_data), retain=True)
-        logger.info(f"📡 Published modem info to MQTT: {modem_data.get('Manufacturer', 'Unknown')} {modem_data.get('Model', 'Unknown')}")
+        logger.info(
+            f"📡 Published modem info to MQTT: {modem_data.get('Manufacturer', 'Unknown')} {modem_data.get('Model', 'Unknown')}"
+        )
 
     def publish_sim_info(self, sim_data: Dict[str, Any]):
         """Publish SIM card information"""
@@ -2684,7 +2970,9 @@ class MQTTPublisher:
 
         topic = f"{self.topic_prefix}/sim_info/state"
         self.client.publish(topic, json.dumps(sim_data), retain=True)
-        logger.info(f"📡 Published SIM info to MQTT: IMSI={sim_data.get('IMSI', 'Unknown')}")
+        logger.info(
+            f"📡 Published SIM info to MQTT: IMSI={sim_data.get('IMSI', 'Unknown')}"
+        )
 
     def publish_sms_capacity(self, capacity_data: Dict[str, Any]):
         """Publish SMS storage capacity"""
@@ -2693,53 +2981,57 @@ class MQTTPublisher:
 
         topic = f"{self.topic_prefix}/sms_capacity/state"
         self.client.publish(topic, json.dumps(capacity_data), retain=True)
-        logger.info(f"📡 Published SMS capacity to MQTT: {capacity_data.get('SIMUsed', 0)}/{capacity_data.get('SIMSize', 0)}")
-    
+        logger.info(
+            f"📡 Published SMS capacity to MQTT: {capacity_data.get('SIMUsed', 0)}/{capacity_data.get('SIMSize', 0)}"
+        )
+
     def publish_balance_info(self, balance_data: Dict[str, Any]):
         """Publish account balance information parsed from SMS"""
         if not self.connected:
             return
-        
+
         topic = f"{self.topic_prefix}/balance/state"
         self.client.publish(topic, json.dumps(balance_data), retain=True)
-        
+
         # Log readable summary
         summary_parts = []
-        if balance_data.get('account_balance'):
+        if balance_data.get("account_balance"):
             summary_parts.append(f"Balance: {balance_data['account_balance']}")
-        if balance_data.get('data_remaining'):
+        if balance_data.get("data_remaining"):
             summary_parts.append(f"Data: {balance_data['data_remaining']}")
-        if balance_data.get('minutes_remaining'):
+        if balance_data.get("minutes_remaining"):
             summary_parts.append(f"Minutes: {balance_data['minutes_remaining']}")
-        if balance_data.get('messages_remaining'):
+        if balance_data.get("messages_remaining"):
             summary_parts.append(f"Messages: {balance_data['messages_remaining']}")
-        if balance_data.get('plan_expiry'):
+        if balance_data.get("plan_expiry"):
             summary_parts.append(f"Expires: {balance_data['plan_expiry']}")
-        
+
         summary = ", ".join(summary_parts) if summary_parts else "No data parsed"
         logger.info(f"💰 Published balance info to MQTT: {summary}")
-    
+
     def publish_delivery_pending(self, message_refs, number):
         """Publish pending delivery status"""
         if not self.connected or not message_refs:
             return
-        
+
         topic = f"{self.topic_prefix}/delivery_status"
         status_data = {
             "status": "pending",
             "message_refs": message_refs,
             "number": number,
             "pending_count": self.delivery_tracker.get_pending_count(),
-            "timestamp": time.strftime("%Y-%m-%d %H:%M:%S")
+            "timestamp": time.strftime("%Y-%m-%d %H:%M:%S"),
         }
         self.client.publish(topic, json.dumps(status_data), retain=True)
-        logger.info(f"📬 Published pending delivery status for {len(message_refs)} message(s) to {number}")
-    
+        logger.info(
+            f"📬 Published pending delivery status for {len(message_refs)} message(s) to {number}"
+        )
+
     def publish_delivery_report(self, message_ref, status, delivery_info):
         """Publish delivery report when received"""
         if not self.connected:
             return
-        
+
         topic = f"{self.topic_prefix}/delivery_status"
         status_data = {
             "status": status,
@@ -2749,26 +3041,28 @@ class MQTTPublisher:
             "sent_timestamp": delivery_info.get("sent_timestamp", ""),
             "delivered_timestamp": delivery_info.get("delivered_timestamp", ""),
             "pending_count": self.delivery_tracker.get_pending_count(),
-            "timestamp": time.strftime("%Y-%m-%d %H:%M:%S")
+            "timestamp": time.strftime("%Y-%m-%d %H:%M:%S"),
         }
         self.client.publish(topic, json.dumps(status_data), retain=True)
         logger.info(f"📬 Published delivery report: ref={message_ref}, status={status}")
-    
+
     def _attempt_reconnect_if_needed(self):
         """Attempt to reconnect to modem if auto_recovery is enabled and threshold is reached"""
         if not self.auto_recovery:
             return
-        
+
         if self.consecutive_failures < self.reconnect_threshold:
             return
-        
+
         current_time = time.time()
         if current_time - self.last_reconnect_attempt < self.reconnect_cooldown:
             return  # Still in cooldown period
-        
+
         self.last_reconnect_attempt = current_time
-        logger.warning(f"🔄 Attempting automatic modem reconnection after {self.consecutive_failures} failures...")
-        
+        logger.warning(
+            f"🔄 Attempting automatic modem reconnection after {self.consecutive_failures} failures..."
+        )
+
         if self._reconnect_gammu():
             logger.info("✅ Automatic modem reconnection successful!")
             self.consecutive_failures = 0
@@ -2776,17 +3070,20 @@ class MQTTPublisher:
             # The reconnect may succeed but modem can still be in bad state.
             # Only reset on actual successful Gammu operation (in track_gammu_operation)
         else:
-            logger.error(f"❌ Automatic modem reconnection failed. Will retry in {self.reconnect_cooldown}s")
+            logger.error(
+                f"❌ Automatic modem reconnection failed. Will retry in {self.reconnect_cooldown}s"
+            )
             # Track failure time for restart timeout (applies to ALL errors, not just specific codes)
             self._check_restart_timeout()
-    
+
     def _reconnect_gammu(self):
         """Attempt to re-initialize Gammu state machine"""
         try:
             from support import init_state_machine
-            pin = self.config.get('pin', '')
-            device_path = self.config.get('device_path', '/dev/ttyUSB0')
-            
+
+            pin = self.config.get("pin", "")
+            device_path = self.config.get("device_path", "/dev/ttyUSB0")
+
             # Acquire lock to prevent other threads from using modem during reinit
             with self.gammu_lock:
                 # CRITICAL: Close existing connection first to release the serial port
@@ -2796,11 +3093,13 @@ class MQTTPublisher:
                         self.gammu_machine.Terminate()
                         logger.info("✅ Existing connection terminated")
                     except Exception as e:
-                        logger.warning(f"⚠️ Terminate failed (may already be closed): {e}")
-                
+                        logger.warning(
+                            f"⚠️ Terminate failed (may already be closed): {e}"
+                        )
+
                 logger.info(f"🔌 Re-initializing Gammu with device: {device_path}")
                 new_machine = init_state_machine(pin, device_path)
-                
+
                 # Test the new connection with a simple operation
                 try:
                     new_machine.GetManufacturer()
@@ -2810,73 +3109,85 @@ class MQTTPublisher:
                 except Exception as e:
                     logger.error(f"❌ Reconnected machine failed test: {e}")
                     return False
-                
+
         except Exception as e:
             logger.error(f"❌ Failed to re-initialize Gammu: {e}")
             return False
 
     def _check_restart_timeout(self):
         """Check if failure duration exceeds restart timeout and trigger restart if needed.
-        
+
         This is called for ALL failures (not just specific error codes) to ensure
         the addon restarts after prolonged modem problems of any kind.
-        
+
         Uses shorter timeout when in hard_offline state (modem completely frozen).
         """
         if not self.auto_restart_on_failure:
             return
-        
+
         current_time = time.time()
         if self.failure_start_time is None:
             self.failure_start_time = current_time
             logger.info(f"⏱️ Failure tracking started at {time.strftime('%H:%M:%S')}")
-        
+
         failure_duration = current_time - self.failure_start_time
-        
+
         # Use shorter timeout when modem is in hard offline state (completely frozen)
         is_hard_offline = self.device_tracker.hard_offline
-        effective_timeout = self.hard_offline_restart_timeout if is_hard_offline else self.restart_timeout
+        effective_timeout = (
+            self.hard_offline_restart_timeout
+            if is_hard_offline
+            else self.restart_timeout
+        )
         timeout_type = "hard offline" if is_hard_offline else "standard"
-        
-        logger.info(f"⏱️ Modem failing for {int(failure_duration)}s "
-                    f"(restart after {effective_timeout}s, {timeout_type})")
-        
+
+        logger.info(
+            f"⏱️ Modem failing for {int(failure_duration)}s "
+            f"(restart after {effective_timeout}s, {timeout_type})"
+        )
+
         if failure_duration >= effective_timeout:
             logger.error(
                 f"🔴 Modem failed for {int(failure_duration)}s - triggering restart!"
             )
             time.sleep(2)  # Brief pause for logs to flush
             os._exit(1)  # Force exit even from threads - HA Supervisor will restart us
-    
+
     def _trigger_emergency_reset(self, error_code=None):
         """Emergency modem reset for hung state recovery - full reconnect or restart"""
         logger.warning("🚨 Triggering emergency modem recovery...")
-        
+
         # Check for device I/O errors (USB is broken - addon restart is the only fix)
         # Code 2: ERR_DEVICEOPENERROR - device unavailable
         # Code 11: ERR_DEVICEWRITEERROR - error writing to device
         if error_code in (2, 11):
-            error_names = {2: 'Device unavailable', 11: 'Device write error'}
-            logger.error(f"🔴 {error_names.get(error_code, 'Device error')} "
-                         "(USB broken) - restart required!")
+            error_names = {2: "Device unavailable", 11: "Device write error"}
+            logger.error(
+                f"🔴 {error_names.get(error_code, 'Device error')} "
+                "(USB broken) - restart required!"
+            )
             if self.auto_restart_on_failure:
                 logger.warning("🔄 Auto-restarting addon to recover device...")
                 time.sleep(2)  # Brief pause for logs to flush
-                os._exit(1)  # Force exit even from threads - HA Supervisor will restart us
+                os._exit(
+                    1
+                )  # Force exit even from threads - HA Supervisor will restart us
             else:
                 logger.warning("⚠️ Auto-restart disabled, manual intervention required")
                 return False
-        
+
         # Track continuous failure time for timeout-based restart
         current_time = time.time()
         if self.failure_start_time is None:
             self.failure_start_time = current_time
             logger.info(f"⏱️ Failure tracking started at {time.strftime('%H:%M:%S')}")
-        
+
         failure_duration = current_time - self.failure_start_time
-        logger.info(f"⏱️ Modem failing for {int(failure_duration)}s "
-                    f"(restart after {self.restart_timeout}s)")
-        
+        logger.info(
+            f"⏱️ Modem failing for {int(failure_duration)}s "
+            f"(restart after {self.restart_timeout}s)"
+        )
+
         # Check if we've exceeded the restart timeout
         if failure_duration >= self.restart_timeout and self.auto_restart_on_failure:
             logger.error(
@@ -2884,18 +3195,18 @@ class MQTTPublisher:
             )
             time.sleep(2)  # Brief pause for logs to flush
             os._exit(1)  # Force exit even from threads - HA Supervisor will restart us
-        
+
         # Clear SMSC cache first
         self.cached_smsc = None
         self.smsc_cache_time = None
         logger.info("🔄 SMSC cache cleared")
-        
+
         # Try soft reset first (faster if it works)
         try:
             self.gammu_machine.Reset(False)
             logger.info("✅ Soft reset completed, waiting 10s...")
             time.sleep(10)
-            
+
             # Test if modem responds after soft reset
             try:
                 self.gammu_machine.GetManufacturer()
@@ -2908,7 +3219,7 @@ class MQTTPublisher:
                 logger.warning("⚠️ Modem still unresponsive, trying full reconnect...")
         except Exception as e:
             logger.warning(f"⚠️ Soft reset failed: {e}, trying full reconnect...")
-        
+
         # Full reconnect if soft reset didn't work
         if self._reconnect_gammu():
             logger.info("✅ Full modem reconnect successful, waiting 5s...")
@@ -2920,7 +3231,7 @@ class MQTTPublisher:
         else:
             logger.error("❌ Full modem reconnect failed")
             return False
-        
+
     def track_gammu_operation(self, operation_name, gammu_function, *args, **kwargs):
         """Execute gammu operation with connectivity tracking, thread safety, and Python-level timeout"""
         # Use lock to serialize all Gammu operations (prevent race conditions on serial port)
@@ -2930,8 +3241,10 @@ class MQTTPublisher:
             if self.device_tracker.hard_offline:
                 logger.debug(f"Skipping {operation_name} - modem in hard_offline state")
                 self._check_restart_timeout()
-                raise TimeoutError(f"Modem in hard_offline state, skipping {operation_name}")
-            
+                raise TimeoutError(
+                    f"Modem in hard_offline state, skipping {operation_name}"
+                )
+
             # Use ThreadPoolExecutor WITHOUT context manager to avoid shutdown(wait=True)
             # which would block until the hung thread completes (could be minutes!)
             executor = concurrent.futures.ThreadPoolExecutor(max_workers=1)
@@ -2941,13 +3254,13 @@ class MQTTPublisher:
                     # Python-level timeout (15s) as second defense layer
                     # Primary defense is Gammu commtimeout=10s in config
                     result = future.result(timeout=15)
-                    
+
                     # Check if we were previously failing (modem recovered)
                     was_failing = self.failure_start_time is not None
-                    
+
                     self.device_tracker.record_success(operation_name=operation_name)
                     self.consecutive_failures = 0  # Reset failure counter on success
-                    
+
                     # Only reset restart timer if NOT in hard_offline state
                     # In hard_offline, we want the timer to keep running until restart
                     if not self.device_tracker.hard_offline:
@@ -2955,18 +3268,18 @@ class MQTTPublisher:
                     else:
                         # Still in hard offline - check if we should restart
                         self._check_restart_timeout()
-                    
+
                     self.publish_device_status()
                     logger.debug(f"✅ Gammu operation '{operation_name}' succeeded")
-                    
+
                     # If modem just recovered, process any pending SMS
                     if was_failing and self.sms_queue.get_count() > 0:
                         logger.info("📥 Modem recovered! Processing pending SMS...")
                         # Schedule processing in background to not block current op
                         import threading
+
                         threading.Thread(
-                            target=self.process_pending_sms,
-                            daemon=True
+                            target=self.process_pending_sms, daemon=True
                         ).start()
 
                     # Configurable delay after each operation to let modem "breathe"
@@ -2982,42 +3295,48 @@ class MQTTPublisher:
                     self.device_tracker.record_failure(
                         f"{operation_name}: Python timeout (15s)",
                         is_timeout=True,
-                        operation_name=operation_name
+                        operation_name=operation_name,
                     )
                     self.publish_device_status()
                     self._attempt_reconnect_if_needed()
                     self._check_restart_timeout()  # Check if restart is needed
-                    logger.error(f"⏱️ Gammu operation '{operation_name}' timed out after 15s")
-                    raise TimeoutError(f"Gammu operation '{operation_name}' timed out after 15s")
+                    logger.error(
+                        f"⏱️ Gammu operation '{operation_name}' timed out after 15s"
+                    )
+                    raise TimeoutError(
+                        f"Gammu operation '{operation_name}' timed out after 15s"
+                    )
                 except Exception as e:
                     # Check for modem hung/communication errors that benefit from reset+retry
                     # These errors indicate the modem is in a bad state and needs a reset
                     # Reference: https://docs.gammu.org/c/error.html
                     RECOVERABLE_ERROR_CODES = {
-                        2: 'ERR_DEVICEOPENERROR',   # Device unavailable (USB gone)
-                        11: 'ERR_DEVICEWRITEERROR', # Error writing to device (USB broken)
-                        14: 'ERR_TIMEOUT',          # Command timed out
-                        31: 'ERR_EMPTYSMSC',        # SMSC number is empty
-                        33: 'ERR_NOTCONNECTED',     # Phone NOT connected
-                        37: 'ERR_BUG',              # Bug in implementation/phone
-                        56: 'ERR_PHONE_INTERNAL',   # Internal phone error
-                        69: 'ERR_GETTING_SMSC',     # Failed to get SMSC from phone
+                        2: "ERR_DEVICEOPENERROR",  # Device unavailable (USB gone)
+                        11: "ERR_DEVICEWRITEERROR",  # Error writing to device (USB broken)
+                        14: "ERR_TIMEOUT",  # Command timed out
+                        31: "ERR_EMPTYSMSC",  # SMSC number is empty
+                        33: "ERR_NOTCONNECTED",  # Phone NOT connected
+                        37: "ERR_BUG",  # Bug in implementation/phone
+                        56: "ERR_PHONE_INTERNAL",  # Internal phone error
+                        69: "ERR_GETTING_SMSC",  # Failed to get SMSC from phone
                     }
-                    
+
                     # Device I/O errors that require immediate restart (USB is broken)
                     DEVICE_ERROR_CODES = {2, 11}  # DEVICEOPENERROR, DEVICEWRITEERROR
-                    
+
                     needs_reset_retry = False
                     error_code = None
                     try:
                         # Try to extract error code from Gammu exception
                         # Gammu exceptions have args[0] as a dict with 'Code' key
-                        if hasattr(e, 'args') and len(e.args) > 0:
+                        if hasattr(e, "args") and len(e.args) > 0:
                             arg0 = e.args[0]
                             if isinstance(arg0, dict):
-                                error_code = arg0.get('Code')
+                                error_code = arg0.get("Code")
                                 if error_code is not None:
-                                    logger.debug(f"Extracted Gammu error code: {error_code}")
+                                    logger.debug(
+                                        f"Extracted Gammu error code: {error_code}"
+                                    )
                                     if error_code in RECOVERABLE_ERROR_CODES:
                                         needs_reset_retry = True
                             else:
@@ -3026,18 +3345,21 @@ class MQTTPublisher:
                                 err_str = str(e)
                                 if "'Code':" in err_str:
                                     import re
+
                                     match = re.search(r"'Code':\s*(\d+)", err_str)
                                     if match:
                                         error_code = int(match.group(1))
-                                        logger.debug(f"Extracted error code from string: {error_code}")
+                                        logger.debug(
+                                            f"Extracted error code from string: {error_code}"
+                                        )
                                         if error_code in RECOVERABLE_ERROR_CODES:
                                             needs_reset_retry = True
                     except Exception as extract_err:
                         logger.debug(f"Error code extraction failed: {extract_err}")
-                    
+
                     if needs_reset_retry:
                         error_name = RECOVERABLE_ERROR_CODES.get(
-                            error_code, f'Code {error_code}'
+                            error_code, f"Code {error_code}"
                         )
                         logger.error(
                             f"🚨 {error_name} detected in '{operation_name}' - "
@@ -3047,12 +3369,11 @@ class MQTTPublisher:
                         # Mark exception for retry logic
                         e.err_recoverable_detected = True
                         raise
-                    
+
                     # All other errors (including Gammu commtimeout errors)
                     self.consecutive_failures += 1
                     self.device_tracker.record_failure(
-                        f"{operation_name}: {str(e)}",
-                        operation_name=operation_name
+                        f"{operation_name}: {str(e)}", operation_name=operation_name
                     )
                     self.publish_device_status()
                     self._attempt_reconnect_if_needed()
@@ -3062,12 +3383,12 @@ class MQTTPublisher:
                 # CRITICAL: shutdown(wait=False) to NOT wait for hung thread
                 # The thread may still be blocked in Gammu for minutes, but we don't care
                 executor.shutdown(wait=False)
-    
+
     def _publish_initial_states(self):
         """Publish initial sensor states on startup"""
         if self.connected:
             import time
-            
+
             # Reset all text input fields on startup (clear old values)
             phone_state_topic = f"{self.topic_prefix}/phone_number/state"
             message_state_topic = f"{self.topic_prefix}/message_text/state"
@@ -3091,45 +3412,58 @@ class MQTTPublisher:
             self.current_phone_number = ""
             self.current_message_text = ""
 
-            logger.info("📡 Published initial text field states: cleared phone, message, and USSD fields")
+            logger.info(
+                "📡 Published initial text field states: cleared phone, message, and USSD fields"
+            )
 
             # Publish initial status sensor states (with retain=True to replace old messages)
             send_status_topic = f"{self.topic_prefix}/send_status"
             delete_status_topic = f"{self.topic_prefix}/delete_sms_status"
             delivery_status_topic = f"{self.topic_prefix}/delivery_status"
-            
+
             # Publish initial send_status as "ready"
             send_status_data = {
                 "status": "ready",
                 "message": "SMS Gateway ready to send messages",
-                "timestamp": time.strftime("%Y-%m-%d %H:%M:%S")
+                "timestamp": time.strftime("%Y-%m-%d %H:%M:%S"),
             }
-            self.client.publish(send_status_topic, json.dumps(send_status_data), retain=True, qos=1)
+            self.client.publish(
+                send_status_topic, json.dumps(send_status_data), retain=True, qos=1
+            )
 
             # Publish initial delete_status as "idle"
             delete_status_data = {
                 "status": "idle",
                 "message": "No delete operations yet",
-                "timestamp": time.strftime("%Y-%m-%d %H:%M:%S")
+                "timestamp": time.strftime("%Y-%m-%d %H:%M:%S"),
             }
-            self.client.publish(delete_status_topic, json.dumps(delete_status_data), retain=True, qos=1)
+            self.client.publish(
+                delete_status_topic, json.dumps(delete_status_data), retain=True, qos=1
+            )
 
             # Publish initial delivery_status as "idle"
             delivery_status_data = {
                 "status": "idle",
                 "message": "No delivery reports yet",
                 "pending_count": 0,
-                "timestamp": time.strftime("%Y-%m-%d %H:%M:%S")
+                "timestamp": time.strftime("%Y-%m-%d %H:%M:%S"),
             }
-            self.client.publish(delivery_status_topic, json.dumps(delivery_status_data), retain=True, qos=1)
+            self.client.publish(
+                delivery_status_topic,
+                json.dumps(delivery_status_data),
+                retain=True,
+                qos=1,
+            )
 
-            logger.info("📡 Published initial status states (send_status: ready, delete_status: idle, delivery_status: idle)")
-    
+            logger.info(
+                "📡 Published initial status states (send_status: ready, delete_status: idle, delivery_status: idle)"
+            )
+
     def _restore_sms_history(self):
         """Restore last SMS from history after discovery is complete"""
         if not self.connected:
             return
-        
+
         history = self.sms_history.get_history()
         if history:
             last_sms = history[-1]  # Get most recent message
@@ -3138,20 +3472,18 @@ class MQTTPublisher:
                 "Number": last_sms.get("number", "Unknown"),
                 "Text": last_sms.get("text", ""),
                 "timestamp": last_sms.get("timestamp", ""),
-                "history": history
+                "history": history,
             }
-            
+
             # Publish to SMS state topic with retain
             topic = f"{self.topic_prefix}/sms/state"
             self.client.publish(
                 topic, json.dumps(restored_sms_data), qos=1, retain=True
             )
-            
-            sender = last_sms.get('number', 'Unknown')
-            timestamp = last_sms.get('timestamp', '')
-            logger.info(
-                f"📡 Restored last SMS from history: {sender} at {timestamp}"
-            )
+
+            sender = last_sms.get("number", "Unknown")
+            timestamp = last_sms.get("timestamp", "")
+            logger.info(f"📡 Restored last SMS from history: {sender} at {timestamp}")
         else:
             logger.info("📡 No SMS history to restore")
 
@@ -3159,20 +3491,18 @@ class MQTTPublisher:
         """Restore last missed call from history after discovery is complete"""
         if not self.connected:
             return
-        
-        if not self.config.get('missed_calls_monitoring_enabled', False):
+
+        if not self.config.get("missed_calls_monitoring_enabled", False):
             return
-        
+
         last_call = self.missed_call_tracker.get_last_call()
         if last_call:
             # Publish to missed call state topic with retain
             topic = f"{self.topic_prefix}/missed_call/state"
-            self.client.publish(
-                topic, json.dumps(last_call), qos=1, retain=True
-            )
-            
-            number = last_call.get('Number', 'Unknown')
-            timestamp = last_call.get('processed_at', '')
+            self.client.publish(topic, json.dumps(last_call), qos=1, retain=True)
+
+            number = last_call.get("Number", "Unknown")
+            timestamp = last_call.get("processed_at", "")
             logger.info(
                 f"📡 Restored last missed call from history: "
                 f"{number} at {timestamp}"
@@ -3184,13 +3514,13 @@ class MQTTPublisher:
         """Restore balance data from persistent storage after discovery"""
         if not self.connected:
             return
-        
+
         if not self.balance_parser:
             return
-        
+
         balance_data = self.balance_parser.get_balance_data()
         # Only restore if we have actual data (not all None)
-        if balance_data.get('last_updated'):
+        if balance_data.get("last_updated"):
             self.publish_balance_info(balance_data)
             logger.info(
                 f"📡 Restored balance from storage: "
@@ -3199,7 +3529,7 @@ class MQTTPublisher:
             )
         else:
             logger.info("📡 No balance data to restore")
-    
+
     def publish_initial_states_with_machine(self, gammu_machine):
         """Publish initial states with gammu machine access"""
         if not self.connected:
@@ -3211,34 +3541,40 @@ class MQTTPublisher:
 
             # Publish initial offline status (will change to online on first successful operation)
             self.publish_device_status()
-            logger.info("📡 Published initial modem status: offline (waiting for first successful communication)")
+            logger.info(
+                "📡 Published initial modem status: offline (waiting for first successful communication)"
+            )
 
             # Cache SMSC on initialization
             logger.info("📞 Caching SMSC for reliable SMS sending...")
             self.cache_smsc()
 
             # Publish initial signal strength with connectivity tracking
-            signal = self.track_gammu_operation("GetSignalQuality", self.gammu_machine.GetSignalQuality)
+            signal = self.track_gammu_operation(
+                "GetSignalQuality", self.gammu_machine.GetSignalQuality
+            )
             # Filter out invalid BER value (-1 means not available)
             if signal.get("BitErrorRate") == -1:
                 signal["BitErrorRate"] = None
             self.publish_signal_strength(signal)
 
             # Publish initial network info with connectivity tracking
-            network = self.track_gammu_operation("GetNetworkInfo", self.gammu_machine.GetNetworkInfo)
+            network = self.track_gammu_operation(
+                "GetNetworkInfo", self.gammu_machine.GetNetworkInfo
+            )
             network_code = network.get("NetworkCode", "")
             network_name = network.get("NetworkName")
-            
+
             # Try multiple lookup methods if name is empty (fixed in python-gammu 3.2.5, kept as defense-in-depth)
             if not network_name and network_code:
                 # First try our comprehensive database
                 network_name = get_network_name(network_code)
                 # Fallback to Gammu's database
                 if not network_name:
-                    network_name = GSMNetworks.get(network_code, 'Unknown')
-            
-            network["NetworkName"] = network_name or 'Unknown'
-            
+                    network_name = GSMNetworks.get(network_code, "Unknown")
+
+            network["NetworkName"] = network_name or "Unknown"
+
             # Map Gammu's state to human-readable format
             state = network.get("State", "Unknown")
             state_map = {
@@ -3250,16 +3586,17 @@ class MQTTPublisher:
                 "Unknown": "Unknown",
             }
             network["State"] = state_map.get(state, state)
-            
+
             # Add network type detection
             try:
                 from support import get_network_type
+
                 network_type = get_network_type(self.gammu_machine)
                 network["NetworkType"] = network_type
             except Exception as e:
                 logger.warning(f"Could not detect network type: {e}")
                 network["NetworkType"] = "Unknown"
-            
+
             self.publish_network_info(network)
 
             # Don't publish empty SMS state on startup - it would overwrite the last real SMS
@@ -3267,7 +3604,9 @@ class MQTTPublisher:
             # 1. A new SMS arrives (SMS monitoring)
             # 2. User retrieves SMS via API
             # This preserves the last SMS value across restarts
-            logger.info("📡 Skipping empty SMS state publish (preserves last SMS across restarts)")
+            logger.info(
+                "📡 Skipping empty SMS state publish (preserves last SMS across restarts)"
+            )
 
             # Publish initial SMS counters
             self.publish_sms_counter()
@@ -3276,12 +3615,20 @@ class MQTTPublisher:
             # Publish modem info
             try:
                 modem_info = {
-                    "IMEI": self.track_gammu_operation("GetIMEI", self.gammu_machine.GetIMEI),
-                    "Manufacturer": self.track_gammu_operation("GetManufacturer", self.gammu_machine.GetManufacturer),
-                    "Model": self.track_gammu_operation("GetModel", self.gammu_machine.GetModel)
+                    "IMEI": self.track_gammu_operation(
+                        "GetIMEI", self.gammu_machine.GetIMEI
+                    ),
+                    "Manufacturer": self.track_gammu_operation(
+                        "GetManufacturer", self.gammu_machine.GetManufacturer
+                    ),
+                    "Model": self.track_gammu_operation(
+                        "GetModel", self.gammu_machine.GetModel
+                    ),
                 }
                 try:
-                    modem_info["Firmware"] = self.track_gammu_operation("GetFirmware", self.gammu_machine.GetFirmware)[0]
+                    modem_info["Firmware"] = self.track_gammu_operation(
+                        "GetFirmware", self.gammu_machine.GetFirmware
+                    )[0]
                 except Exception:
                     modem_info["Firmware"] = "Unknown"
                 self.publish_modem_info(modem_info)
@@ -3290,20 +3637,26 @@ class MQTTPublisher:
 
             # Publish SIM info
             try:
-                sim_info = {"IMSI": self.track_gammu_operation("GetSIMIMSI", self.gammu_machine.GetSIMIMSI)}
+                sim_info = {
+                    "IMSI": self.track_gammu_operation(
+                        "GetSIMIMSI", self.gammu_machine.GetSIMIMSI
+                    )
+                }
                 self.publish_sim_info(sim_info)
             except Exception as e:
                 logger.warning(f"Could not publish SIM info: {e}")
 
             # Publish SMS capacity
             try:
-                capacity = self.track_gammu_operation("GetSMSStatus", self.gammu_machine.GetSMSStatus)
+                capacity = self.track_gammu_operation(
+                    "GetSMSStatus", self.gammu_machine.GetSMSStatus
+                )
                 self.publish_sms_capacity(capacity)
             except Exception as e:
                 logger.warning(f"Could not publish SMS capacity: {e}")
 
             logger.info("📡 Published initial states to MQTT")
-            
+
             # Process any pending SMS from queue (from previous failed sends)
             if self.sms_queue.get_count() > 0:
                 logger.info("📥 Found pending SMS in queue, processing...")
@@ -3311,12 +3664,12 @@ class MQTTPublisher:
 
         except Exception as e:
             logger.error(f"Error publishing initial states: {e}")
-    
+
     def start_sms_monitoring(self, gammu_machine, check_interval=10):
         """Start SMS monitoring in background thread"""
         if not self.connected:
             return
-            
+
         def _sms_monitor_loop():
             logger.info(f"📱 Started SMS monitoring (check every {check_interval}s)")
 
@@ -3325,7 +3678,7 @@ class MQTTPublisher:
             first_run = True
 
             while self.connected and not self.disconnecting:
-                from support import retrieveAllSms, deleteSms
+                from support import deleteSms, retrieveAllSms
 
                 # Skip SMS polling during active incoming call to avoid modem conflicts
                 # The ReadDevice loop handles the call, and SMS operations can cause timeouts
@@ -3338,10 +3691,13 @@ class MQTTPublisher:
                 # Modem needs recovery time after handling an incoming call
                 if self._call_ended_at is not None:
                     from datetime import datetime
+
                     elapsed = (datetime.now() - self._call_ended_at).total_seconds()
                     if elapsed < self.CALL_COOLDOWN_SECONDS:
                         remaining = self.CALL_COOLDOWN_SECONDS - elapsed
-                        logger.debug(f"📱 Skipping SMS poll - post-call cooldown ({remaining:.0f}s remaining)")
+                        logger.debug(
+                            f"📱 Skipping SMS poll - post-call cooldown ({remaining:.0f}s remaining)"
+                        )
                         time.sleep(check_interval)
                         continue
                     else:
@@ -3349,19 +3705,27 @@ class MQTTPublisher:
                         # This prevents race condition with status poll
                         if self._post_call_reinit_needed:
                             self._post_call_reinit_needed = False
-                            self._reinit_in_progress = True  # Block other threads BEFORE clearing cooldown
+                            self._reinit_in_progress = (
+                                True  # Block other threads BEFORE clearing cooldown
+                            )
                             self._call_ended_at = None  # Now safe to clear
-                            logger.info("📱 Post-call cooldown complete, starting modem reinit...")
+                            logger.info(
+                                "📱 Post-call cooldown complete, starting modem reinit..."
+                            )
                             try:
                                 if self._reconnect_gammu():
                                     logger.info("✅ Post-call modem reinit successful")
                                 else:
-                                    logger.warning("⚠️ Post-call modem reinit failed - will retry on next failure")
+                                    logger.warning(
+                                        "⚠️ Post-call modem reinit failed - will retry on next failure"
+                                    )
                             finally:
                                 self._reinit_in_progress = False  # Release lock
                         else:
                             self._call_ended_at = None
-                            logger.info("📱 Post-call cooldown complete, resuming SMS monitoring")
+                            logger.info(
+                                "📱 Post-call cooldown complete, resuming SMS monitoring"
+                            )
 
                 # When in hard_offline, skip ALL modem operations to avoid blocking
                 # Just check restart timeout, publish status (to update seconds_since_last_success), and wait
@@ -3373,16 +3737,24 @@ class MQTTPublisher:
 
                 # Check for new SMS with connectivity tracking (this will handle errors and update status)
                 try:
-                    all_sms = self.track_gammu_operation("retrieveAllSms", retrieveAllSms, self.gammu_machine)
+                    all_sms = self.track_gammu_operation(
+                        "retrieveAllSms", retrieveAllSms, self.gammu_machine
+                    )
                     current_count = len(all_sms)
                     # Only log routine polling in debug mode to reduce log spam
-                    if self.log_level == 'debug':
-                        logger.info(f"✅ SMS monitoring cycle OK: {current_count} messages on SIM")
+                    if self.log_level == "debug":
+                        logger.info(
+                            f"✅ SMS monitoring cycle OK: {current_count} messages on SIM"
+                        )
                     else:
-                        logger.debug(f"SMS monitoring cycle OK: {current_count} messages on SIM")
+                        logger.debug(
+                            f"SMS monitoring cycle OK: {current_count} messages on SIM"
+                        )
                 except Exception as e:
                     # track_gammu_operation already recorded the failure and published status
-                    logger.warning(f"❌ SMS monitoring cycle failed (modem offline): {e}")
+                    logger.warning(
+                        f"❌ SMS monitoring cycle failed (modem offline): {e}"
+                    )
 
                     # Check restart timeout on EVERY failed cycle (not just inside track_gammu_operation)
                     # This ensures the restart timer keeps being checked even after initial timeout
@@ -3391,7 +3763,9 @@ class MQTTPublisher:
                     # When in hard_offline (modem completely frozen), skip retry attempts
                     # that would block for 15+ seconds. Just wait for restart timeout.
                     if self.device_tracker.hard_offline:
-                        logger.debug("Skipping soft reset - modem in hard_offline state, waiting for restart")
+                        logger.debug(
+                            "Skipping soft reset - modem in hard_offline state, waiting for restart"
+                        )
                         time.sleep(check_interval)
                         continue
 
@@ -3399,11 +3773,17 @@ class MQTTPublisher:
                     # Then retry every 5 failures (5, 10, 15, 20...)
                     failures = self.device_tracker.get_consecutive_failures()
                     if failures == 2 or (failures > 2 and failures % 5 == 0):
-                        logger.warning(f"🔄 Attempting modem soft reset after {failures} failures...")
+                        logger.warning(
+                            f"🔄 Attempting modem soft reset after {failures} failures..."
+                        )
                         try:
                             # Soft reset: AT+CFUN=1,1 (restart modem software, keep SIM state)
-                            self.track_gammu_operation("Reset", self.gammu_machine.Reset, False)
-                            logger.info("✅ Modem soft reset completed, waiting 5s for recovery...")
+                            self.track_gammu_operation(
+                                "Reset", self.gammu_machine.Reset, False
+                            )
+                            logger.info(
+                                "✅ Modem soft reset completed, waiting 5s for recovery..."
+                            )
                             time.sleep(5)
                         except Exception as reset_err:
                             logger.error(f"❌ Modem soft reset failed: {reset_err}")
@@ -3414,71 +3794,100 @@ class MQTTPublisher:
                 try:
                     if first_run:
                         # On first run, publish only unread SMS and process delivery reports
-                        logger.info(f"📱 Initial SMS check: {current_count} total SMS on SIM")
+                        logger.info(
+                            f"📱 Initial SMS check: {current_count} total SMS on SIM"
+                        )
                         unread_count = 0
                         delivery_reports_processed = 0
                         deleted_count = 0
-                        
+
                         for i, sms in enumerate(all_sms):
                             # Check if this is a delivery report (process even if read)
-                            if self.config.get('sms_delivery_reports', False):
-                                sms_type = sms.get('Type', '')
-                                if sms_type == 'Status_Report':
-                                    message_ref = sms.get('MessageReference', None)
-                                    status = sms.get('DeliveryStatus', 'unknown')
-                                    
+                            if self.config.get("sms_delivery_reports", False):
+                                sms_type = sms.get("Type", "")
+                                if sms_type == "Status_Report":
+                                    message_ref = sms.get("MessageReference", None)
+                                    status = sms.get("DeliveryStatus", "unknown")
+
                                     if message_ref:
                                         delivery_info = self.delivery_tracker.update_delivery_status(
                                             message_ref, status
                                         )
                                         if delivery_info:
-                                            self.publish_delivery_report(message_ref, status, delivery_info)
+                                            self.publish_delivery_report(
+                                                message_ref, status, delivery_info
+                                            )
                                             delivery_reports_processed += 1
-                                    
+
                                     # Auto-delete delivery report
                                     try:
-                                        self.track_gammu_operation("deleteSms", deleteSms, self.gammu_machine, all_sms[i])
-                                        logger.debug(f"🗑️ Auto-deleted delivery report (ref={message_ref})")
+                                        self.track_gammu_operation(
+                                            "deleteSms",
+                                            deleteSms,
+                                            self.gammu_machine,
+                                            all_sms[i],
+                                        )
+                                        logger.debug(
+                                            f"🗑️ Auto-deleted delivery report (ref={message_ref})"
+                                        )
                                         deleted_count += 1
                                     except Exception as e:
-                                        logger.error(f"Error deleting delivery report: {e}")
+                                        logger.error(
+                                            f"Error deleting delivery report: {e}"
+                                        )
                                     continue  # Skip publishing as regular SMS
-                            
+
                             # Publish unread regular SMS
-                            if sms.get('State') == 'UnRead':
+                            if sms.get("State") == "UnRead":
                                 sms_copy = sms.copy()
                                 sms_copy.pop("Locations", None)
                                 self.publish_sms_received(sms_copy)
                                 unread_count += 1
 
                         if unread_count > 0:
-                            logger.info(f"📱 Published {unread_count} unread SMS messages")
+                            logger.info(
+                                f"📱 Published {unread_count} unread SMS messages"
+                            )
                         if delivery_reports_processed > 0:
-                            logger.info(f"📬 Processed {delivery_reports_processed} delivery reports")
+                            logger.info(
+                                f"📬 Processed {delivery_reports_processed} delivery reports"
+                            )
                         if deleted_count > 0:
-                            logger.info(f"🗑️ Auto-deleted {deleted_count} delivery report(s)")
+                            logger.info(
+                                f"🗑️ Auto-deleted {deleted_count} delivery report(s)"
+                            )
                         if unread_count == 0 and delivery_reports_processed == 0:
                             logger.info(f"📱 No unread messages or delivery reports")
 
                         # If we deleted any delivery reports, update SMS capacity
                         if deleted_count > 0:
                             try:
-                                capacity = self.track_gammu_operation("GetSMSStatus", self.gammu_machine.GetSMSStatus)
+                                capacity = self.track_gammu_operation(
+                                    "GetSMSStatus", self.gammu_machine.GetSMSStatus
+                                )
                                 self.publish_sms_capacity(capacity)
                                 # Update count to reflect deleted delivery reports
-                                current_count = capacity.get('SIMUsed', 0) + capacity.get('PhoneUsed', 0)
-                                logger.info(f"📊 After deleting delivery reports: {current_count} SMS remaining on SIM")
+                                current_count = capacity.get(
+                                    "SIMUsed", 0
+                                ) + capacity.get("PhoneUsed", 0)
+                                logger.info(
+                                    f"📊 After deleting delivery reports: {current_count} SMS remaining on SIM"
+                                )
                             except Exception as e:
-                                logger.warning(f"Could not update SMS capacity after deleting delivery reports: {e}")
+                                logger.warning(
+                                    f"Could not update SMS capacity after deleting delivery reports: {e}"
+                                )
 
                         last_sms_count = current_count
                         first_run = False
                     elif current_count > last_sms_count:
                         # On subsequent runs, publish all new SMS
-                        logger.info(f"📱 Detected {current_count - last_sms_count} new SMS messages")
+                        logger.info(
+                            f"📱 Detected {current_count - last_sms_count} new SMS messages"
+                        )
 
                         deleted_count = 0
-                        auto_delete = self.config.get('auto_delete_read_sms', False)
+                        auto_delete = self.config.get("auto_delete_read_sms", False)
 
                         # Process new SMS (from the end, newest first)
                         for i in range(last_sms_count, current_count):
@@ -3487,42 +3896,65 @@ class MQTTPublisher:
                                 sms.pop("Locations", None)
 
                                 # Check if this is a delivery report
-                                if self.config.get('sms_delivery_reports', False):
-                                    sms_type = sms.get('Type', '')
-                                    if sms_type == 'Status_Report':
+                                if self.config.get("sms_delivery_reports", False):
+                                    sms_type = sms.get("Type", "")
+                                    if sms_type == "Status_Report":
                                         # This is a delivery report
-                                        message_ref = sms.get('MessageReference', None)
-                                        status = sms.get('DeliveryStatus', 'unknown')
-                                        
+                                        message_ref = sms.get("MessageReference", None)
+                                        status = sms.get("DeliveryStatus", "unknown")
+
                                         if message_ref:
                                             # Update delivery tracking
                                             delivery_info = self.delivery_tracker.update_delivery_status(
                                                 message_ref, status
                                             )
-                                            
+
                                             if delivery_info:
                                                 # Publish delivery report
-                                                self.publish_delivery_report(message_ref, status, delivery_info)
-                                                logger.info(f"📬 Processed delivery report: ref={message_ref}, status={status}")
-                                        
+                                                self.publish_delivery_report(
+                                                    message_ref, status, delivery_info
+                                                )
+                                                logger.info(
+                                                    f"📬 Processed delivery report: ref={message_ref}, status={status}"
+                                                )
+
                                         # Don't publish delivery reports as regular SMS
                                         # Auto-delete delivery report
                                         try:
-                                            self.track_gammu_operation("deleteSms", deleteSms, self.gammu_machine, all_sms[i])
-                                            logger.debug(f"🗑️ Auto-deleted delivery report (ref={message_ref})")
+                                            self.track_gammu_operation(
+                                                "deleteSms",
+                                                deleteSms,
+                                                self.gammu_machine,
+                                                all_sms[i],
+                                            )
+                                            logger.debug(
+                                                f"🗑️ Auto-deleted delivery report (ref={message_ref})"
+                                            )
                                             deleted_count += 1
                                         except Exception as e:
-                                            logger.error(f"Error deleting delivery report: {e}")
+                                            logger.error(
+                                                f"Error deleting delivery report: {e}"
+                                            )
                                         continue  # Skip regular SMS processing
 
                                 # Publish regular SMS to MQTT
                                 self.publish_sms_received(sms)
 
                                 # Auto-delete if enabled and SMS is read
-                                if auto_delete and sms.get('State') in ['Read', 'UnRead']:
+                                if auto_delete and sms.get("State") in [
+                                    "Read",
+                                    "UnRead",
+                                ]:
                                     try:
-                                        self.track_gammu_operation("deleteSms", deleteSms, self.gammu_machine, all_sms[i])
-                                        logger.info(f"🗑️ Auto-deleted SMS from {sms.get('Number', 'Unknown')}")
+                                        self.track_gammu_operation(
+                                            "deleteSms",
+                                            deleteSms,
+                                            self.gammu_machine,
+                                            all_sms[i],
+                                        )
+                                        logger.info(
+                                            f"🗑️ Auto-deleted SMS from {sms.get('Number', 'Unknown')}"
+                                        )
                                         deleted_count += 1
                                     except Exception as e:
                                         logger.error(f"Error auto-deleting SMS: {e}")
@@ -3530,13 +3962,21 @@ class MQTTPublisher:
                         # If we deleted any SMS (delivery reports or auto-delete), update capacity and get new count
                         if deleted_count > 0:
                             try:
-                                capacity = self.track_gammu_operation("GetSMSStatus", self.gammu_machine.GetSMSStatus)
+                                capacity = self.track_gammu_operation(
+                                    "GetSMSStatus", self.gammu_machine.GetSMSStatus
+                                )
                                 self.publish_sms_capacity(capacity)
                                 # Update count to reflect deleted SMS
-                                current_count = capacity.get('SIMUsed', 0) + capacity.get('PhoneUsed', 0)
-                                logger.info(f"📊 After deleting {deleted_count} SMS: {current_count} remaining on SIM")
+                                current_count = capacity.get(
+                                    "SIMUsed", 0
+                                ) + capacity.get("PhoneUsed", 0)
+                                logger.info(
+                                    f"📊 After deleting {deleted_count} SMS: {current_count} remaining on SIM"
+                                )
                             except Exception as e:
-                                logger.warning(f"Could not update SMS capacity after deletion: {e}")
+                                logger.warning(
+                                    f"Could not update SMS capacity after deletion: {e}"
+                                )
 
                     last_sms_count = current_count
 
@@ -3545,18 +3985,19 @@ class MQTTPublisher:
                     logger.error(f"Error processing SMS data: {e}")
 
                 time.sleep(check_interval)
-        
-        # Only start if both MQTT and SMS monitoring are enabled  
-        if (self.config.get('mqtt_enabled', False) and 
-            self.config.get('sms_monitoring_enabled', True)):
+
+        # Only start if both MQTT and SMS monitoring are enabled
+        if self.config.get("mqtt_enabled", False) and self.config.get(
+            "sms_monitoring_enabled", True
+        ):
             thread = threading.Thread(target=_sms_monitor_loop, daemon=True)
             thread.start()
-    
+
     def publish_status_periodic(self, gammu_machine, interval=60):
         """Publish status data periodically in background thread"""
         if not self.connected:
             return
-            
+
         def _publish_loop():
             while self.connected and not self.disconnecting:
                 # Skip periodic status polling during active incoming call
@@ -3570,6 +4011,7 @@ class MQTTPublisher:
                 # Modem needs recovery time after handling an incoming call
                 if self._call_ended_at is not None:
                     from datetime import datetime
+
                     elapsed = (datetime.now() - self._call_ended_at).total_seconds()
                     if elapsed < self.CALL_COOLDOWN_SECONDS:
                         logger.debug(f"📡 Skipping status poll - post-call cooldown")
@@ -3592,10 +4034,12 @@ class MQTTPublisher:
 
                 signal = None
                 network = None
-                
+
                 # Get signal strength with connectivity tracking
                 try:
-                    signal = self.track_gammu_operation("GetSignalQuality", self.gammu_machine.GetSignalQuality)
+                    signal = self.track_gammu_operation(
+                        "GetSignalQuality", self.gammu_machine.GetSignalQuality
+                    )
                     # Filter out invalid BER value (-1 means not available)
                     if signal.get("BitErrorRate") == -1:
                         signal["BitErrorRate"] = None
@@ -3614,20 +4058,23 @@ class MQTTPublisher:
                 # Get network info with connectivity tracking
                 try:
                     from gammu import GSMNetworks
-                    network = self.track_gammu_operation("GetNetworkInfo", self.gammu_machine.GetNetworkInfo)
+
+                    network = self.track_gammu_operation(
+                        "GetNetworkInfo", self.gammu_machine.GetNetworkInfo
+                    )
                     network_code = network.get("NetworkCode", "")
                     network_name = network.get("NetworkName")
-                    
+
                     # Try multiple lookup methods if name is empty (fixed in python-gammu 3.2.5, kept as defense-in-depth)
                     if not network_name and network_code:
                         # First try our comprehensive database
                         network_name = get_network_name(network_code)
                         # Fallback to Gammu's database
                         if not network_name:
-                            network_name = GSMNetworks.get(network_code, 'Unknown')
-                    
-                    network["NetworkName"] = network_name or 'Unknown'
-                    
+                            network_name = GSMNetworks.get(network_code, "Unknown")
+
+                    network["NetworkName"] = network_name or "Unknown"
+
                     # Map Gammu's state to human-readable format
                     state = network.get("State", "Unknown")
                     state_map = {
@@ -3639,20 +4086,21 @@ class MQTTPublisher:
                         "Unknown": "Unknown",
                     }
                     network["State"] = state_map.get(state, state)
-                    
+
                     # Add network type detection
                     try:
                         from support import get_network_type
+
                         network_type = get_network_type(self.gammu_machine)
                         network["NetworkType"] = network_type
                     except Exception as net_type_err:
                         logger.debug(f"Could not detect network type: {net_type_err}")
                         network["NetworkType"] = "Unknown"
-                        
+
                 except Exception as e:
                     # track_gammu_operation already recorded the failure
                     pass  # Warning already logged by track_gammu_operation
-                
+
                 # Publish combined status if we have both
                 if signal and network:
                     self.publish_status_combined(signal, network)
@@ -3662,12 +4110,12 @@ class MQTTPublisher:
                     self.publish_network_info(network)
 
                 time.sleep(interval)
-        
-        if self.config.get('mqtt_enabled', False):
+
+        if self.config.get("mqtt_enabled", False):
             thread = threading.Thread(target=_publish_loop, daemon=True)
             thread.start()
             logger.info(f"Started MQTT periodic publishing (interval: {interval}s)")
-    
+
     def disconnect(self):
         """Disconnect from MQTT broker - thread-safe with duplicate call prevention"""
         if self.disconnecting:
@@ -3679,8 +4127,12 @@ class MQTTPublisher:
         if self.client and self.connected:
             # Publish offline availability - makes ALL entities unavailable in HA
             try:
-                self.client.publish(self.availability_topic, "offline", qos=1, retain=True)
-                logger.info("📡 Published availability: offline (all entities now unavailable)")
+                self.client.publish(
+                    self.availability_topic, "offline", qos=1, retain=True
+                )
+                logger.info(
+                    "📡 Published availability: offline (all entities now unavailable)"
+                )
                 time.sleep(0.5)  # Give time for message to be sent
             except Exception as e:
                 logger.warning(f"Could not publish offline availability: {e}")
@@ -3700,9 +4152,10 @@ class MQTTPublisher:
     def publish_missed_call(self, call_data: dict):
         """Publish missed call to MQTT (real-time callback version)."""
         from datetime import datetime
+
         # Add processed_at if missing
-        if 'processed_at' not in call_data:
-            call_data['processed_at'] = datetime.now().isoformat()
+        if "processed_at" not in call_data:
+            call_data["processed_at"] = datetime.now().isoformat()
 
         # Save to persistent storage (backup for MQTT retained message loss)
         self.missed_call_tracker.add_call(call_data)
@@ -3733,10 +4186,10 @@ class MQTTPublisher:
             last_call = self.call_queue[-1]
             payload = {
                 "state": "ON",
-                "Number": last_call['number'],
-                "ring_start": last_call['ring_start'].isoformat(),
-                "ring_count": last_call['ring_count'],
-                "queue_size": len(self.call_queue)
+                "Number": last_call["number"],
+                "ring_start": last_call["ring_start"].isoformat(),
+                "ring_count": last_call["ring_count"],
+                "queue_size": len(self.call_queue),
             }
         else:
             payload = {"state": "OFF"}
@@ -3752,9 +4205,9 @@ class MQTTPublisher:
         try:
             logger.debug(f"📱 Gammu event: type={event_type}, data={data}")
 
-            if event_type == 'Call':
+            if event_type == "Call":
                 self._handle_call_event(data)
-            elif event_type == 'SMS':
+            elif event_type == "SMS":
                 self._handle_sms_event(data)
             else:
                 logger.debug(f"📱 Unknown event type: {event_type}")
@@ -3765,18 +4218,19 @@ class MQTTPublisher:
     def _handle_call_event(self, call_data):
         """Handle call event with queue support (up to 5 simultaneous calls)."""
         from datetime import datetime
-        status = call_data.get('Status', '')
-        number = call_data.get('Number', '') or 'Unknown'
+
+        status = call_data.get("Status", "")
+        number = call_data.get("Number", "") or "Unknown"
 
         logger.debug(f"📞 Call event: status={status}, number={number}")
 
-        if status == 'IncomingCall':
+        if status == "IncomingCall":
             # Find existing call by number
-            existing = next((c for c in self.call_queue if c['number'] == number), None)
+            existing = next((c for c in self.call_queue if c["number"] == number), None)
 
             if existing:
                 # Continued ringing (RING) - increment ring_count
-                existing['ring_count'] += 1
+                existing["ring_count"] += 1
                 logger.info(f"📞 RING #{existing['ring_count']} from {number}")
             else:
                 # New call
@@ -3784,12 +4238,14 @@ class MQTTPublisher:
                     # Queue full - publish oldest as missed
                     oldest = self.call_queue.pop(0)
                     self._publish_missed_call_from_queue(oldest, queue_full=True)
-                    logger.info(f"📞 Queue full, evicting oldest call from {oldest['number']}")
+                    logger.info(
+                        f"📞 Queue full, evicting oldest call from {oldest['number']}"
+                    )
 
                 new_call = {
-                    'number': number,
-                    'ring_start': datetime.now(),
-                    'ring_count': 1
+                    "number": number,
+                    "ring_start": datetime.now(),
+                    "ring_count": 1,
                 }
                 self.call_queue.append(new_call)
                 logger.info(f"📞 Incoming call from {number}")
@@ -3799,50 +4255,60 @@ class MQTTPublisher:
             self._start_call_auto_reset_timer()
             self.publish_incoming_call_state(True)
 
-        elif status in ['CallRemoteEnd', 'CallLocalEnd']:
+        elif status in ["CallRemoteEnd", "CallLocalEnd"]:
             # Call ended - find call by number
             call = None
 
-            if number and number != 'Unknown':
+            if number and number != "Unknown":
                 # Have number - search by it
-                call = next((c for c in self.call_queue if c['number'] == number), None)
+                call = next((c for c in self.call_queue if c["number"] == number), None)
 
             if not call and len(self.call_queue) == 1:
                 # No number (or not found), but only 1 call - remove it
                 call = self.call_queue[0]
-                logger.info(f"📞 CallEnd without number, removing only queued call from {call['number']}")
+                logger.info(
+                    f"📞 CallEnd without number, removing only queued call from {call['number']}"
+                )
 
             elif not call and len(self.call_queue) > 1:
                 # Multiple calls and don't know which - log warning
-                logger.warning(f"📞 CallEnd without number, but {len(self.call_queue)} calls in queue - cannot determine which to remove")
+                logger.warning(
+                    f"📞 CallEnd without number, but {len(self.call_queue)} calls in queue - cannot determine which to remove"
+                )
 
             if call:
                 self.call_queue.remove(call)
                 self._publish_missed_call_from_queue(call)
-                logger.info(f"📞 Call ended from {call['number']} (rang {call['ring_count']} times)")
+                logger.info(
+                    f"📞 Call ended from {call['number']} (rang {call['ring_count']} times)"
+                )
 
             # If queue is empty, reset state
             if not self.call_queue:
                 self._cancel_call_auto_reset_timer()
                 self._call_ended_at = datetime.now()  # Start cooldown
-                self._post_call_reinit_needed = True  # Request modem reinit after cooldown
+                self._post_call_reinit_needed = (
+                    True  # Request modem reinit after cooldown
+                )
                 logger.info("🔄 Modem reinit requested after cooldown")
                 self.publish_incoming_call_state(False)
             else:
                 # Update binary sensor to show last number in queue
                 self.publish_incoming_call_state(True)
 
-        elif status == 'CallStart':
+        elif status == "CallStart":
             # Call was answered - not missed, remove from queue
             call = None
 
-            if number and number != 'Unknown':
-                call = next((c for c in self.call_queue if c['number'] == number), None)
+            if number and number != "Unknown":
+                call = next((c for c in self.call_queue if c["number"] == number), None)
 
             if not call and len(self.call_queue) == 1:
                 # No number, but only 1 call - remove it
                 call = self.call_queue[0]
-                logger.info(f"📞 CallStart without number, removing only queued call from {call['number']}")
+                logger.info(
+                    f"📞 CallStart without number, removing only queued call from {call['number']}"
+                )
 
             if call:
                 self.call_queue.remove(call)
@@ -3851,30 +4317,35 @@ class MQTTPublisher:
             if not self.call_queue:
                 self._cancel_call_auto_reset_timer()
                 self._call_ended_at = datetime.now()  # Start cooldown
-                self._post_call_reinit_needed = True  # Request modem reinit after cooldown
+                self._post_call_reinit_needed = (
+                    True  # Request modem reinit after cooldown
+                )
                 logger.info("🔄 Modem reinit requested after cooldown")
                 self.publish_incoming_call_state(False)
             else:
                 self.publish_incoming_call_state(True)
 
-    def _publish_missed_call_from_queue(self, call: dict, queue_full: bool = False, auto_reset: bool = False):
+    def _publish_missed_call_from_queue(
+        self, call: dict, queue_full: bool = False, auto_reset: bool = False
+    ):
         """Publish missed call from queue with additional attributes."""
         from datetime import datetime
+
         ring_end = datetime.now()
-        duration = (ring_end - call['ring_start']).total_seconds()
+        duration = (ring_end - call["ring_start"]).total_seconds()
 
         missed_data = {
-            'Number': call['number'],
-            'ring_start': call['ring_start'].isoformat(),
-            'ring_end': ring_end.isoformat(),
-            'ring_duration_seconds': int(duration),
-            'ring_count': call['ring_count']
+            "Number": call["number"],
+            "ring_start": call["ring_start"].isoformat(),
+            "ring_end": ring_end.isoformat(),
+            "ring_duration_seconds": int(duration),
+            "ring_count": call["ring_count"],
         }
 
         if queue_full:
-            missed_data['queue_full'] = True
+            missed_data["queue_full"] = True
         if auto_reset:
-            missed_data['auto_reset'] = True
+            missed_data["auto_reset"] = True
 
         self.publish_missed_call(missed_data)
 
@@ -3882,12 +4353,11 @@ class MQTTPublisher:
         """Start timer to auto-reset incoming call state (fallback for modems that don't send CallEnd events)."""
         self._cancel_call_auto_reset_timer()
 
-        timeout = self.config.get('incoming_call_auto_reset_seconds', 60)
+        timeout = self.config.get("incoming_call_auto_reset_seconds", 60)
         logger.debug(f"📞 Starting call auto-reset timer: {timeout}s")
 
         self._call_auto_reset_timer = threading.Timer(
-            timeout,
-            self._auto_reset_incoming_call
+            timeout, self._auto_reset_incoming_call
         )
         self._call_auto_reset_timer.daemon = True
         self._call_auto_reset_timer.start()
@@ -3901,8 +4371,11 @@ class MQTTPublisher:
     def _auto_reset_incoming_call(self):
         """Auto-reset: publish all calls in queue as missed."""
         from datetime import datetime
+
         if self.call_queue:
-            logger.info(f"📞 Auto-reset timeout - publishing {len(self.call_queue)} missed call(s)")
+            logger.info(
+                f"📞 Auto-reset timeout - publishing {len(self.call_queue)} missed call(s)"
+            )
 
             for call in self.call_queue:
                 self._publish_missed_call_from_queue(call, auto_reset=True)
@@ -3918,7 +4391,7 @@ class MQTTPublisher:
     def _handle_sms_event(self, sms_data):
         """Process SMS event - trigger for faster processing via callback."""
         # Respect sms_monitoring_enabled setting
-        if not self.config.get('sms_monitoring_enabled', True):
+        if not self.config.get("sms_monitoring_enabled", True):
             logger.debug("📨 SMS event ignored (sms_monitoring_enabled=false)")
             return
 
@@ -3930,10 +4403,7 @@ class MQTTPublisher:
 
         # Set flag and start timer (3s debounce for multi-part SMS)
         self._sms_callback_pending = True
-        self._sms_callback_timer = threading.Timer(
-            3.0,
-            self._process_sms_from_callback
-        )
+        self._sms_callback_timer = threading.Timer(3.0, self._process_sms_from_callback)
         self._sms_callback_timer.start()
 
     def _process_sms_from_callback(self):
@@ -3949,21 +4419,23 @@ class MQTTPublisher:
             return
 
         try:
-            from support import retrieveAllSms, deleteSms
+            from support import deleteSms, retrieveAllSms
 
             # Get all SMS
-            all_sms = self.track_gammu_operation("retrieveAllSms", retrieveAllSms, self.gammu_machine)
+            all_sms = self.track_gammu_operation(
+                "retrieveAllSms", retrieveAllSms, self.gammu_machine
+            )
 
             if not all_sms:
                 logger.debug("No SMS to process")
                 return
 
-            auto_delete = self.config.get('auto_delete_read_sms', False)
+            auto_delete = self.config.get("auto_delete_read_sms", False)
             processed_count = 0
 
             # Process all unread SMS
             for sms in all_sms:
-                if sms.get('State') == 'UnRead':
+                if sms.get("State") == "UnRead":
                     sms_copy = sms.copy()
                     sms_copy.pop("Locations", None)
 
@@ -3974,8 +4446,12 @@ class MQTTPublisher:
                     # Auto-delete if enabled
                     if auto_delete:
                         try:
-                            self.track_gammu_operation("deleteSms", deleteSms, self.gammu_machine, sms)
-                            logger.info(f"🗑️ Auto-deleted SMS from {sms.get('Number', 'Unknown')}")
+                            self.track_gammu_operation(
+                                "deleteSms", deleteSms, self.gammu_machine, sms
+                            )
+                            logger.info(
+                                f"🗑️ Auto-deleted SMS from {sms.get('Number', 'Unknown')}"
+                            )
                         except Exception as e:
                             logger.error(f"Error auto-deleting SMS: {e}")
 
@@ -3984,7 +4460,9 @@ class MQTTPublisher:
 
                 # Update capacity
                 try:
-                    capacity = self.track_gammu_operation("GetSMSStatus", self.gammu_machine.GetSMSStatus)
+                    capacity = self.track_gammu_operation(
+                        "GetSMSStatus", self.gammu_machine.GetSMSStatus
+                    )
                     self.publish_sms_capacity(capacity)
                 except Exception as e:
                     logger.warning(f"Could not update SMS capacity: {e}")
@@ -4005,14 +4483,11 @@ class MQTTPublisher:
         from support import setupCallbacks
 
         # Setup unified callback for calls and SMS
-        result = setupCallbacks(
-            gammu_machine,
-            self._handle_gammu_event
-        )
+        result = setupCallbacks(gammu_machine, self._handle_gammu_event)
 
         # Our setupCallbacks returns 'incoming_call' and 'incoming_sms' keys
-        self.call_monitoring_enabled = result.get('incoming_call', False)
-        self.sms_callback_enabled = result.get('incoming_sms', False)
+        self.call_monitoring_enabled = result.get("incoming_call", False)
+        self.sms_callback_enabled = result.get("incoming_sms", False)
 
         if self.call_monitoring_enabled:
             logger.info("📞 Call callback: ENABLED (real-time detection)")
@@ -4028,6 +4503,7 @@ class MQTTPublisher:
 
         # Start ReadDevice loop only if at least one callback works
         if self.call_monitoring_enabled or self.sms_callback_enabled:
+
             def _read_device_loop():
                 logger.info("🔄 ReadDevice loop started (1s interval)")
                 while self.connected and not self.disconnecting:
@@ -4051,9 +4527,7 @@ class MQTTPublisher:
                 logger.info("🔄 ReadDevice loop stopped")
 
             self._read_device_thread = threading.Thread(
-                target=_read_device_loop,
-                daemon=True,
-                name="ReadDeviceLoop"
+                target=_read_device_loop, daemon=True, name="ReadDeviceLoop"
             )
             self._read_device_thread.start()
             return True

--- a/addon-test-current/network_codes.py
+++ b/addon-test-current/network_codes.py
@@ -15,8 +15,6 @@ Auto-update: Monthly via GitHub Actions
 # Comprehensive database of mobile network operators by MCC+MNC
 # Format: "MCCMNC": "Operator Name"
 NETWORK_OPERATORS = {
-
-
     # United States (MCC 310-316)
     "310005": "Verizon",
     "310006": "Verizon",
@@ -352,7 +350,6 @@ NETWORK_OPERATORS = {
     "310970": "Globalstar",
     "310980": "Peoples Telephone",
     "310990": "Evolve Broadband",
-
     # US MVNOs with unique codes
     "310032": "IT&E Wireless",
     "310053": "Virgin Mobile",
@@ -483,7 +480,6 @@ NETWORK_OPERATORS = {
     "313970": "Tycrhron",
     "313980": "Next Generation Application LLC",
     "313990": "Ericsson US",
-
     # Canada (MCC 302)
     "302100": "dotmobile",
     "302130": "Xplore",
@@ -566,7 +562,6 @@ NETWORK_OPERATORS = {
     "302996": "Powertech Labs",
     "302997": "Powertech Labs",
     "302998": "Institut de Recherche d’Hydro-Québec",
-
     # United Kingdom (MCC 234, 235)
     "23400": "BT",
     "23401": "Vectone Mobile",
@@ -631,7 +626,6 @@ NETWORK_OPERATORS = {
     "23479": "UKTL",
     "23486": "EE",
     "23488": "telet",
-
     # Germany (MCC 262)
     "26201": "Telekom",
     "26202": "Vodafone",
@@ -675,7 +669,6 @@ NETWORK_OPERATORS = {
     "26279": "ng4T GmbH",
     "26292": "Nash Technologies",
     "26298": "private networks",
-
     # France (MCC 208)
     "20801": "Orange",
     "20802": "Orange",
@@ -753,7 +746,6 @@ NETWORK_OPERATORS = {
     "20896": "Région Bourgogne-Franche-Comté",
     "20897": "Thales Communications & Security SAS",
     "20898": "Société Air France",
-
     # Spain (MCC 214)
     "21401": "Vodafone",
     "21402": "Fibracat",
@@ -796,7 +788,6 @@ NETWORK_OPERATORS = {
     "21451": "ADIF",
     "214700": "Iberdrola",
     "214701": "Endesa",
-
     # Italy (MCC 222)
     "22201": "TIM",
     "22202": "Elsacom",
@@ -827,7 +818,6 @@ NETWORK_OPERATORS = {
     "22288": "WINDTRE",
     "22298": "BLU",
     "22299": "WINDTRE",
-
     # Netherlands (MCC 204)
     "20400": "Intovoice B.V.",
     "20401": "RadioAccess Network Services",
@@ -873,7 +863,6 @@ NETWORK_OPERATORS = {
     "20468": "Roamware (Netherlands) B.V.",
     "20469": "KPN Mobile The Netherlands B.V.",
     "20491": "Enexis Netbeheer B.V.",
-
     # Australia (MCC 505)
     "50501": "Telstra",
     "50502": "Optus",
@@ -936,7 +925,6 @@ NETWORK_OPERATORS = {
     "50588": "Pivotel Group Pty Ltd",
     "50590": "Optus",
     "50599": "One.Tel",
-
     # China (MCC 460, 461)
     "46000": "China Mobile",
     "46001": "China Unicom",
@@ -951,7 +939,6 @@ NETWORK_OPERATORS = {
     "46011": "China Telecom",
     "46015": "China Broadnet",
     "46020": "China Tietong",
-
     # Japan (MCC 440, 441)
     "44000": "Y!Mobile",
     "44001": "KDDI Corporation",
@@ -990,7 +977,6 @@ NETWORK_OPERATORS = {
     "44075": "au",
     "44076": "au",
     "44078": "au",
-
     # India (MCC 404, 405)
     "40401": "Vi India",
     "40402": "AirTel",
@@ -1080,7 +1066,6 @@ NETWORK_OPERATORS = {
     "40496": "AirTel",
     "40497": "AirTel",
     "40498": "AirTel",
-
     # Brazil (MCC 724)
     "72400": "Nextel",
     "72401": "SISTEER DO BRASIL TELECOMUNICAÇÔES",
@@ -1113,7 +1098,6 @@ NETWORK_OPERATORS = {
     "72439": "Nextel",
     "72454": "Conecta",
     "72499": "Local",
-
     # Mexico (MCC 334)
     "334001": "Comunicaciones Digitales Del Norte, S.A. de C.V.",
     "334010": "AT&T",
@@ -1143,7 +1127,6 @@ NETWORK_OPERATORS = {
     "334200": "Virgin Mobile",
     "334210": "YO Mobile",
     "334220": "Megamóvil",
-
     # Russia (MCC 250)
     "25001": "MTS",
     "25002": "MegaFon",
@@ -1194,7 +1177,6 @@ NETWORK_OPERATORS = {
     "25096": "+7Telecom",
     "25097": "Phoenix",
     "25099": "Beeline",
-
     # South Africa (MCC 655)
     "65501": "Vodacom",
     "65502": "Telkom",
@@ -1235,9 +1217,7 @@ NETWORK_OPERATORS = {
     "65575": "ACSA",
     "65576": "Comsol Networks (Pty) Ltd",
     "65577": "Umoja Connect",
-
     # Add more countries as needed...
-
     # Additional network codes
     "001001": "TEST",
     "00101": "TEST",
@@ -3114,10 +3094,10 @@ NETWORK_OPERATORS = {
 
 def get_network_name(network_code: str):
     """Get network operator name from MCC+MNC code.
-    
+
     Args:
         network_code: MCC+MNC code (e.g., "310260" for T-Mobile USA)
-        
+
     Returns:
         Network operator name or None if not found
     """

--- a/addon-test-current/run.py
+++ b/addon-test-current/run.py
@@ -11,31 +11,39 @@ Credits:
 Licensed under Apache License 2.0
 """
 
-import os
 import json
 import logging
+import os
 import signal
 import sys
+
 from flask import Flask, request
 from flask_httpauth import HTTPBasicAuth
 from flask_restx import Api, Resource, fields, reqparse
-
-from support import init_state_machine, retrieveAllSms, deleteSms, encodeSms, set_network_type_cache_duration, invalidate_network_type_cache
-from mqtt_publisher import MQTTPublisher
 from gammu import GSMNetworks
+from mqtt_publisher import MQTTPublisher
+from support import (
+    deleteSms,
+    encodeSms,
+    init_state_machine,
+    invalidate_network_type_cache,
+    retrieveAllSms,
+    set_network_type_cache_duration,
+)
+
 from network_codes import get_network_name
 
 # Configure logging with timestamp
 logging.basicConfig(
     level=logging.INFO,
-    format='[%(asctime)s] %(levelname)s: %(message)s',
-    datefmt='%H:%M:%S'
+    format="[%(asctime)s] %(levelname)s: %(message)s",
+    datefmt="%H:%M:%S",
 )
-mqtt_logger = logging.getLogger('mqtt_publisher')
+mqtt_logger = logging.getLogger("mqtt_publisher")
 mqtt_logger.setLevel(logging.INFO)
 
 # Suppress Flask development server warnings
-log = logging.getLogger('werkzeug')
+log = logging.getLogger("werkzeug")
 log.setLevel(logging.ERROR)
 
 # Load version early for startup banner
@@ -43,14 +51,20 @@ VERSION = None  # Will be loaded properly later
 
 # Monkey-patch click.echo to suppress Flask CLI startup messages
 import click
+
 _original_echo = click.echo
+
+
 def _silent_echo(message=None, **kwargs):
     # Only suppress Flask's "Debug mode:" and "Serving Flask app" messages
     if message and isinstance(message, str):
-        if 'Debug mode:' in message or 'Serving Flask app' in message:
+        if "Debug mode:" in message or "Serving Flask app" in message:
             return
     _original_echo(message, **kwargs)
+
+
 click.echo = _silent_echo
+
 
 def load_version():
     """Load version from config.yaml"""
@@ -60,17 +74,20 @@ def load_version():
         if supervisor_token:
             try:
                 import requests
-                response = requests.get('http://supervisor/addons/self/info',
-                                       headers={'Authorization': f'Bearer {supervisor_token}'},
-                                       timeout=2)
+
+                response = requests.get(
+                    "http://supervisor/addons/self/info",
+                    headers={"Authorization": f"Bearer {supervisor_token}"},
+                    timeout=2,
+                )
                 if response.status_code == 200:
                     data = response.json()
                     logging.debug(f"Supervisor API response: {data}")
                     # The structure might be: {'result': 'ok', 'data': {'version': 'x.x.x'}}
                     # or just: {'data': {'version': 'x.x.x'}}
-                    if 'data' in data and 'version' in data['data']:
-                        version = data['data']['version']
-                        if version and version != 'unknown':
+                    if "data" in data and "version" in data["data"]:
+                        version = data["data"]["version"]
+                        if version and version != "unknown":
                             logging.debug(f"Got version from Supervisor API: {version}")
                             return version
             except Exception as e:
@@ -79,18 +96,21 @@ def load_version():
 
         # Fallback: try to read from config.yaml in multiple locations
         possible_paths = [
-            '/config.yaml',  # Root location when copied to container
-            os.path.join(os.path.dirname(__file__), 'config.yaml'),  # Same directory as run.py
-            '/data/../config.yaml',  # Relative to data directory
+            "/config.yaml",  # Root location when copied to container
+            os.path.join(
+                os.path.dirname(__file__), "config.yaml"
+            ),  # Same directory as run.py
+            "/data/../config.yaml",  # Relative to data directory
         ]
-        
+
         import yaml
+
         for config_yaml_path in possible_paths:
             logging.debug(f"Trying to read version from: {config_yaml_path}")
             if os.path.exists(config_yaml_path):
-                with open(config_yaml_path, 'r') as f:
+                with open(config_yaml_path, "r") as f:
                     config_data = yaml.safe_load(f)
-                    version = config_data.get('version')
+                    version = config_data.get("version")
                     if version:
                         logging.debug(f"Got version from {config_yaml_path}: {version}")
                         return version
@@ -101,44 +121,46 @@ def load_version():
         logging.warning(f"Could not read version: {e}")
         return "unknown"
 
+
 def load_ha_config():
     """Load Home Assistant add-on configuration"""
-    config_path = '/data/options.json'
+    config_path = "/data/options.json"
     if os.path.exists(config_path):
-        with open(config_path, 'r') as f:
+        with open(config_path, "r") as f:
             return json.load(f)
     else:
         # Default values for testing outside HA
         return {
-            'device_path': '/dev/ttyUSB0',
-            'pin': '',
-            'port': 5000,
-            'ssl': False,
-            'username': 'admin',
-            'password': 'password',
-            'mqtt_enabled': True,
-            'mqtt_host': 'localhost',
-            'mqtt_port': 1883,
-            'mqtt_username': '',
-            'mqtt_password': '',
-            'mqtt_topic_prefix': 'homeassistant/sensor/sms_gateway',
-            'sms_monitoring_enabled': True,
-            'sms_check_interval': 60,
-            'sms_cost_per_message': 0.0,
-            'sms_cost_currency': 'CZK',
-            'auto_delete_read_sms': False
+            "device_path": "/dev/ttyUSB0",
+            "pin": "",
+            "port": 5000,
+            "ssl": False,
+            "username": "admin",
+            "password": "password",
+            "mqtt_enabled": True,
+            "mqtt_host": "localhost",
+            "mqtt_port": 1883,
+            "mqtt_username": "",
+            "mqtt_password": "",
+            "mqtt_topic_prefix": "homeassistant/sensor/sms_gateway",
+            "sms_monitoring_enabled": True,
+            "sms_check_interval": 60,
+            "sms_cost_per_message": 0.0,
+            "sms_cost_currency": "CZK",
+            "auto_delete_read_sms": False,
         }
+
 
 # Load version and configuration
 VERSION = load_version()
 config = load_ha_config()
 
 # Configure logging level based on config
-log_level = config.get('log_level', 'info')
-if log_level == 'debug':
+log_level = config.get("log_level", "info")
+if log_level == "debug":
     logging.getLogger().setLevel(logging.DEBUG)
     logging.info("🔍 Logging level set to DEBUG (all messages)")
-elif log_level == 'warning':
+elif log_level == "warning":
     logging.getLogger().setLevel(logging.WARNING)
     logging.warning("⚠️  Logging level set to WARNING (warnings and errors only)")
 else:  # info
@@ -148,17 +170,19 @@ else:  # info
 # Log version at startup
 logging.info(f"GSM SMS Gateway Enhanced v{VERSION}")
 
-pin = config.get('pin') if config.get('pin') else None
-ssl = config.get('ssl', False)
-port = config.get('port', 5000)
-username = config.get('username', 'admin')
-password = config.get('password', 'password')
-device_path = config.get('device_path', '/dev/ttyUSB0')
+pin = config.get("pin") if config.get("pin") else None
+ssl = config.get("ssl", False)
+port = config.get("port", 5000)
+username = config.get("username", "admin")
+password = config.get("password", "password")
+device_path = config.get("device_path", "/dev/ttyUSB0")
 
 # GET endpoint security settings
-get_endpoint_auth_required = config.get('get_endpoint_auth_required', False)
-get_endpoint_allowed_ips = config.get('get_endpoint_allowed_ips', [])
-get_endpoint_deduplication_enabled = config.get('get_endpoint_deduplication_enabled', True)
+get_endpoint_auth_required = config.get("get_endpoint_auth_required", False)
+get_endpoint_allowed_ips = config.get("get_endpoint_allowed_ips", [])
+get_endpoint_deduplication_enabled = config.get(
+    "get_endpoint_deduplication_enabled", True
+)
 logging.info(
     f"🔒 GET endpoint auth: {'REQUIRED' if get_endpoint_auth_required else 'DISABLED'}"
 )
@@ -174,28 +198,34 @@ _sms_dedup_cache = {}
 _sms_dedup_window = 15  # seconds
 
 # Configure network type cache duration
-network_type_cache_seconds = config.get('network_type_cache_seconds', 300)
+network_type_cache_seconds = config.get("network_type_cache_seconds", 300)
 set_network_type_cache_duration(network_type_cache_seconds)
 
 # Log device path and check accessibility
 logging.info(f"📱 Configured device path: {device_path}")
 
 # Check if it's a by-id symlink
-if '/dev/serial/by-id/' in device_path:
+if "/dev/serial/by-id/" in device_path:
     if os.path.islink(device_path):
         resolved_path = os.path.realpath(device_path)
         logging.info(f"🔗 By-ID symlink resolves to: {resolved_path}")
-        
+
         # Check if resolved device exists and is accessible
         if os.path.exists(resolved_path):
             logging.info(f"✅ Resolved device {resolved_path} is accessible")
         else:
-            logging.error(f"❌ ERROR: Resolved device {resolved_path} is NOT accessible!")
-            logging.error(f"💡 TIP: Add '{resolved_path}' to the 'devices' list in config.yaml")
+            logging.error(
+                f"❌ ERROR: Resolved device {resolved_path} is NOT accessible!"
+            )
+            logging.error(
+                f"💡 TIP: Add '{resolved_path}' to the 'devices' list in config.yaml"
+            )
     else:
         logging.error(f"❌ ERROR: {device_path} is not a valid symlink!")
         if not os.path.exists(device_path):
-            logging.error(f"💡 TIP: Check if /dev/serial/by-id is mounted (add to 'devices' list)")
+            logging.error(
+                f"💡 TIP: Check if /dev/serial/by-id is mounted (add to 'devices' list)"
+            )
 elif os.path.exists(device_path):
     logging.info(f"✅ Device {device_path} is accessible")
 else:
@@ -218,6 +248,7 @@ machine = init_state_machine(pin, device_path)
 # Set gammu machine for MQTT SMS sending
 mqtt_publisher.set_gammu_machine(machine)
 
+
 # Setup signal handlers for graceful shutdown
 def signal_handler(signum, frame):
     """Handle shutdown signals (SIGTERM, SIGINT)"""
@@ -230,11 +261,14 @@ def signal_handler(signum, frame):
     finally:
         sys.exit(0)
 
+
 signal.signal(signal.SIGTERM, signal_handler)
 signal.signal(signal.SIGINT, signal_handler)
 
 # Register atexit handler as backup
 import atexit
+
+
 def cleanup():
     """Cleanup function called on normal exit"""
     logging.info("🧹 Cleanup: Publishing offline status...")
@@ -243,20 +277,25 @@ def cleanup():
     except Exception as e:
         logging.error(f"Error during cleanup: {e}")
 
+
 atexit.register(cleanup)
 
 app = Flask(__name__)
 
 # Check if running under Ingress
 import os
-ingress_path = os.environ.get('INGRESS_PATH', '')
+
+ingress_path = os.environ.get("INGRESS_PATH", "")
+
 
 # Create simple HTML page for Ingress
-@app.route('/')
+@app.route("/")
 def home():
     """Simple status page for Home Assistant Ingress"""
     from flask import Response, request
-    html = '''
+
+    html = (
+        """
     <!DOCTYPE html>
     <html>
     <head>
@@ -323,7 +362,9 @@ def home():
                 Version: {VERSION}
             </div>
             
-            <a href="http://''' + request.host.split(':')[0] + ''':5000/docs/" 
+            <a href="http://"""
+        + request.host.split(":")[0]
+        + """:5000/docs/" 
                class="swagger-link" target="_blank">
                 📋 Open Swagger API Documentation
             </a>
@@ -344,29 +385,28 @@ def home():
         </div>
     </body>
     </html>
-    '''
-    return Response(html.replace('{VERSION}', VERSION), mimetype='text/html')
+    """
+    )
+    return Response(html.replace("{VERSION}", VERSION), mimetype="text/html")
+
 
 # Swagger UI Configuration
 # Put Swagger UI on /docs/ path for direct access via port 5000
 api = Api(
     app,
     version=VERSION,
-    title='SMS Gammu Gateway API',
-    description='REST API for sending and receiving SMS messages via USB GSM modems (SIM800L, Huawei, etc.). Modern replacement for deprecated SMS notifications via GSM-modem integration.',
-    doc='/docs/',  # Swagger UI on /docs/ path
-    prefix='',
+    title="SMS Gammu Gateway API",
+    description="REST API for sending and receiving SMS messages via USB GSM modems (SIM800L, Huawei, etc.). Modern replacement for deprecated SMS notifications via GSM-modem integration.",
+    doc="/docs/",  # Swagger UI on /docs/ path
+    prefix="",
     authorizations={
-        'basicAuth': {
-            'type': 'basic',
-            'in': 'header',
-            'name': 'Authorization'
-        }
+        "basicAuth": {"type": "basic", "in": "header", "name": "Authorization"}
     },
-    security='basicAuth'
+    security="basicAuth",
 )
 
 auth = HTTPBasicAuth()
+
 
 @auth.verify_password
 def verify(user, pwd):
@@ -374,173 +414,273 @@ def verify(user, pwd):
         return False
     return user == username and pwd == password
 
+
 # API Models for Swagger documentation
-sms_model = api.model('SMS', {
-    'text': fields.String(required=True, description='SMS message text', example='Hello, how are you?'),
-    'number': fields.String(required=True, description='Phone number (international format)', example='+420123456789'),
-    'smsc': fields.String(required=False, description='SMS Center number (optional)', example='+420603052000'),
-    'unicode': fields.Boolean(required=False, description='Use Unicode encoding', default=False),
-    'flash': fields.Boolean(required=False, description='Send as Flash SMS (displays on screen, not saved)', default=False)
-})
+sms_model = api.model(
+    "SMS",
+    {
+        "text": fields.String(
+            required=True, description="SMS message text", example="Hello, how are you?"
+        ),
+        "number": fields.String(
+            required=True,
+            description="Phone number (international format)",
+            example="+420123456789",
+        ),
+        "smsc": fields.String(
+            required=False,
+            description="SMS Center number (optional)",
+            example="+420603052000",
+        ),
+        "unicode": fields.Boolean(
+            required=False, description="Use Unicode encoding", default=False
+        ),
+        "flash": fields.Boolean(
+            required=False,
+            description="Send as Flash SMS (displays on screen, not saved)",
+            default=False,
+        ),
+    },
+)
 
-sms_response = api.model('SMS Response', {
-    'Date': fields.String(description='Date and time received', example='2025-01-19 14:30:00'),
-    'Number': fields.String(description='Sender phone number', example='+420123456789'),
-    'State': fields.String(description='SMS state', example='UnRead'),
-    'Text': fields.String(description='SMS message text', example='Hello World!')
-})
+sms_response = api.model(
+    "SMS Response",
+    {
+        "Date": fields.String(
+            description="Date and time received", example="2025-01-19 14:30:00"
+        ),
+        "Number": fields.String(
+            description="Sender phone number", example="+420123456789"
+        ),
+        "State": fields.String(description="SMS state", example="UnRead"),
+        "Text": fields.String(description="SMS message text", example="Hello World!"),
+    },
+)
 
-signal_response = api.model('Signal Quality', {
-    'SignalStrength': fields.Integer(description='Signal strength in dBm', example=-75),
-    'SignalPercent': fields.Integer(description='Signal strength percentage', example=65),
-    'BitErrorRate': fields.Integer(description='Bit error rate', example=-1)
-})
+signal_response = api.model(
+    "Signal Quality",
+    {
+        "SignalStrength": fields.Integer(
+            description="Signal strength in dBm", example=-75
+        ),
+        "SignalPercent": fields.Integer(
+            description="Signal strength percentage", example=65
+        ),
+        "BitErrorRate": fields.Integer(description="Bit error rate", example=-1),
+    },
+)
 
-network_response = api.model('Network Info', {
-    'NetworkName': fields.String(description='Network operator name', example='T-Mobile'),
-    'State': fields.String(description='Network registration state', example='HomeNetwork'),
-    'NetworkCode': fields.String(description='Network operator code', example='230 01'),
-    'CID': fields.String(description='Cell ID', example='0A1B2C3D'),
-    'LAC': fields.String(description='Location Area Code', example='1234')
-})
+network_response = api.model(
+    "Network Info",
+    {
+        "NetworkName": fields.String(
+            description="Network operator name", example="T-Mobile"
+        ),
+        "State": fields.String(
+            description="Network registration state", example="HomeNetwork"
+        ),
+        "NetworkCode": fields.String(
+            description="Network operator code", example="230 01"
+        ),
+        "CID": fields.String(description="Cell ID", example="0A1B2C3D"),
+        "LAC": fields.String(description="Location Area Code", example="1234"),
+    },
+)
 
-send_response = api.model('Send Response', {
-    'status': fields.Integer(description='HTTP status code', example=200),
-    'message': fields.String(description='Response message', example='[1]')
-})
+send_response = api.model(
+    "Send Response",
+    {
+        "status": fields.Integer(description="HTTP status code", example=200),
+        "message": fields.String(description="Response message", example="[1]"),
+    },
+)
 
-reset_response = api.model('Reset Response', {
-    'status': fields.Integer(description='HTTP status code', example=200),
-    'message': fields.String(description='Reset message', example='Reset done')
-})
+reset_response = api.model(
+    "Reset Response",
+    {
+        "status": fields.Integer(description="HTTP status code", example=200),
+        "message": fields.String(description="Reset message", example="Reset done"),
+    },
+)
 
-modem_info_response = api.model('Modem Info', {
-    'IMEI': fields.String(description='Modem IMEI number', example='123456789012345'),
-    'Manufacturer': fields.String(description='Modem manufacturer', example='Huawei'),
-    'Model': fields.String(description='Modem model', example='E3372'),
-    'Firmware': fields.String(description='Firmware version', example='22.323.62.00.143')
-})
+modem_info_response = api.model(
+    "Modem Info",
+    {
+        "IMEI": fields.String(
+            description="Modem IMEI number", example="123456789012345"
+        ),
+        "Manufacturer": fields.String(
+            description="Modem manufacturer", example="Huawei"
+        ),
+        "Model": fields.String(description="Modem model", example="E3372"),
+        "Firmware": fields.String(
+            description="Firmware version", example="22.323.62.00.143"
+        ),
+    },
+)
 
-sim_info_response = api.model('SIM Info', {
-    'IMSI': fields.String(description='SIM IMSI number', example='230011234567890')
-})
+sim_info_response = api.model(
+    "SIM Info",
+    {"IMSI": fields.String(description="SIM IMSI number", example="230011234567890")},
+)
 
-sms_capacity_response = api.model('SMS Capacity', {
-    'SIMUsed': fields.Integer(description='SMS count in SIM memory', example=5),
-    'SIMSize': fields.Integer(description='SIM total capacity', example=50),
-    'PhoneUsed': fields.Integer(description='SMS count in phone memory', example=0),
-    'PhoneSize': fields.Integer(description='Phone memory capacity', example=100),
-    'TemplatesUsed': fields.Integer(description='SMS templates used', example=0)
-})
+sms_capacity_response = api.model(
+    "SMS Capacity",
+    {
+        "SIMUsed": fields.Integer(description="SMS count in SIM memory", example=5),
+        "SIMSize": fields.Integer(description="SIM total capacity", example=50),
+        "PhoneUsed": fields.Integer(description="SMS count in phone memory", example=0),
+        "PhoneSize": fields.Integer(description="Phone memory capacity", example=100),
+        "TemplatesUsed": fields.Integer(description="SMS templates used", example=0),
+    },
+)
 
 # API Namespaces
-ns_sms = api.namespace('sms', description='SMS operations (requires authentication)')
-ns_status = api.namespace('status', description='Device status and information (public)')
+ns_sms = api.namespace("sms", description="SMS operations (requires authentication)")
+ns_status = api.namespace(
+    "status", description="Device status and information (public)"
+)
 
-@ns_sms.route('')
-@ns_sms.doc('sms_operations')
+
+@ns_sms.route("")
+@ns_sms.doc("sms_operations")
 class SmsCollection(Resource):
-    @ns_sms.doc('get_all_sms')
+    @ns_sms.doc("get_all_sms")
     @ns_sms.marshal_list_with(sms_response, code=200)
-    @ns_sms.doc(security='basicAuth')
+    @ns_sms.doc(security="basicAuth")
     @auth.login_required
     def get(self):
         """Get all SMS messages from SIM/device memory"""
-        allSms = mqtt_publisher.track_gammu_operation("retrieveAllSms", retrieveAllSms, machine)
+        allSms = mqtt_publisher.track_gammu_operation(
+            "retrieveAllSms", retrieveAllSms, machine
+        )
         list(map(lambda sms: sms.pop("Locations", None), allSms))
         return allSms
 
-    @ns_sms.doc('send_sms')
+    @ns_sms.doc("send_sms")
     @ns_sms.expect(sms_model)
     @ns_sms.marshal_with(send_response, code=200)
-    @ns_sms.doc(security='basicAuth')
+    @ns_sms.doc(security="basicAuth")
     @auth.login_required
     def post(self):
         """Send SMS message(s)"""
         # Support both JSON and form-encoded data
         # Check Content-Type to decide how to parse request
-        content_type = request.content_type or ''
-        
-        if 'application/json' in content_type:
+        content_type = request.content_type or ""
+
+        if "application/json" in content_type:
             # JSON request - use get_json()
             data = request.get_json() or {}
-        elif 'application/x-www-form-urlencoded' in content_type or 'multipart/form-data' in content_type:
+        elif (
+            "application/x-www-form-urlencoded" in content_type
+            or "multipart/form-data" in content_type
+        ):
             # Form-encoded request - use form data
             data = dict(request.form)
             # Convert boolean strings to actual booleans
-            if 'unicode' in data:
-                data['unicode'] = data['unicode'].lower() in ('true', '1', 'yes')
-            if 'flash' in data:
-                data['flash'] = data['flash'].lower() in ('true', '1', 'yes')
+            if "unicode" in data:
+                data["unicode"] = data["unicode"].lower() in ("true", "1", "yes")
+            if "flash" in data:
+                data["flash"] = data["flash"].lower() in ("true", "1", "yes")
         else:
             # Try both methods as fallback
             data = request.get_json(silent=True) or {}
             if not data:
                 # Fall back to form data
                 data = dict(request.form)
-        
+
         # If still no data, try query parameters as last resort
         if not data:
             parser = reqparse.RequestParser()
-            parser.add_argument('text', required=False, help='SMS message text')
-            parser.add_argument('message', required=False, help='SMS message text (alias for text)')
-            parser.add_argument('number', required=False, help='Phone number(s), comma separated')
-            parser.add_argument('target', required=False, help='Phone number (alias for number)')
-            parser.add_argument('smsc', required=False, help='SMS Center number (optional)')
-            parser.add_argument('unicode', type=bool, required=False, default=None, help='Use Unicode encoding (auto-detect if not specified)')
-            parser.add_argument('flash', type=bool, required=False, default=False, help='Send as Flash SMS')
+            parser.add_argument("text", required=False, help="SMS message text")
+            parser.add_argument(
+                "message", required=False, help="SMS message text (alias for text)"
+            )
+            parser.add_argument(
+                "number", required=False, help="Phone number(s), comma separated"
+            )
+            parser.add_argument(
+                "target", required=False, help="Phone number (alias for number)"
+            )
+            parser.add_argument(
+                "smsc", required=False, help="SMS Center number (optional)"
+            )
+            parser.add_argument(
+                "unicode",
+                type=bool,
+                required=False,
+                default=None,
+                help="Use Unicode encoding (auto-detect if not specified)",
+            )
+            parser.add_argument(
+                "flash",
+                type=bool,
+                required=False,
+                default=False,
+                help="Send as Flash SMS",
+            )
             data = parser.parse_args()
         # Note: Don't set unicode default here - let auto-detection handle it
-        
+
         # Support both 'text' and 'message' parameters
-        sms_text = data.get('text') or data.get('message')
+        sms_text = data.get("text") or data.get("message")
         if not sms_text:
-            return {"status": 400, "message": "Missing required field: text or message"}, 400
-        
+            return {
+                "status": 400,
+                "message": "Missing required field: text or message",
+            }, 400
+
         # Support both 'number' and 'target' parameters
-        sms_number = data.get('number') or data.get('target')
+        sms_number = data.get("number") or data.get("target")
         if not sms_number:
-            return {"status": 400, "message": "Missing required field: number or target"}, 400
-        
-        logging.info(f"SMS send request - Text: '{sms_text}', Numbers: '{sms_number}', Type: {type(sms_number)}")
-        
+            return {
+                "status": 400,
+                "message": "Missing required field: number or target",
+            }, 400
+
+        logging.info(
+            f"SMS send request - Text: '{sms_text}', Numbers: '{sms_number}', Type: {type(sms_number)}"
+        )
+
         # Handle both string (comma-separated) and list formats
         if isinstance(sms_number, list):
             numbers = sms_number
         else:
             # Check if it's a string representation of a list (e.g., "['phone1', 'phone2']")
             sms_number_str = str(sms_number).strip()
-            if sms_number_str.startswith('[') and sms_number_str.endswith(']'):
+            if sms_number_str.startswith("[") and sms_number_str.endswith("]"):
                 try:
                     # Try to parse as JSON array first
                     import json
+
                     numbers = json.loads(sms_number_str)
                 except:
                     # If JSON parsing fails, try Python literal eval
                     try:
                         import ast
+
                         numbers = ast.literal_eval(sms_number_str)
                     except:
                         # Fall back to treating as single number
                         numbers = [sms_number_str]
             else:
                 # Comma-separated string
-                numbers = [n.strip() for n in sms_number_str.split(',')]
-        
+                numbers = [n.strip() for n in sms_number_str.split(",")]
+
         # Auto-detect unicode if not explicitly specified
         # This matches the behavior of MQTT send methods
-        unicode_mode = data.get('unicode')
+        unicode_mode = data.get("unicode")
         if unicode_mode is None:
             # Auto-detect: check if text contains non-ASCII characters (emojis, etc.)
             try:
-                sms_text.encode('ascii')
+                sms_text.encode("ascii")
                 unicode_mode = False
             except UnicodeEncodeError:
                 unicode_mode = True
                 logging.info("🔤 Auto-detected Unicode mode for non-ASCII text")
 
         # Determine SMS class based on flash parameter
-        flash_mode = data.get('flash', False)
+        flash_mode = data.get("flash", False)
         sms_class = 0 if flash_mode else -1
         if flash_mode:
             logging.info("⚡ Sending Flash SMS (will display on screen without saving)")
@@ -555,24 +695,24 @@ class SmsCollection(Resource):
                 }
             ],
         }
-        
+
         # Get cached SMSC for reliable sending
         cached_smsc = mqtt_publisher.get_cached_smsc()
-        
+
         messages = []
         for number in numbers:
             for message in encodeSms(smsinfo):
                 # Use cached SMSC if available (more reliable)
                 if data.get("smsc"):
-                    message["SMSC"] = {'Number': data.get("smsc")}
+                    message["SMSC"] = {"Number": data.get("smsc")}
                 elif cached_smsc:
-                    message["SMSC"] = {'Number': cached_smsc}
+                    message["SMSC"] = {"Number": cached_smsc}
                 else:
-                    message["SMSC"] = {'Location': 1}
-                
+                    message["SMSC"] = {"Location": 1}
+
                 message["Number"] = number.strip()
                 messages.append(message)
-        
+
         # Send SMS with automatic retry on recoverable errors
         # Queue SMS BEFORE sending to survive restarts during send/retry
         results = []
@@ -582,10 +722,10 @@ class SmsCollection(Resource):
             smsc = None
             if message.get("SMSC") and message["SMSC"].get("Number"):
                 smsc = message["SMSC"]["Number"]
-            
+
             # Queue SMS first to survive restarts during send attempt
             mqtt_publisher.queue_sms_for_retry(number, sms_text, smsc)
-            
+
             try:
                 mqtt_publisher.track_gammu_operation(
                     "SendSMS", machine.SendSMS, message
@@ -596,68 +736,62 @@ class SmsCollection(Resource):
                 mqtt_publisher.sms_counter.increment()
             except Exception as e:
                 # Check if recoverable error was detected and reset triggered
-                if getattr(e, 'err_recoverable_detected', False):
+                if getattr(e, "err_recoverable_detected", False):
                     logging.warning(
-                        f"🔄 Retrying SMS to {number} "
-                        "after modem reconnect..."
+                        f"🔄 Retrying SMS to {number} " "after modem reconnect..."
                     )
                     time.sleep(5)  # Additional wait after reconnect
                     try:
                         # Use publisher's gammu_machine (may have been reconnected)
                         mqtt_publisher.track_gammu_operation(
-                            "SendSMS",
-                            mqtt_publisher.gammu_machine.SendSMS,
-                            message
+                            "SendSMS", mqtt_publisher.gammu_machine.SendSMS, message
                         )
                         # Success - remove from queue
                         mqtt_publisher.sms_queue.remove(number, sms_text)
                         results.append(number)
                         mqtt_publisher.sms_counter.increment()
-                        logging.info(
-                            f"✅ SMS sent to {number} after retry"
-                        )
+                        logging.info(f"✅ SMS sent to {number} after retry")
                     except Exception as retry_error:
                         # Final failure - already in queue, just log
                         logging.error(
                             f"❌ SMS retry failed for {number}: {retry_error}"
                         )
-                        logging.info(
-                            f"📥 SMS to {number} remains queued for later"
-                        )
+                        logging.info(f"📥 SMS to {number} remains queued for later")
                         # Don't raise - continue with other messages
                 else:
                     # Non-recoverable error - already in queue, just log
                     logging.error(f"❌ SMS failed for {number}: {e}")
                     logging.info(f"📥 SMS to {number} remains queued for later")
                     # Don't raise - continue with other messages
-        
+
         mqtt_publisher.publish_sms_counter()
-        
+
         # Build response message
         total_numbers = len(set([m["Number"] for m in messages]))
         sent_count = len(results)
         queued_count = total_numbers - sent_count
-        
+
         if queued_count > 0:
             msg = f"Sent to {sent_count} number(s), {queued_count} queued for retry"
             return {"status": 200, "message": msg}, 200
         else:
             return {"status": 200, "message": f"Sent to {sent_count} number(s)"}, 200
 
-@ns_sms.route('/add/<path:sms_data>')
-@ns_sms.route('/<path:sms_data>')
-@ns_sms.doc('send_sms_get')
+
+@ns_sms.route("/add/<path:sms_data>")
+@ns_sms.route("/<path:sms_data>")
+@ns_sms.doc("send_sms_get")
 class SmsGet(Resource):
-    @ns_sms.doc('send_sms_via_get')
+    @ns_sms.doc("send_sms_via_get")
     @ns_sms.doc(
         params={
-            'sms_data': {
-                'description': 'Phone number and message format: {PHONE}&{MESSAGE}',
-                'type': 'string',
-                'example': '5555551234&Test+message'
+            "sms_data": {
+                "description": "Phone number and message format: {PHONE}&{MESSAGE}",
+                "type": "string",
+                "example": "5555551234&Test+message",
             }
         },
-        description='''
+        description="""
         Add/Send SMS via GET request with data in URL path - designed for legacy devices.
         
         📱 **Format:** GET /sms/add/{PHONE_NUMBER}&{MESSAGE} (or /sms/{PHONE_NUMBER}&{MESSAGE})
@@ -684,12 +818,12 @@ class SmsGet(Resource):
         • Authentication disabled by default for legacy device compatibility
         • Use POST /sms for authenticated requests in modern applications
         • Deduplication uses: {phone}|{message} as cache key
-        '''
+        """,
     )
-    @ns_sms.response(200, 'SMS sent successfully', send_response)
-    @ns_sms.response(400, 'Invalid request format')
-    @ns_sms.response(401, 'Authentication required')
-    @ns_sms.response(403, 'IP address not authorized')
+    @ns_sms.response(200, "SMS sent successfully", send_response)
+    @ns_sms.response(400, "Invalid request format")
+    @ns_sms.response(401, "Authentication required")
+    @ns_sms.response(403, "IP address not authorized")
     def get(self, sms_data):
         """Send SMS via GET request (legacy compatibility)"""
         # Check IP whitelist
@@ -697,88 +831,87 @@ class SmsGet(Resource):
         if get_endpoint_allowed_ips:
             if not is_ip_allowed(client_ip, get_endpoint_allowed_ips):
                 logging.warning(
-                    f"🚫 Access denied from {client_ip} "
-                    f"(not in whitelist)"
+                    f"🚫 Access denied from {client_ip} " f"(not in whitelist)"
                 )
                 return {
-                    'status': 403,
-                    'message': 'Access denied - IP not authorized'
+                    "status": 403,
+                    "message": "Access denied - IP not authorized",
                 }, 403
-        
+
         # Check auth if required
         if get_endpoint_auth_required:
-            auth_header = request.headers.get('Authorization')
+            auth_header = request.headers.get("Authorization")
             if not auth_header:
-                logging.warning(
-                    f"🔒 Unauthorized GET request from {client_ip}"
-                )
-                return {
-                    'status': 401,
-                    'message': 'Authentication required'
-                }, 401
-            
+                logging.warning(f"🔒 Unauthorized GET request from {client_ip}")
+                return {"status": 401, "message": "Authentication required"}, 401
+
             # Verify Basic Auth
             try:
                 import base64
-                auth_type, credentials = auth_header.split(' ', 1)
-                if auth_type.lower() != 'basic':
-                    return {'status': 401, 'message': 'Invalid auth'}, 401
-                
-                decoded = base64.b64decode(credentials).decode('utf-8')
-                provided_user, provided_pass = decoded.split(':', 1)
-                
+
+                auth_type, credentials = auth_header.split(" ", 1)
+                if auth_type.lower() != "basic":
+                    return {"status": 401, "message": "Invalid auth"}, 401
+
+                decoded = base64.b64decode(credentials).decode("utf-8")
+                provided_user, provided_pass = decoded.split(":", 1)
+
                 if provided_user != username or provided_pass != password:
                     logging.warning(f"🔒 Invalid credentials from {client_ip}")
-                    return {'status': 401, 'message': 'Invalid credentials'}, 401
+                    return {"status": 401, "message": "Invalid credentials"}, 401
             except Exception as e:
                 logging.error(f"Auth error: {e}")
-                return {'status': 401, 'message': 'Auth error'}, 401
-        
+                return {"status": 401, "message": "Auth error"}, 401
+
         # Parse path: {PHONE}&{MESSAGE}
-        if '&' not in sms_data:
+        if "&" not in sms_data:
             return {
                 "status": 400,
-                "message": "Invalid format. Use: /sms/{PHONE}&{MESSAGE}"
+                "message": "Invalid format. Use: /sms/{PHONE}&{MESSAGE}",
             }, 400
-        
+
         # Split on first &
-        parts = sms_data.split('&', 1)
+        parts = sms_data.split("&", 1)
         if len(parts) != 2:
             return {
                 "status": 400,
-                "message": "Invalid format. Use: /sms/{PHONE}&{MESSAGE}"
+                "message": "Invalid format. Use: /sms/{PHONE}&{MESSAGE}",
             }, 400
-        
+
         sms_number = parts[0].strip()
         sms_text = parts[1].strip()
-        
+
         # URL decode (replace + with space, etc.)
         from urllib.parse import unquote_plus
+
         sms_number = unquote_plus(sms_number)
         sms_text = unquote_plus(sms_text)
-        
+
         if not sms_number or not sms_text:
             return {
                 "status": 400,
-                "message": "Phone number and message cannot be empty"
+                "message": "Phone number and message cannot be empty",
             }, 400
-        
+
         logging.info(
-            f"📨 GET SMS request - Number: '{sms_number}', "
-            f"Text: '{sms_text}'"
+            f"📨 GET SMS request - Number: '{sms_number}', " f"Text: '{sms_text}'"
         )
-        
+
         # Check for duplicate request (device retry) if enabled
         import time
+
         dedup_key = f"{sms_number}|{sms_text}"
         current_time = time.time()
-        
+
         if get_endpoint_deduplication_enabled:
             # Clean old entries from cache
             global _sms_dedup_cache
-            _sms_dedup_cache = {k: v for k, v in _sms_dedup_cache.items() 
-                                if current_time - v < _sms_dedup_window}
-            
+            _sms_dedup_cache = {
+                k: v
+                for k, v in _sms_dedup_cache.items()
+                if current_time - v < _sms_dedup_window
+            }
+
             # Check if this SMS was just sent
             if dedup_key in _sms_dedup_cache:
                 time_since = current_time - _sms_dedup_cache[dedup_key]
@@ -788,18 +921,18 @@ class SmsGet(Resource):
                 )
                 return {
                     "status": 200,
-                    "message": f"SMS already sent to {sms_number} recently"
+                    "message": f"SMS already sent to {sms_number} recently",
                 }, 200
-        
+
         # Encode and send SMS (same logic as POST)
         try:
             # Auto-detect unicode
             try:
-                sms_text.encode('ascii')
+                sms_text.encode("ascii")
                 unicode_mode = False
             except UnicodeEncodeError:
                 unicode_mode = True
-            
+
             # Build smsinfo dict (same as POST endpoint)
             smsinfo = {
                 "Class": -1,  # Normal SMS
@@ -811,68 +944,64 @@ class SmsGet(Resource):
                     }
                 ],
             }
-            
+
             # Get cached SMSC for reliable sending
             cached_smsc = mqtt_publisher.get_cached_smsc()
-            
+
             # Encode SMS (returns list of message parts)
             messages = []
             for message in encodeSms(smsinfo):
                 if cached_smsc:
-                    message["SMSC"] = {'Number': cached_smsc}
+                    message["SMSC"] = {"Number": cached_smsc}
                 else:
-                    message["SMSC"] = {'Location': 1}
+                    message["SMSC"] = {"Location": 1}
                 message["Number"] = sms_number
                 messages.append(message)
-            
+
             # Validate we got messages
             if not messages:
                 raise ValueError("encodeSms returned no messages")
-            
+
             # Queue SMS first
             smsc = messages[0].get("SMSC", {}).get("Number")
             mqtt_publisher.queue_sms_for_retry(sms_number, sms_text, smsc)
-            
+
             # Send all message parts
             for message in messages:
                 mqtt_publisher.track_gammu_operation(
                     "SendSMS", machine.SendSMS, message
                 )
-            
+
             # Success - remove from queue
             mqtt_publisher.sms_queue.remove(sms_number, sms_text)
             mqtt_publisher.sms_counter.increment()
             mqtt_publisher.publish_sms_counter()
-            
+
             # Add to deduplication cache if enabled
             if get_endpoint_deduplication_enabled:
                 _sms_dedup_cache[dedup_key] = current_time
-            
+
             logging.info(f"✅ SMS sent via GET to {sms_number}")
-            
-            return {
-                "status": 200,
-                "message": f"SMS sent to {sms_number}"
-            }, 200
-            
+
+            return {"status": 200, "message": f"SMS sent to {sms_number}"}, 200
+
         except Exception as e:
             logging.error(f"❌ GET SMS failed for {sms_number}: {e}")
-            return {
-                "status": 500,
-                "message": f"Failed to send SMS: {str(e)}"
-            }, 500
+            return {"status": 500, "message": f"Failed to send SMS: {str(e)}"}, 500
 
 
-@ns_sms.route('/getsms')
-@ns_sms.doc('get_and_delete_first_sms')
+@ns_sms.route("/getsms")
+@ns_sms.doc("get_and_delete_first_sms")
 class GetSms(Resource):
-    @ns_sms.doc('pop_first_sms')
+    @ns_sms.doc("pop_first_sms")
     @ns_sms.marshal_with(sms_response, code=200)
-    @ns_sms.doc(security='basicAuth')
+    @ns_sms.doc(security="basicAuth")
     @auth.login_required
     def get(self):
         """Get first SMS and delete it from memory"""
-        allSms = mqtt_publisher.track_gammu_operation("retrieveAllSms", retrieveAllSms, machine)
+        allSms = mqtt_publisher.track_gammu_operation(
+            "retrieveAllSms", retrieveAllSms, machine
+        )
         sms = {"Date": "", "Number": "", "State": "", "Text": ""}
         if len(allSms) > 0:
             sms = allSms[0]
@@ -883,75 +1012,91 @@ class GetSms(Resource):
                 mqtt_publisher.publish_sms_received(sms)
         return sms
 
-@ns_sms.route('/deleteall')
-@ns_sms.doc('delete_all_sms')
+
+@ns_sms.route("/deleteall")
+@ns_sms.doc("delete_all_sms")
 class DeleteAllSms(Resource):
-    @ns_sms.doc('delete_all_messages')
-    @ns_sms.doc(security='basicAuth')
+    @ns_sms.doc("delete_all_messages")
+    @ns_sms.doc(security="basicAuth")
     @auth.login_required
     def delete(self):
         """Delete all SMS messages from SIM/device memory"""
-        allSms = mqtt_publisher.track_gammu_operation("retrieveAllSms", retrieveAllSms, machine)
+        allSms = mqtt_publisher.track_gammu_operation(
+            "retrieveAllSms", retrieveAllSms, machine
+        )
         count = len(allSms)
         for sms in allSms:
             mqtt_publisher.track_gammu_operation("deleteSms", deleteSms, machine, sms)
         return {"status": 200, "message": f"Deleted {count} SMS messages"}, 200
 
-@ns_sms.route('/<int:id>')
-@ns_sms.doc('sms_by_id')
+
+@ns_sms.route("/<int:id>")
+@ns_sms.doc("sms_by_id")
 class SmsItem(Resource):
-    @ns_sms.doc('get_sms_by_id')
+    @ns_sms.doc("get_sms_by_id")
     @ns_sms.marshal_with(sms_response, code=200)
-    @ns_sms.doc(security='basicAuth')
+    @ns_sms.doc(security="basicAuth")
     @auth.login_required
     def get(self, id):
         """Get specific SMS by ID"""
-        allSms = mqtt_publisher.track_gammu_operation("retrieveAllSms", retrieveAllSms, machine)
+        allSms = mqtt_publisher.track_gammu_operation(
+            "retrieveAllSms", retrieveAllSms, machine
+        )
         if id < 0 or id >= len(allSms):
             api.abort(404, f"SMS with id '{id}' not found")
         sms = allSms[id]
         sms.pop("Locations", None)
         return sms
 
-    @ns_sms.doc('delete_sms_by_id')
-    @ns_sms.doc(security='basicAuth')
+    @ns_sms.doc("delete_sms_by_id")
+    @ns_sms.doc(security="basicAuth")
     @auth.login_required
     def delete(self, id):
         """Delete SMS by ID"""
-        allSms = mqtt_publisher.track_gammu_operation("retrieveAllSms", retrieveAllSms, machine)
+        allSms = mqtt_publisher.track_gammu_operation(
+            "retrieveAllSms", retrieveAllSms, machine
+        )
         if id < 0 or id >= len(allSms):
             api.abort(404, f"SMS with id '{id}' not found")
-        mqtt_publisher.track_gammu_operation("deleteSms", deleteSms, machine, allSms[id])
-        return '', 204
+        mqtt_publisher.track_gammu_operation(
+            "deleteSms", deleteSms, machine, allSms[id]
+        )
+        return "", 204
 
-@ns_status.route('/signal')
-@ns_status.doc('get_signal_quality')
+
+@ns_status.route("/signal")
+@ns_status.doc("get_signal_quality")
 class Signal(Resource):
-    @ns_status.doc('signal_strength')
+    @ns_status.doc("signal_strength")
     @ns_status.marshal_with(signal_response)
     def get(self):
         """Get GSM signal strength and quality"""
-        signal_data = mqtt_publisher.track_gammu_operation("GetSignalQuality", machine.GetSignalQuality)
+        signal_data = mqtt_publisher.track_gammu_operation(
+            "GetSignalQuality", machine.GetSignalQuality
+        )
         # Publish to MQTT if enabled
         mqtt_publisher.publish_signal_strength(signal_data)
         return signal_data
 
-@ns_status.route('/network')
-@ns_status.doc('get_network_info')
+
+@ns_status.route("/network")
+@ns_status.doc("get_network_info")
 class Network(Resource):
     # Cache for last known numeric network code (for MVNO name handling)
     _last_network_code = None
-    
-    @ns_status.doc('network_information')
+
+    @ns_status.doc("network_information")
     @ns_status.marshal_with(network_response)
     def get(self):
         """Get network operator and registration information"""
-        network = mqtt_publisher.track_gammu_operation("GetNetworkInfo", machine.GetNetworkInfo)
+        network = mqtt_publisher.track_gammu_operation(
+            "GetNetworkInfo", machine.GetNetworkInfo
+        )
         raw_network_name = network.get("NetworkName")
         network_code = network.get("NetworkCode", "")
         network_name = raw_network_name
         resolved_code = None
-        
+
         # Handle modem quirk: Some modems put operator name (e.g., "Red Pocket") in NetworkCode field
         if network_code:
             if network_code.isdigit():
@@ -961,31 +1106,32 @@ class Network(Resource):
                     # Lookup name from database if NetworkName is empty
                     network_name = get_network_name(network_code)
                     if not network_name:
-                        network_name = GSMNetworks.get(network_code, 'Unknown')
+                        network_name = GSMNetworks.get(network_code, "Unknown")
             else:
                 # Operator name in NetworkCode field (e.g., "Red Pocket", "Xfinity Mobile")
                 if not network_name or not network_name.strip():
                     network_name = network_code
-                
+
                 # Try reverse lookup: find numeric code for this operator name
                 from network_codes import NETWORK_OPERATORS
+
                 for code, name in NETWORK_OPERATORS.items():
                     if name.lower() == network_code.lower():
                         resolved_code = code
                         break
-                
+
                 # If reverse lookup fails, use cached code from previous poll
                 if not resolved_code and Network._last_network_code:
                     resolved_code = Network._last_network_code
-        
+
         # Cache the numeric code for next time (when modem reports operator name)
         if resolved_code:
             Network._last_network_code = resolved_code
-        
+
         # Update network dict with resolved values
         network["NetworkCode"] = resolved_code
-        network["NetworkName"] = network_name or 'Unknown'
-        
+        network["NetworkName"] = network_name or "Unknown"
+
         # Map Gammu's state to human-readable format
         state = network.get("State", "Unknown")
         state_map = {
@@ -997,27 +1143,36 @@ class Network(Resource):
             "Unknown": "Unknown",
         }
         network["State"] = state_map.get(state, state)
-        
+
         # Publish to MQTT if enabled
         mqtt_publisher.publish_network_info(network)
         return network
 
-@ns_status.route('/modem')
-@ns_status.doc('get_modem_info')
+
+@ns_status.route("/modem")
+@ns_status.doc("get_modem_info")
 class ModemInfo(Resource):
-    @ns_status.doc('modem_information')
+    @ns_status.doc("modem_information")
     @ns_status.marshal_with(modem_info_response)
     def get(self):
         """Get modem hardware information (IMEI, manufacturer, model, firmware)"""
         try:
             modem_info = {
-                "IMEI": mqtt_publisher.track_gammu_operation("GetIMEI", machine.GetIMEI),
-                "Manufacturer": mqtt_publisher.track_gammu_operation("GetManufacturer", machine.GetManufacturer),
-                "Model": mqtt_publisher.track_gammu_operation("GetModel", machine.GetModel)
+                "IMEI": mqtt_publisher.track_gammu_operation(
+                    "GetIMEI", machine.GetIMEI
+                ),
+                "Manufacturer": mqtt_publisher.track_gammu_operation(
+                    "GetManufacturer", machine.GetManufacturer
+                ),
+                "Model": mqtt_publisher.track_gammu_operation(
+                    "GetModel", machine.GetModel
+                ),
             }
             try:
                 # Firmware can fail on some modems
-                modem_info["Firmware"] = mqtt_publisher.track_gammu_operation("GetFirmware", machine.GetFirmware)[0]
+                modem_info["Firmware"] = mqtt_publisher.track_gammu_operation(
+                    "GetFirmware", machine.GetFirmware
+                )[0]
             except:
                 modem_info["Firmware"] = "Unknown"
 
@@ -1027,16 +1182,19 @@ class ModemInfo(Resource):
         except Exception as e:
             api.abort(500, f"Failed to get modem info: {str(e)}")
 
-@ns_status.route('/sim')
-@ns_status.doc('get_sim_info')
+
+@ns_status.route("/sim")
+@ns_status.doc("get_sim_info")
 class SimInfo(Resource):
-    @ns_status.doc('sim_information')
+    @ns_status.doc("sim_information")
     @ns_status.marshal_with(sim_info_response)
     def get(self):
         """Get SIM card information (IMSI)"""
         try:
             sim_info = {
-                "IMSI": mqtt_publisher.track_gammu_operation("GetSIMIMSI", machine.GetSIMIMSI)
+                "IMSI": mqtt_publisher.track_gammu_operation(
+                    "GetSIMIMSI", machine.GetSIMIMSI
+                )
             }
             # Publish to MQTT if enabled
             mqtt_publisher.publish_sim_info(sim_info)
@@ -1044,54 +1202,62 @@ class SimInfo(Resource):
         except Exception as e:
             api.abort(500, f"Failed to get SIM info: {str(e)}")
 
-@ns_status.route('/sms_capacity')
-@ns_status.doc('get_sms_capacity')
+
+@ns_status.route("/sms_capacity")
+@ns_status.doc("get_sms_capacity")
 class SmsCapacity(Resource):
-    @ns_status.doc('sms_storage_capacity')
+    @ns_status.doc("sms_storage_capacity")
     @ns_status.marshal_with(sms_capacity_response)
     def get(self):
         """Get SMS storage capacity and usage"""
         try:
-            capacity = mqtt_publisher.track_gammu_operation("GetSMSStatus", machine.GetSMSStatus)
+            capacity = mqtt_publisher.track_gammu_operation(
+                "GetSMSStatus", machine.GetSMSStatus
+            )
             # Publish to MQTT if enabled
             mqtt_publisher.publish_sms_capacity(capacity)
             return capacity
         except Exception as e:
             api.abort(500, f"Failed to get SMS capacity: {str(e)}")
 
-@ns_status.route('/reset')
-@ns_status.doc('reset_modem')
+
+@ns_status.route("/reset")
+@ns_status.doc("reset_modem")
 class Reset(Resource):
-    @ns_status.doc('modem_reset')
+    @ns_status.doc("modem_reset")
     @ns_status.marshal_with(reset_response)
     def get(self):
         """Reset GSM modem (useful for stuck connections)"""
         mqtt_publisher.track_gammu_operation("Reset", machine.Reset, False)
         return {"status": 200, "message": "Reset done"}, 200
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     print(f"🚀 SMS Gammu Gateway v{VERSION} started successfully!")
     print(f"📱 Device: {device_path}")
     print(f"🌐 API available on port {port}")
     print(f"🏠 Web UI: http://localhost:{port}/")
     print(f"🔒 SSL: {'Enabled' if ssl else 'Disabled'}")
-    
+
     # MQTT info
-    if config.get('mqtt_enabled', False):
-        print(f"📡 MQTT: Enabled -> {config.get('mqtt_host')}:{config.get('mqtt_port')}")
-        
+    if config.get("mqtt_enabled", False):
+        print(
+            f"📡 MQTT: Enabled -> {config.get('mqtt_host')}:{config.get('mqtt_port')}"
+        )
+
         # Wait a moment for MQTT connection, then publish initial states
         import time
+
         time.sleep(2)
         mqtt_publisher.publish_initial_states_with_machine(machine)
-        
+
         # Start periodic MQTT publishing
-        status_interval = config.get('status_update_interval', 300)
+        status_interval = config.get("status_update_interval", 300)
         mqtt_publisher.publish_status_periodic(machine, interval=status_interval)
         print(f"📊 Status Updates: Every {status_interval}s (signal, network)")
 
         # Start call monitoring via Gammu callbacks (real-time detection)
-        if config.get('missed_calls_monitoring_enabled', False):
+        if config.get("missed_calls_monitoring_enabled", False):
             if mqtt_publisher.start_callback_monitoring(machine):
                 print(f"📞 Call Monitoring: Enabled (real-time via callbacks)")
             else:
@@ -1100,21 +1266,26 @@ if __name__ == '__main__':
             print(f"📞 Call Monitoring: Disabled in configuration")
 
         # Start SMS monitoring if enabled
-        if config.get('sms_monitoring_enabled', True):
-            check_interval = config.get('sms_check_interval', 60)
+        if config.get("sms_monitoring_enabled", True):
+            check_interval = config.get("sms_check_interval", 60)
             mqtt_publisher.start_sms_monitoring(machine, check_interval=check_interval)
             print(f"📱 SMS Monitoring: Enabled (check every {check_interval}s)")
         else:
             print(f"📱 SMS Monitoring: Disabled")
     else:
         print(f"📡 MQTT: Disabled")
-    
+
     print(f"✅ Ready to send/receive SMS messages")
 
     try:
         if ssl:
-            app.run(port=port, host="0.0.0.0", ssl_context=('/ssl/cert.pem', '/ssl/key.pem'),
-                    debug=False, use_reloader=False)
+            app.run(
+                port=port,
+                host="0.0.0.0",
+                ssl_context=("/ssl/cert.pem", "/ssl/key.pem"),
+                debug=False,
+                use_reloader=False,
+            )
         else:
             app.run(port=port, host="0.0.0.0", debug=False, use_reloader=False)
     finally:

--- a/addon-test-current/support.py
+++ b/addon-test-current/support.py
@@ -6,13 +6,14 @@ Based on: https://github.com/pajikos/sms-gammu-gateway
 Licensed under Apache License 2.0
 """
 
-import sys
 import os
-import gammu
+import sys
 import time as time_module
 
+import gammu
+
 # Cache for network type detection (avoid frequent disconnects)
-_network_type_cache = {'type': None, 'timestamp': 0}
+_network_type_cache = {"type": None, "timestamp": 0}
 _network_type_cache_seconds = 300  # Default: Cache for 5 minutes (configurable)
 
 
@@ -25,11 +26,11 @@ def set_network_type_cache_duration(seconds):
 def invalidate_network_type_cache():
     """Invalidate the network type cache (call when modem reconnects)"""
     global _network_type_cache
-    _network_type_cache['type'] = None
-    _network_type_cache['timestamp'] = 0
+    _network_type_cache["type"] = None
+    _network_type_cache["timestamp"] = 0
 
 
-def init_state_machine(pin, device_path='/dev/ttyUSB0'):
+def init_state_machine(pin, device_path="/dev/ttyUSB0"):
     """Initialize gammu state machine with HA add-on config"""
     sm = gammu.StateMachine()
 
@@ -41,46 +42,47 @@ commtimeout = 10
 """
 
     # Write config to temporary file
-    config_file = '/tmp/gammu.config'
-    with open(config_file, 'w') as f:
+    config_file = "/tmp/gammu.config"
+    with open(config_file, "w") as f:
         f.write(config_content)
 
     sm.ReadConfig(Filename=config_file)
-    
+
     try:
         sm.Init()
         print(f"Successfully initialized gammu with device: {device_path}")
-        
+
         # Try to check security status
         try:
             security_status = sm.GetSecurityStatus()
             print(f"SIM security status: {security_status}")
-            
-            if security_status == 'PIN':
-                if pin is None or pin == '':
+
+            if security_status == "PIN":
+                if pin is None or pin == "":
                     print("PIN is required but not provided.")
                     sys.exit(1)
                 else:
-                    sm.EnterSecurityCode('PIN', pin)
+                    sm.EnterSecurityCode("PIN", pin)
                     print("PIN entered successfully")
-                    
+
         except Exception as e:
             print(f"Warning: Could not check SIM security status: {e}")
-            
+
     except gammu.ERR_NOSIM:
         print("Warning: SIM card not accessible, but device is connected")
     except Exception as e:
         print(f"Error initializing device: {e}")
         print("Available devices:")
         import os
+
         try:
-            devices = [d for d in os.listdir('/dev/') if d.startswith('tty')]
+            devices = [d for d in os.listdir("/dev/") if d.startswith("tty")]
             for device in sorted(devices):
                 print(f"  /dev/{device}")
         except:
             pass
         raise
-        
+
     return sm
 
 
@@ -88,7 +90,9 @@ def retrieveAllSms(machine):
     """Retrieve all SMS messages from SIM/device memory"""
     try:
         status = machine.GetSMSStatus()
-        allMultiPartSmsCount = status['SIMUsed'] + status['PhoneUsed'] + status['TemplatesUsed']
+        allMultiPartSmsCount = (
+            status["SIMUsed"] + status["PhoneUsed"] + status["TemplatesUsed"]
+        )
 
         allMultiPartSms = []
         start = True
@@ -98,7 +102,9 @@ def retrieveAllSms(machine):
                 currentMultiPartSms = machine.GetNextSMS(Start=True, Folder=0)
                 start = False
             else:
-                currentMultiPartSms = machine.GetNextSMS(Location=currentMultiPartSms[0]['Location'], Folder=0)
+                currentMultiPartSms = machine.GetNextSMS(
+                    Location=currentMultiPartSms[0]["Location"], Folder=0
+                )
             allMultiPartSms.append(currentMultiPartSms)
 
         allSms = gammu.LinkSMS(allMultiPartSms)
@@ -108,10 +114,10 @@ def retrieveAllSms(machine):
             smsPart = sms[0]
 
             result = {
-                "Date": str(smsPart['DateTime']),
-                "Number": smsPart['Number'],
-                "State": smsPart['State'],
-                "Locations": [smsPart['Location'] for smsPart in sms],
+                "Date": str(smsPart["DateTime"]),
+                "Number": smsPart["Number"],
+                "State": smsPart["State"],
+                "Locations": [smsPart["Location"] for smsPart in sms],
             }
 
             # Try to decode SMS - this may fail for MMS notifications or corrupted messages
@@ -119,41 +125,47 @@ def retrieveAllSms(machine):
                 decodedSms = gammu.DecodeSMS(sms)
                 if decodedSms == None:
                     # DecodeSMS returned None - use raw text from SMS part
-                    result["Text"] = smsPart.get('Text', '')
+                    result["Text"] = smsPart.get("Text", "")
                 else:
                     # Successfully decoded - concatenate all text entries
                     text = ""
-                    for entry in decodedSms['Entries']:
-                        if entry.get('Buffer') is not None:
-                            text += entry['Buffer']
-                    result["Text"] = text if text else smsPart.get('Text', '')
+                    for entry in decodedSms["Entries"]:
+                        if entry.get("Buffer") is not None:
+                            text += entry["Buffer"]
+                    result["Text"] = text if text else smsPart.get("Text", "")
 
             except UnicodeDecodeError as e:
                 # MMS notification or binary message that can't be decoded as UTF-8
-                print(f"Warning: Cannot decode SMS as UTF-8 (probably MMS notification): {e}")
+                print(
+                    f"Warning: Cannot decode SMS as UTF-8 (probably MMS notification): {e}"
+                )
                 # Try to get raw text, but handle potential binary data safely
                 try:
-                    raw_text = smsPart.get('Text', '')
+                    raw_text = smsPart.get("Text", "")
                     # If Text is bytes, try to decode with error handling
                     if isinstance(raw_text, bytes):
-                        result["Text"] = raw_text.decode('utf-8', errors='replace')
+                        result["Text"] = raw_text.decode("utf-8", errors="replace")
                     else:
-                        result["Text"] = str(raw_text) if raw_text else '[MMS or binary message]'
+                        result["Text"] = (
+                            str(raw_text) if raw_text else "[MMS or binary message]"
+                        )
                 except Exception:
-                    result["Text"] = '[MMS or binary message - cannot display]'
+                    result["Text"] = "[MMS or binary message - cannot display]"
 
             except Exception as e:
                 # Any other decoding error (corrupted SMS, unknown format, etc.)
                 print(f"Warning: Error decoding SMS: {e}")
                 # Fallback to raw text with safe handling
                 try:
-                    raw_text = smsPart.get('Text', '')
+                    raw_text = smsPart.get("Text", "")
                     if isinstance(raw_text, bytes):
-                        result["Text"] = raw_text.decode('utf-8', errors='replace')
+                        result["Text"] = raw_text.decode("utf-8", errors="replace")
                     else:
-                        result["Text"] = str(raw_text) if raw_text else '[Decoding error]'
+                        result["Text"] = (
+                            str(raw_text) if raw_text else "[Decoding error]"
+                        )
                 except Exception:
-                    result["Text"] = '[Message decoding failed]'
+                    result["Text"] = "[Message decoding failed]"
 
             results.append(result)
 
@@ -167,7 +179,12 @@ def retrieveAllSms(machine):
 def deleteSms(machine, sms):
     """Delete SMS by location"""
     try:
-        list(map(lambda location: machine.DeleteSMS(Folder=0, Location=location), sms["Locations"]))
+        list(
+            map(
+                lambda location: machine.DeleteSMS(Folder=0, Location=location),
+                sms["Locations"],
+            )
+        )
     except Exception as e:
         print(f"Error deleting SMS: {e}")
 
@@ -179,48 +196,51 @@ def encodeSms(smsinfo):
 
 def get_network_type(machine):
     """Get network type (2G/3G/4G/LTE) via AT commands
-    
+
     Uses AT+CEREG? command to retrieve Access Technology (AcT) parameter
     Returns human-readable network type string
-    
+
     Note: Temporarily disconnects Gammu to send AT commands, then reconnects
     Results are cached for 5 minutes to minimize disconnects
     """
     import logging
-    import serial
-    import time
     import os
-    
+    import time
+
+    import serial
+
     # Check cache first
     # If _network_type_cache_seconds <= 0, cache never expires (only on modem reconnect)
     # Otherwise, cache expires after the configured duration
     global _network_type_cache, _network_type_cache_seconds
     current_time = time_module.time()
-    if _network_type_cache['type'] is not None:
+    if _network_type_cache["type"] is not None:
         # Cache exists - check if it's still valid
         if _network_type_cache_seconds <= 0:
             # Cache never expires (reconnect-only mode)
-            logging.debug(f"🔍 DEBUG: Using cached network type (reconnect-only mode): {_network_type_cache['type']}")
-            return _network_type_cache['type']
-        cache_age = current_time - _network_type_cache['timestamp']
+            logging.debug(
+                f"🔍 DEBUG: Using cached network type (reconnect-only mode): {_network_type_cache['type']}"
+            )
+            return _network_type_cache["type"]
+        cache_age = current_time - _network_type_cache["timestamp"]
         if cache_age < _network_type_cache_seconds:
             # Cache hasn't expired yet
-            return _network_type_cache['type']
-    
+            return _network_type_cache["type"]
+
     try:
         # Get the device path from Gammu config
         config = machine.GetConfig(0)
-        device_path = config.get('Device', '')
-        
+        device_path = config.get("Device", "")
+
         if not device_path:
             logging.warning("No device path found in Gammu config")
-            return 'Unknown'
-        
+            return "Unknown"
+
         # Resolve symlinks to get actual device
         if os.path.islink(device_path):
             device_path = os.path.realpath(device_path)
             logging.debug(f"🔍 Resolved device path for AT commands: {device_path}")
-        
+
         # Temporarily disconnect Gammu to free the serial port
         try:
             machine.Terminate()
@@ -228,98 +248,101 @@ def get_network_type(machine):
             logging.debug(f"🔍 Temporarily closed Gammu connection")
         except Exception as e:
             logging.warning(f"Could not terminate Gammu: {e}")
-            return 'Unknown'
-        
+            return "Unknown"
+
         # Open serial connection
         ser = None
-        network_type = 'Unknown'
+        network_type = "Unknown"
         try:
             ser = serial.Serial(
-                port=device_path,
-                baudrate=115200,
-                timeout=2,
-                write_timeout=2
+                port=device_path, baudrate=115200, timeout=2, write_timeout=2
             )
-            
+
             # Small delay to let modem respond
             time.sleep(0.1)
-            
+
             # Clear any existing data
             ser.reset_input_buffer()
             ser.reset_output_buffer()
-            
+
             # Use AT+CEREG? (EPS/LTE registration) - most reliable for LTE modems
             # Note: For optimal results, try CEREG first (LTE), then CGREG (GPRS), then CREG (CS)
-            
-            ser.write(b'AT+CEREG=2\r\n')
+
+            ser.write(b"AT+CEREG=2\r\n")
             time.sleep(0.2)
-            response1 = ser.read_all().decode('utf-8', errors='ignore')
+            response1 = ser.read_all().decode("utf-8", errors="ignore")
             logging.debug(f"🔍 AT+CEREG=2 response: {response1.strip()}")
-            
-            ser.write(b'AT+CEREG?\r\n')
+
+            ser.write(b"AT+CEREG?\r\n")
             time.sleep(0.2)
-            response2 = ser.read_all().decode('utf-8', errors='ignore')
+            response2 = ser.read_all().decode("utf-8", errors="ignore")
             logging.debug(f"🔍 AT+CEREG? response: {response2.strip()}")
-            
-            for line in response2.split('\n'):
-                if '+CEREG:' in line:
-                    parts = line.split(':')[1].strip().split(',')
+
+            for line in response2.split("\n"):
+                if "+CEREG:" in line:
+                    parts = line.split(":")[1].strip().split(",")
                     logging.debug(f"🔍 Parsed CEREG parts: {parts}")
                     if len(parts) >= 5:
                         try:
                             act = int(parts[4].strip().strip('"'))
                             network_type = map_act_to_network_type(act)
-                            logging.debug(f"🔍 AT+CEREG? detected: {network_type} (AcT={act})")
+                            logging.debug(
+                                f"🔍 AT+CEREG? detected: {network_type} (AcT={act})"
+                            )
                         except (ValueError, IndexError):
                             pass
-            
+
             # Fallback: Try AT+CGREG? (GPRS) if CEREG didn't work
-            if network_type == 'Unknown':
-                ser.write(b'AT+CGREG=2\r\n')
+            if network_type == "Unknown":
+                ser.write(b"AT+CGREG=2\r\n")
                 time.sleep(0.2)
-                response3 = ser.read_all().decode('utf-8', errors='ignore')
-                
-                ser.write(b'AT+CGREG?\r\n')
+                response3 = ser.read_all().decode("utf-8", errors="ignore")
+
+                ser.write(b"AT+CGREG?\r\n")
                 time.sleep(0.2)
-                response4 = ser.read_all().decode('utf-8', errors='ignore')
+                response4 = ser.read_all().decode("utf-8", errors="ignore")
                 logging.debug(f"🔍 AT+CGREG? response: {response4.strip()}")
-                
-                for line in response4.split('\n'):
-                    if '+CGREG:' in line:
-                        parts = line.split(':')[1].strip().split(',')
+
+                for line in response4.split("\n"):
+                    if "+CGREG:" in line:
+                        parts = line.split(":")[1].strip().split(",")
                         logging.debug(f"🔍 Parsed CGREG parts: {parts}")
                         if len(parts) >= 5:
                             try:
                                 act = int(parts[4].strip().strip('"'))
                                 network_type = map_act_to_network_type(act)
-                                logging.debug(f"🔍 AT+CGREG? detected: {network_type} (AcT={act})")
+                                logging.debug(
+                                    f"🔍 AT+CGREG? detected: {network_type} (AcT={act})"
+                                )
                             except (ValueError, IndexError):
                                 pass
-            
-            if network_type == 'Unknown':
-                logging.warning("No AcT parameter found in AT+CEREG? or AT+CGREG? response")
-            
+
+            if network_type == "Unknown":
+                logging.warning(
+                    "No AcT parameter found in AT+CEREG? or AT+CGREG? response"
+                )
+
         except Exception as e:
             logging.warning(f"Error sending AT commands: {e}")
-            
+
         finally:
             if ser and ser.is_open:
                 ser.close()
             time.sleep(0.3)
-        
+
         # Reconnect Gammu
         try:
             machine.Init()
             logging.debug(f"🔍 Reconnected Gammu successfully")
         except Exception as e:
             logging.error(f"Failed to reconnect Gammu: {e}")
-        
+
         # Update cache
-        _network_type_cache['type'] = network_type
-        _network_type_cache['timestamp'] = current_time
-        
+        _network_type_cache["type"] = network_type
+        _network_type_cache["timestamp"] = current_time
+
         return network_type
-        
+
     except Exception as e:
         logging.warning(f"Could not detect network type via AT commands: {e}")
         # Try to reconnect Gammu if it was disconnected
@@ -327,7 +350,7 @@ def get_network_type(machine):
             machine.Init()
         except:
             pass
-        return 'Unknown'
+        return "Unknown"
 
 
 def map_act_to_network_type(act):
@@ -346,7 +369,7 @@ def map_act_to_network_type(act):
         10: "4G (LTE-5G)",
         11: "5G (NR)",
         12: "5G (NG-RAN)",
-        13: "4G+5G (EN-DC)"
+        13: "4G+5G (EN-DC)",
     }
     return act_map.get(act, f"Unknown (AcT={act})")
 
@@ -357,17 +380,13 @@ def setupCallbacks(machine, unified_callback):
     Uses Gammu SetIncomingCall, SetIncomingSMS and SetIncomingCallback.
     Returns dict with status of each callback setup.
     """
-    results = {
-        'callback': False,
-        'incoming_call': False,
-        'incoming_sms': False
-    }
+    results = {"callback": False, "incoming_call": False, "incoming_sms": False}
 
     # Set unified callback handler
     try:
         machine.SetIncomingCallback(unified_callback)
         print("📱 Unified callback: SetIncomingCallback registered")
-        results['callback'] = True
+        results["callback"] = True
     except Exception as e:
         print(f"📱 SetIncomingCallback failed: {type(e).__name__}: {e}")
 
@@ -375,7 +394,7 @@ def setupCallbacks(machine, unified_callback):
     try:
         machine.SetIncomingCall()
         print("📞 SetIncomingCall: Enabled")
-        results['incoming_call'] = True
+        results["incoming_call"] = True
     except gammu.ERR_NOTSUPPORTED:
         print("📞 SetIncomingCall: Not supported by this modem")
     except Exception as e:
@@ -385,7 +404,7 @@ def setupCallbacks(machine, unified_callback):
     try:
         machine.SetIncomingSMS()
         print("📨 SetIncomingSMS: Enabled")
-        results['incoming_sms'] = True
+        results["incoming_sms"] = True
     except gammu.ERR_NOTSUPPORTED:
         print("📨 SetIncomingSMS: Not supported by this modem")
     except Exception as e:

--- a/addon-test-current/tests/test_balance_parser.py
+++ b/addon-test-current/tests/test_balance_parser.py
@@ -8,21 +8,23 @@ These tests verify the balance SMS parsing and data migration:
 - Migration of old string-based format to new numeric format
 - Currency symbol detection
 """
+
 import json
 import os
 import tempfile
+
 import pytest
 
 
 class MockBalanceSMSParser:
     """
     Mock implementation of BalanceSMSParser for testing.
-    
+
     This mirrors the actual implementation in mqtt_publisher.py but without
     external dependencies (logging, file I/O during init).
     """
-    
-    def __init__(self, balance_file=None, currency='USD'):
+
+    def __init__(self, balance_file=None, currency="USD"):
         self.balance_file = balance_file
         self.currency = currency
         self.balance_data = {
@@ -34,50 +36,52 @@ class MockBalanceSMSParser:
             "messages_remaining": None,
             "plan_expiry": None,
             "last_updated": None,
-            "raw_message": None
+            "raw_message": None,
         }
-    
+
     def _migrate_old_format(self, data):
         """Migrate old string-based format to new numeric format"""
         import re
+
         migrated = False
-        
+
         # Migrate data_remaining from "200.00 MB" to 200.0
-        if isinstance(data.get('data_remaining'), str):
-            match = re.match(r'([\d.]+)\s*(MB|GB)?', data['data_remaining'])
+        if isinstance(data.get("data_remaining"), str):
+            match = re.match(r"([\d.]+)\s*(MB|GB)?", data["data_remaining"])
             if match:
                 value = float(match.group(1))
-                unit = match.group(2) or 'MB'
-                if unit.upper() == 'GB':
+                unit = match.group(2) or "MB"
+                if unit.upper() == "GB":
                     value *= 1024
-                data['data_remaining'] = value
-                data['data_remaining_unit'] = 'MB'
+                data["data_remaining"] = value
+                data["data_remaining_unit"] = "MB"
                 migrated = True
-        
+
         # Migrate account_balance from "$3.00" to 3.0
-        if isinstance(data.get('account_balance'), str):
-            match = re.match(r'[\$€£]?([\d.]+)', data['account_balance'])
+        if isinstance(data.get("account_balance"), str):
+            match = re.match(r"[\$€£]?([\d.]+)", data["account_balance"])
             if match:
                 value = float(match.group(1))
-                data['account_balance'] = value
-                data['account_balance_currency'] = self.currency
+                data["account_balance"] = value
+                data["account_balance_currency"] = self.currency
                 migrated = True
-        
+
         return data
-    
+
     def parse_balance_sms(self, message_text):
         """Parse balance information from SMS text"""
         import re
         import time
-        
+
         updated = False
-        self.balance_data["last_updated"] = time.strftime('%Y-%m-%d %H:%M:%S')
+        self.balance_data["last_updated"] = time.strftime("%Y-%m-%d %H:%M:%S")
         self.balance_data["raw_message"] = message_text
-        
+
         # Parse data remaining (MB or GB) - store as numeric MB
         data_match = re.search(
-            r'([\d.]+)\s*(MB|GB)\s*(?:of\s*)?(?:High\s*Speed\s*)?Data',
-            message_text, re.IGNORECASE
+            r"([\d.]+)\s*(MB|GB)\s*(?:of\s*)?(?:High\s*Speed\s*)?Data",
+            message_text,
+            re.IGNORECASE,
         )
         if data_match:
             amount = float(data_match.group(1))
@@ -88,42 +92,42 @@ class MockBalanceSMSParser:
             self.balance_data["data_remaining"] = amount
             self.balance_data["data_remaining_unit"] = "MB"
             updated = True
-        
+
         # Parse minutes remaining
-        minutes_match = re.search(r'([\d,]+)\s*Minutes', message_text, re.IGNORECASE)
+        minutes_match = re.search(r"([\d,]+)\s*Minutes", message_text, re.IGNORECASE)
         if minutes_match:
-            minutes = int(minutes_match.group(1).replace(',', ''))
+            minutes = int(minutes_match.group(1).replace(",", ""))
             self.balance_data["minutes_remaining"] = minutes
             updated = True
-        
+
         # Parse messages remaining
-        messages_match = re.search(r'([\d,]+)\s*Messages', message_text, re.IGNORECASE)
+        messages_match = re.search(r"([\d,]+)\s*Messages", message_text, re.IGNORECASE)
         if messages_match:
-            messages = int(messages_match.group(1).replace(',', ''))
+            messages = int(messages_match.group(1).replace(",", ""))
             self.balance_data["messages_remaining"] = messages
             updated = True
-        
+
         # Parse account balance (dollar amount) - store as numeric
         balance_match = re.search(
-            r'balance\s*of\s*\$?([\d.]+)', message_text, re.IGNORECASE
+            r"balance\s*of\s*\$?([\d.]+)", message_text, re.IGNORECASE
         )
         if balance_match:
             balance = float(balance_match.group(1))
             self.balance_data["account_balance"] = balance
             self.balance_data["account_balance_currency"] = self.currency
             updated = True
-        
+
         # Parse plan expiry date
         expiry_match = re.search(
-            r'expires?\s*on\s*([\d-]+)', message_text, re.IGNORECASE
+            r"expires?\s*on\s*([\d-]+)", message_text, re.IGNORECASE
         )
         if expiry_match:
             expiry_date = expiry_match.group(1)
             self.balance_data["plan_expiry"] = expiry_date
             updated = True
-        
+
         return self.balance_data
-    
+
     def get_balance_data(self):
         """Get current balance data"""
         return self.balance_data
@@ -131,96 +135,98 @@ class MockBalanceSMSParser:
 
 class TestBalanceSMSParsing:
     """Tests for parsing balance information from SMS messages."""
-    
+
     def test_parse_data_minutes_messages(self):
         """Test parsing data, minutes, and messages from typical carrier SMS."""
         parser = MockBalanceSMSParser()
-        message = "You have 200.00 MB of High Speed Data Remaining 200 Minutes & 991 Messages"
-        
+        message = (
+            "You have 200.00 MB of High Speed Data Remaining 200 Minutes & 991 Messages"
+        )
+
         result = parser.parse_balance_sms(message)
-        
+
         assert result["data_remaining"] == 200.0
         assert result["data_remaining_unit"] == "MB"
         assert result["minutes_remaining"] == 200
         assert result["messages_remaining"] == 991
-    
+
     def test_parse_account_balance_and_expiry(self):
         """Test parsing account balance and plan expiry date."""
         parser = MockBalanceSMSParser()
         message = "Your plan expires on 2026-01-19. You have balance of $2.00"
-        
+
         result = parser.parse_balance_sms(message)
-        
+
         assert result["account_balance"] == 2.0
         assert result["account_balance_currency"] == "USD"
         assert result["plan_expiry"] == "2026-01-19"
-    
+
     def test_parse_gb_to_mb_conversion(self):
         """Test that GB values are converted to MB."""
         parser = MockBalanceSMSParser()
         message = "You have 1.5 GB of High Speed Data Remaining"
-        
+
         result = parser.parse_balance_sms(message)
-        
+
         assert result["data_remaining"] == 1536.0  # 1.5 * 1024
         assert result["data_remaining_unit"] == "MB"
-    
+
     def test_parse_with_commas_in_numbers(self):
         """Test parsing numbers with comma separators."""
         parser = MockBalanceSMSParser()
         message = "You have 1,500 Minutes & 2,000 Messages remaining"
-        
+
         result = parser.parse_balance_sms(message)
-        
+
         assert result["minutes_remaining"] == 1500
         assert result["messages_remaining"] == 2000
-    
+
     def test_parse_balance_without_dollar_sign(self):
         """Test parsing balance amount without currency symbol."""
         parser = MockBalanceSMSParser()
         message = "You have balance of 5.50"
-        
+
         result = parser.parse_balance_sms(message)
-        
+
         assert result["account_balance"] == 5.50
-    
+
     def test_custom_currency_setting(self):
         """Test that custom currency is applied to parsed balance."""
-        parser = MockBalanceSMSParser(currency='EUR')
+        parser = MockBalanceSMSParser(currency="EUR")
         message = "You have balance of 10.00"
-        
+
         result = parser.parse_balance_sms(message)
-        
+
         assert result["account_balance"] == 10.0
         assert result["account_balance_currency"] == "EUR"
-    
+
     def test_partial_message_data_only(self):
         """Test parsing message with only data information."""
         parser = MockBalanceSMSParser()
         message = "You have 500 MB of Data remaining"
-        
+
         result = parser.parse_balance_sms(message)
-        
+
         assert result["data_remaining"] == 500.0
         assert result["minutes_remaining"] is None
         assert result["messages_remaining"] is None
-    
+
     def test_raw_message_stored(self):
         """Test that raw message is stored in balance data."""
         parser = MockBalanceSMSParser()
         message = "Test message content"
-        
+
         result = parser.parse_balance_sms(message)
-        
+
         assert result["raw_message"] == message
-    
+
     def test_last_updated_set(self):
         """Test that last_updated timestamp is set."""
         parser = MockBalanceSMSParser()
         message = "You have 100 MB of Data"
-        
+
         result = parser.parse_balance_sms(message)
-        
+
         assert result["last_updated"] is not None
         # Should be in format YYYY-MM-DD HH:MM:SS
         assert len(result["last_updated"]) == 19
@@ -228,203 +234,203 @@ class TestBalanceSMSParsing:
 
 class TestBalanceDataMigration:
     """Tests for migrating old string-based format to new numeric format."""
-    
+
     def test_migrate_data_remaining_mb(self):
         """Test migration of MB string format to numeric."""
         parser = MockBalanceSMSParser()
         old_data = {"data_remaining": "200.00 MB"}
-        
+
         migrated = parser._migrate_old_format(old_data)
-        
+
         assert migrated["data_remaining"] == 200.0
         assert migrated["data_remaining_unit"] == "MB"
-    
+
     def test_migrate_data_remaining_gb(self):
         """Test migration of GB string format to numeric MB."""
         parser = MockBalanceSMSParser()
         old_data = {"data_remaining": "2.5 GB"}
-        
+
         migrated = parser._migrate_old_format(old_data)
-        
+
         assert migrated["data_remaining"] == 2560.0  # 2.5 * 1024
         assert migrated["data_remaining_unit"] == "MB"
-    
+
     def test_migrate_account_balance_with_dollar(self):
         """Test migration of dollar balance string to numeric."""
         parser = MockBalanceSMSParser()
         old_data = {"account_balance": "$3.00"}
-        
+
         migrated = parser._migrate_old_format(old_data)
-        
+
         assert migrated["account_balance"] == 3.0
         assert migrated["account_balance_currency"] == "USD"
-    
+
     def test_migrate_account_balance_with_euro(self):
         """Test migration of euro balance string to numeric."""
-        parser = MockBalanceSMSParser(currency='EUR')
+        parser = MockBalanceSMSParser(currency="EUR")
         old_data = {"account_balance": "€15.50"}
-        
+
         migrated = parser._migrate_old_format(old_data)
-        
+
         assert migrated["account_balance"] == 15.50
         assert migrated["account_balance_currency"] == "EUR"
-    
+
     def test_migrate_account_balance_with_pound(self):
         """Test migration of pound balance string to numeric."""
-        parser = MockBalanceSMSParser(currency='GBP')
+        parser = MockBalanceSMSParser(currency="GBP")
         old_data = {"account_balance": "£7.25"}
-        
+
         migrated = parser._migrate_old_format(old_data)
-        
+
         assert migrated["account_balance"] == 7.25
         assert migrated["account_balance_currency"] == "GBP"
-    
+
     def test_migrate_already_numeric_data(self):
         """Test that already numeric data is not changed."""
         parser = MockBalanceSMSParser()
         old_data = {"data_remaining": 150.0, "account_balance": 5.0}
-        
+
         migrated = parser._migrate_old_format(old_data)
-        
+
         assert migrated["data_remaining"] == 150.0
         assert migrated["account_balance"] == 5.0
-    
+
     def test_migrate_mixed_format(self):
         """Test migration with mix of old string and new numeric formats."""
         parser = MockBalanceSMSParser()
         old_data = {
             "data_remaining": "100.50 MB",  # Old format
             "account_balance": 10.0,  # Already numeric
-            "minutes_remaining": 500  # Already numeric
+            "minutes_remaining": 500,  # Already numeric
         }
-        
+
         migrated = parser._migrate_old_format(old_data)
-        
+
         assert migrated["data_remaining"] == 100.5
         assert migrated["account_balance"] == 10.0
         assert migrated["minutes_remaining"] == 500
-    
+
     def test_migrate_preserves_other_fields(self):
         """Test that migration preserves unrelated fields."""
         parser = MockBalanceSMSParser()
         old_data = {
             "data_remaining": "50 MB",
             "plan_expiry": "2026-01-19",
-            "minutes_remaining": 200
+            "minutes_remaining": 200,
         }
-        
+
         migrated = parser._migrate_old_format(old_data)
-        
+
         assert migrated["plan_expiry"] == "2026-01-19"
         assert migrated["minutes_remaining"] == 200
 
 
 class TestSensorValueTypes:
     """Tests verifying sensor values are correct types for Home Assistant."""
-    
+
     def test_data_remaining_is_float(self):
         """Verify data_remaining is float for device_class: data_size."""
         parser = MockBalanceSMSParser()
         message = "You have 200.00 MB of High Speed Data Remaining"
-        
+
         result = parser.parse_balance_sms(message)
-        
+
         assert isinstance(result["data_remaining"], float)
-    
+
     def test_account_balance_is_float(self):
         """Verify account_balance is float for device_class: monetary."""
         parser = MockBalanceSMSParser()
         message = "You have balance of $3.00"
-        
+
         result = parser.parse_balance_sms(message)
-        
+
         assert isinstance(result["account_balance"], float)
-    
+
     def test_minutes_remaining_is_int(self):
         """Verify minutes_remaining is int for device_class: duration."""
         parser = MockBalanceSMSParser()
         message = "You have 200 Minutes remaining"
-        
+
         result = parser.parse_balance_sms(message)
-        
+
         assert isinstance(result["minutes_remaining"], int)
-    
+
     def test_messages_remaining_is_int(self):
         """Verify messages_remaining is int."""
         parser = MockBalanceSMSParser()
         message = "You have 991 Messages remaining"
-        
+
         result = parser.parse_balance_sms(message)
-        
+
         assert isinstance(result["messages_remaining"], int)
-    
+
     def test_plan_expiry_is_string(self):
         """Verify plan_expiry is string for device_class: date."""
         parser = MockBalanceSMSParser()
         message = "Your plan expires on 2026-01-19"
-        
+
         result = parser.parse_balance_sms(message)
-        
+
         assert isinstance(result["plan_expiry"], str)
         assert result["plan_expiry"] == "2026-01-19"
 
 
 class TestEdgeCases:
     """Tests for edge cases and unusual inputs."""
-    
+
     def test_empty_message(self):
         """Test parsing empty message."""
         parser = MockBalanceSMSParser()
         message = ""
-        
+
         result = parser.parse_balance_sms(message)
-        
+
         assert result["data_remaining"] is None
         assert result["minutes_remaining"] is None
         assert result["messages_remaining"] is None
         assert result["account_balance"] is None
         assert result["plan_expiry"] is None
-    
+
     def test_unrelated_message(self):
         """Test parsing message without balance info."""
         parser = MockBalanceSMSParser()
         message = "Thank you for your payment. Have a nice day!"
-        
+
         result = parser.parse_balance_sms(message)
-        
+
         assert result["data_remaining"] is None
         assert result["account_balance"] is None
-    
+
     def test_decimal_precision(self):
         """Test parsing preserves decimal precision."""
         parser = MockBalanceSMSParser()
         message = "You have 123.45 MB of Data and balance of $67.89"
-        
+
         result = parser.parse_balance_sms(message)
-        
+
         assert result["data_remaining"] == 123.45
         assert result["account_balance"] == 67.89
-    
+
     def test_case_insensitive_parsing(self):
         """Test that parsing is case-insensitive."""
         parser = MockBalanceSMSParser()
         message = "you have 100 mb of high speed data REMAINING 50 MINUTES"
-        
+
         result = parser.parse_balance_sms(message)
-        
+
         assert result["data_remaining"] == 100.0
         assert result["minutes_remaining"] == 50
-    
+
     def test_multiple_parse_calls_accumulate(self):
         """Test that multiple parse calls update the same data object."""
         parser = MockBalanceSMSParser()
-        
+
         # First message with data
         parser.parse_balance_sms("You have 200 MB of Data Remaining")
-        
+
         # Second message with balance
         result = parser.parse_balance_sms("Your balance is balance of $5.00")
-        
+
         # Both should be present
         assert result["data_remaining"] == 200.0
         assert result["account_balance"] == 5.0

--- a/addon-test-current/tests/test_device_connectivity.py
+++ b/addon-test-current/tests/test_device_connectivity.py
@@ -7,9 +7,11 @@ These tests verify the modem offline detection and auto-restart functionality:
 - Restart timer persists through status polls when in hard_offline state
 - Configurable hard_offline_restart_timeout works correctly
 """
+
 import json
 import threading
 import time
+
 import pytest
 
 
@@ -30,7 +32,7 @@ class MockDeviceTracker:
             self.last_success_time = time.time()
 
             if self.hard_offline:
-                is_sms_operation = operation_name and 'sms' in operation_name.lower()
+                is_sms_operation = operation_name and "sms" in operation_name.lower()
                 is_same_operation = operation_name == self.hard_offline_operation
 
                 if is_sms_operation or is_same_operation:
@@ -88,7 +90,8 @@ class MockMQTTPublisher:
         failure_duration = current_time - self.failure_start_time
         is_hard_offline = self.device_tracker.hard_offline
         effective_timeout = (
-            self.hard_offline_restart_timeout if is_hard_offline 
+            self.hard_offline_restart_timeout
+            if is_hard_offline
             else self.restart_timeout
         )
 
@@ -112,7 +115,7 @@ class MockMQTTPublisher:
         self.device_tracker.record_failure(
             f"{operation_name}: Python timeout (15s)",
             is_timeout=True,
-            operation_name=operation_name
+            operation_name=operation_name,
         )
         self._check_restart_timeout()
 
@@ -321,47 +324,49 @@ class TestIntegrationScenario:
     def test_repeated_sms_failures_trigger_restart(self):
         """
         THIS IS THE EXACT BUG SCENARIO from 2025-12-16:
-        
+
         Log showed:
         [15:58:01] WARNING: 🔴 Hard offline: retrieveAllSms timed out
         [15:58:01] INFO: ⏱️ Failure tracking started at 15:58:01
         [15:58:01] INFO: ⏱️ Modem failing for 0s (restart after 30s, hard offline)
-        
+
         Then 5+ minutes passed with NO restart because _check_restart_timeout()
         was only called once at the initial timeout, not on subsequent cycles.
-        
+
         This test verifies that repeated calls to _check_restart_timeout()
         (as would happen on each failed SMS monitoring cycle) will eventually
         trigger the restart.
         """
         pub = MockMQTTPublisher(hard_offline_restart_timeout=30)
-        
+
         # Initial timeout - sets failure_start_time
         pub.track_timeout("retrieveAllSms")
         assert pub.device_tracker.hard_offline is True
         assert pub.failure_start_time is not None
         initial_start_time = pub.failure_start_time
-        
+
         # Verify restart NOT triggered yet (0s elapsed)
         assert pub._would_restart is False
-        
+
         # Simulate SMS monitoring loop calling _check_restart_timeout
         # on each 10s cycle. This is what the fix adds.
         # After 4 cycles (40s total), restart should have triggered.
-        
+
         restart_triggered = False
         for cycle in range(1, 5):  # Cycles at 10s, 20s, 30s, 40s
             # Simulate time passing (10s per cycle)
             pub.failure_start_time = initial_start_time - (cycle * 10)
-            
+
             # This is what the SMS monitoring loop now does on each failure
             pub._check_restart_timeout()
-            
+
             if pub._would_restart:
                 restart_triggered = True
-                assert cycle == 3, f"Restart should trigger at cycle 3 (30s), not {cycle}"
+                assert (
+                    cycle == 3
+                ), f"Restart should trigger at cycle 3 (30s), not {cycle}"
                 break
-        
+
         assert restart_triggered, (
             "CRITICAL BUG: Restart never triggered after 40s of failures! "
             "The _check_restart_timeout() must be called on each failed cycle."
@@ -370,11 +375,11 @@ class TestIntegrationScenario:
 
 class TestLockRaceCondition:
     """Tests for the lock race condition fix (v2.15.3).
-    
+
     The bug: Thread A checks hard_offline=False, then waits at gammu_lock.
     Thread B times out, sets hard_offline=True, releases lock.
     Thread A acquires lock and proceeds even though hard_offline is now True.
-    
+
     The fix: Check hard_offline AFTER acquiring the lock, inside track_gammu_operation.
     """
 
@@ -388,7 +393,7 @@ class TestLockRaceCondition:
         pub = MockMQTTPublisher()
         lock = threading.Lock()
         operation_executed = threading.Event()
-        
+
         def simulate_track_gammu_operation():
             """Simulates the fixed track_gammu_operation logic."""
             with lock:
@@ -400,26 +405,26 @@ class TestLockRaceCondition:
                 else:
                     operation_executed.set()
                     return "executed"
-        
+
         # Initially hard_offline is False
         assert pub.device_tracker.hard_offline is False
-        
+
         # Thread A: Check hard_offline (False), then wait at lock
         # Simulate this by having Thread A acquire lock first
         lock.acquire()
-        
+
         # Now simulate Thread B setting hard_offline while Thread A holds lock
         # (In reality, Thread A would be waiting, but we're testing the check)
         pub.device_tracker.hard_offline = True
         pub.device_tracker.hard_offline_operation = "retrieveAllSms"
         pub.failure_start_time = time.time()
-        
+
         # Release lock - now the "next thread" should check hard_offline
         lock.release()
-        
+
         # Thread C comes in after hard_offline is set
         result = simulate_track_gammu_operation()
-        
+
         # The operation should be SKIPPED because hard_offline is True
         assert result == "skipped"
         assert not operation_executed.is_set()
@@ -433,7 +438,7 @@ class TestLockRaceCondition:
         lock = threading.Lock()
         skipped_count = 0
         executed_count = 0
-        
+
         def simulate_operation():
             nonlocal skipped_count, executed_count
             with lock:
@@ -444,22 +449,19 @@ class TestLockRaceCondition:
                 # Simulate operation
                 time.sleep(0.01)
                 executed_count += 1
-        
+
         # Set hard_offline
         pub.device_tracker.hard_offline = True
         pub.failure_start_time = time.time() - 10  # 10s ago
-        
+
         # Simulate multiple operations trying to run
-        threads = [
-            threading.Thread(target=simulate_operation)
-            for _ in range(5)
-        ]
-        
+        threads = [threading.Thread(target=simulate_operation) for _ in range(5)]
+
         for t in threads:
             t.start()
         for t in threads:
             t.join()
-        
+
         # All operations should have been skipped
         assert skipped_count == 5
         assert executed_count == 0

--- a/addon-test-current/tests/test_get_endpoint.py
+++ b/addon-test-current/tests/test_get_endpoint.py
@@ -8,6 +8,7 @@ These tests verify the GET endpoint implementation:
 - Configuration default values
 - Path parsing for /sms/{PHONE}&{MESSAGE} format
 """
+
 import ipaddress
 import time
 from urllib.parse import unquote_plus
@@ -15,12 +16,12 @@ from urllib.parse import unquote_plus
 
 class TestIPWhitelist:
     """Test IP address whitelisting with CIDR notation."""
-    
+
     def test_ip_in_private_network(self):
         """Test that private network IPs are allowed."""
         client_ip = "192.168.1.100"
         allowed_networks = ["192.168.0.0/16", "10.0.0.0/8", "172.16.0.0/12"]
-        
+
         client = ipaddress.ip_address(client_ip)
         allowed = False
         for network_str in allowed_networks:
@@ -28,14 +29,14 @@ class TestIPWhitelist:
             if client in network:
                 allowed = True
                 break
-        
+
         assert allowed is True, "Private IP should be allowed"
-    
+
     def test_ip_outside_private_network(self):
         """Test that public IPs are blocked."""
         client_ip = "8.8.8.8"
         allowed_networks = ["192.168.0.0/16", "10.0.0.0/8", "172.16.0.0/12"]
-        
+
         client = ipaddress.ip_address(client_ip)
         allowed = False
         for network_str in allowed_networks:
@@ -43,14 +44,14 @@ class TestIPWhitelist:
             if client in network:
                 allowed = True
                 break
-        
+
         assert allowed is False, "Public IP should be blocked"
-    
+
     def test_localhost_allowed(self):
         """Test that localhost is allowed."""
         client_ip = "127.0.0.1"
         allowed_networks = ["127.0.0.1"]
-        
+
         client = ipaddress.ip_address(client_ip)
         allowed = False
         for network_str in allowed_networks:
@@ -58,38 +59,38 @@ class TestIPWhitelist:
             if client in network:
                 allowed = True
                 break
-        
+
         assert allowed is True, "Localhost should be allowed"
-    
+
     def test_empty_whitelist_allows_all(self):
         """Test that empty whitelist allows all IPs."""
         allowed_networks = []
-        
+
         # When list is empty, IP check should be skipped
         assert not allowed_networks, "Empty list should be falsy"
 
 
 class TestURLDecoding:
     """Test URL decoding for phone numbers and messages."""
-    
+
     def test_plus_to_space(self):
         """Test that + signs are decoded to spaces."""
         encoded = "Hello+World"
         decoded = unquote_plus(encoded)
         assert decoded == "Hello World", "Plus should decode to space"
-    
+
     def test_percent20_to_space(self):
         """Test that %20 is decoded to spaces."""
         encoded = "Hello%20World"
         decoded = unquote_plus(encoded)
         assert decoded == "Hello World", "%20 should decode to space"
-    
+
     def test_mixed_encoding(self):
         """Test mixed encoding formats."""
         encoded = "Test+Message%20Here"
         decoded = unquote_plus(encoded)
         assert decoded == "Test Message Here", "Mixed encoding should work"
-    
+
     def test_phone_number_with_plus(self):
         """Test phone number with + prefix."""
         encoded = "%2B15555551234"
@@ -99,126 +100,125 @@ class TestURLDecoding:
 
 class TestPathParsing:
     """Test path parsing for GET endpoint."""
-    
+
     def test_split_on_first_ampersand(self):
         """Test that path is split on first & only."""
         path = "5555551234&Hello&World"
-        parts = path.split('&', 1)
-        
+        parts = path.split("&", 1)
+
         assert len(parts) == 2, "Should split into 2 parts"
         assert parts[0] == "5555551234", "First part should be phone"
         assert parts[1] == "Hello&World", "Second part should be rest of message"
-    
+
     def test_path_without_ampersand(self):
         """Test that path without & is handled."""
         path = "5555551234"
-        parts = path.split('&', 1)
-        
+        parts = path.split("&", 1)
+
         assert len(parts) == 1, "Should have 1 part only"
-    
+
     def test_path_with_decoded_content(self):
         """Test path parsing with URL decoding."""
         path = "5555551234&Test+Message"
-        parts = path.split('&', 1)
+        parts = path.split("&", 1)
         phone = unquote_plus(parts[0])
         message = unquote_plus(parts[1])
-        
+
         assert phone == "5555551234", "Phone should be decoded"
         assert message == "Test Message", "Message should be decoded"
 
 
 class TestDeduplication:
     """Test SMS deduplication logic."""
-    
+
     def test_duplicate_detection_within_window(self):
         """Test that duplicates within 15s window are detected."""
         cache = {}
         window = 15
-        
+
         # First request
         key1 = "5555551234|Test message"
         time1 = time.time()
         cache[key1] = time1
-        
+
         # Duplicate request 1 second later
         time2 = time1 + 1
         is_duplicate = key1 in cache and (time2 - cache[key1] < window)
-        
+
         assert is_duplicate is True, "Should detect duplicate within window"
-    
+
     def test_duplicate_detection_outside_window(self):
         """Test that requests outside window are not duplicates."""
         cache = {}
         window = 15
-        
+
         # First request
         key1 = "5555551234|Test message"
         time1 = time.time()
         cache[key1] = time1
-        
+
         # Request 20 seconds later
         time2 = time1 + 20
         is_duplicate = key1 in cache and (time2 - cache[key1] < window)
-        
+
         assert is_duplicate is False, "Should not detect duplicate outside window"
-    
+
     def test_cache_cleanup(self):
         """Test that old cache entries are removed."""
         cache = {
             "key1|msg1": time.time() - 20,  # 20 seconds old
-            "key2|msg2": time.time() - 5,   # 5 seconds old
+            "key2|msg2": time.time() - 5,  # 5 seconds old
         }
         window = 15
         current_time = time.time()
-        
+
         # Clean cache
-        cleaned = {k: v for k, v in cache.items() 
-                   if current_time - v < window}
-        
+        cleaned = {k: v for k, v in cache.items() if current_time - v < window}
+
         assert "key1|msg1" not in cleaned, "Old entry should be removed"
         assert "key2|msg2" in cleaned, "Recent entry should remain"
-    
+
     def test_different_message_not_duplicate(self):
         """Test that different messages are not duplicates."""
         key1 = "5555551234|Message 1"
         key2 = "5555551234|Message 2"
-        
+
         assert key1 != key2, "Different messages should have different keys"
-    
+
     def test_different_number_not_duplicate(self):
         """Test that different numbers are not duplicates."""
         key1 = "5555551234|Test message"
         key2 = "9999999999|Test message"
-        
+
         assert key1 != key2, "Different numbers should have different keys"
 
 
 class TestConfigDefaults:
     """Test configuration default values."""
-    
+
     def test_auth_defaults_to_false(self):
         """Test that auth_required defaults to False."""
         config = {}
-        auth_required = config.get('get_endpoint_auth_required', False)
+        auth_required = config.get("get_endpoint_auth_required", False)
         assert auth_required is False, "Auth should default to False"
-    
+
     def test_allowed_ips_defaults_to_empty(self):
         """Test that allowed_ips defaults to empty list."""
         config = {}
-        allowed_ips = config.get('get_endpoint_allowed_ips', [])
+        allowed_ips = config.get("get_endpoint_allowed_ips", [])
         assert allowed_ips == [], "Allowed IPs should default to []"
-    
+
     def test_deduplication_defaults_to_true(self):
         """Test that deduplication defaults to True."""
         config = {}
-        dedup_enabled = config.get('get_endpoint_deduplication_enabled', True)
+        dedup_enabled = config.get("get_endpoint_deduplication_enabled", True)
         assert dedup_enabled is True, "Deduplication should default to True"
-    
+
     def test_empty_list_is_falsy(self):
         """Test that empty IP list is falsy (disables IP check)."""
         allowed_ips = []
         assert not allowed_ips, "Empty list should be falsy"
-    
+
     def test_nonempty_list_is_truthy(self):
         """Test that non-empty IP list is truthy (enables IP check)."""
         allowed_ips = ["192.168.0.0/16"]

--- a/addon-test-current/tests/test_route_order.py
+++ b/addon-test-current/tests/test_route_order.py
@@ -2,9 +2,11 @@
 Test to verify Flask-RESTX route registration order
 Ensures endpoints appear in the correct order in Swagger UI
 """
-import pytest
-import sys
+
 import os
+import sys
+
+import pytest
 
 # Add parent directory to path to import run.py
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
@@ -12,50 +14,62 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 
 def test_route_definitions_exist():
     """Verify all SMS routes are properly defined in run.py"""
-    with open(os.path.join(os.path.dirname(__file__), '..', 'run.py'), 'r') as f:
+    with open(os.path.join(os.path.dirname(__file__), "..", "run.py"), "r") as f:
         content = f.read()
-    
+
     # Check all routes exist
-    assert "@ns_sms.route('')" in content, "POST /sms route not found"
-    assert "@ns_sms.route('/add/<path:sms_data>')" in content, "GET /sms/add/{sms_data} route not found"
-    assert "@ns_sms.route('/<path:sms_data>')" in content, "GET /sms/{sms_data} route not found"
-    assert "@ns_sms.route('/getsms')" in content, "GET /sms/getsms route not found"
-    assert "@ns_sms.route('/deleteall')" in content, "DELETE /sms/deleteall route not found"
-    assert "@ns_sms.route('/<int:id>')" in content, "GET/DELETE /sms/{id} route not found"
+    assert '@ns_sms.route("")' in content, "POST /sms route not found"
+    assert (
+        '@ns_sms.route("/add/<path:sms_data>")' in content
+    ), "GET /sms/add/{sms_data} route not found"
+    assert (
+        '@ns_sms.route("/<path:sms_data>")' in content
+    ), "GET /sms/{sms_data} route not found"
+    assert '@ns_sms.route("/getsms")' in content, "GET /sms/getsms route not found"
+    assert (
+        '@ns_sms.route("/deleteall")' in content
+    ), "DELETE /sms/deleteall route not found"
+    assert (
+        '@ns_sms.route("/<int:id>")' in content
+    ), "GET/DELETE /sms/{id} route not found"
 
 
 def test_route_order():
     """Verify routes are defined in the correct order for Swagger UI"""
-    with open(os.path.join(os.path.dirname(__file__), '..', 'run.py'), 'r') as f:
+    with open(os.path.join(os.path.dirname(__file__), "..", "run.py"), "r") as f:
         lines = f.readlines()
-    
+
     # Find line numbers for each route
     route_lines = {}
     for i, line in enumerate(lines, 1):
-        if "@ns_sms.route('')" in line:
-            route_lines['post_sms'] = i
-        elif "@ns_sms.route('/<path:sms_data>')" in line:
-            route_lines['get_sms_path'] = i
-        elif "@ns_sms.route('/getsms')" in line:
-            route_lines['get_sms_list'] = i
-        elif "@ns_sms.route('/deleteall')" in line:
-            route_lines['delete_all'] = i
-        elif "@ns_sms.route('/<int:id>')" in line:
-            route_lines['sms_by_id'] = i
-    
+        if '@ns_sms.route("")' in line:
+            route_lines["post_sms"] = i
+        elif '@ns_sms.route("/<path:sms_data>")' in line:
+            route_lines["get_sms_path"] = i
+        elif '@ns_sms.route("/getsms")' in line:
+            route_lines["get_sms_list"] = i
+        elif '@ns_sms.route("/deleteall")' in line:
+            route_lines["delete_all"] = i
+        elif '@ns_sms.route("/<int:id>")' in line:
+            route_lines["sms_by_id"] = i
+
     # Verify all routes found
     assert len(route_lines) == 5, f"Expected 5 routes, found {len(route_lines)}"
-    
+
     # Verify order: POST /sms → GET /sms/{sms_data} → GET /getsms → DELETE /deleteall → /{id}
-    assert route_lines['post_sms'] < route_lines['get_sms_path'], \
-        "POST /sms should come before GET /sms/{sms_data}"
-    assert route_lines['get_sms_path'] < route_lines['get_sms_list'], \
-        "GET /sms/{sms_data} should come before GET /getsms"
-    assert route_lines['get_sms_list'] < route_lines['delete_all'], \
-        "GET /getsms should come before DELETE /deleteall"
-    assert route_lines['delete_all'] < route_lines['sms_by_id'], \
-        "DELETE /deleteall should come before /{id}"
-    
+    assert (
+        route_lines["post_sms"] < route_lines["get_sms_path"]
+    ), "POST /sms should come before GET /sms/{sms_data}"
+    assert (
+        route_lines["get_sms_path"] < route_lines["get_sms_list"]
+    ), "GET /sms/{sms_data} should come before GET /getsms"
+    assert (
+        route_lines["get_sms_list"] < route_lines["delete_all"]
+    ), "GET /getsms should come before DELETE /deleteall"
+    assert (
+        route_lines["delete_all"] < route_lines["sms_by_id"]
+    ), "DELETE /deleteall should come before /{id}"
+
     print(f"\n✅ Route order correct:")
     print(f"  1. POST /sms (line {route_lines['post_sms']})")
     print(f"  2. GET /sms/{{sms_data}} (line {route_lines['get_sms_path']})")
@@ -66,25 +80,25 @@ def test_route_order():
 
 def test_no_duplicate_classes():
     """Verify there are no duplicate class definitions"""
-    with open(os.path.join(os.path.dirname(__file__), '..', 'run.py'), 'r') as f:
+    with open(os.path.join(os.path.dirname(__file__), "..", "run.py"), "r") as f:
         content = f.read()
-    
+
     # Check for duplicate class definitions
-    classes = ['SmsCollection', 'SmsGet', 'GetSms', 'DeleteAllSms', 'SmsItem']
+    classes = ["SmsCollection", "SmsGet", "GetSms", "DeleteAllSms", "SmsItem"]
     for cls in classes:
-        count = content.count(f'class {cls}(Resource)')
+        count = content.count(f"class {cls}(Resource)")
         assert count == 1, f"Class {cls} defined {count} times (expected 1)"
 
 
 def test_deduplication_cache_defined():
     """Verify deduplication cache is properly defined"""
-    with open(os.path.join(os.path.dirname(__file__), '..', 'run.py'), 'r') as f:
+    with open(os.path.join(os.path.dirname(__file__), "..", "run.py"), "r") as f:
         content = f.read()
-    
-    assert '_sms_dedup_cache = {}' in content, "Deduplication cache not initialized"
-    assert '_sms_dedup_window = 15' in content, "Deduplication window not set"
-    assert 'global _sms_dedup_cache' in content, "Cache not declared as global"
+
+    assert "_sms_dedup_cache = {}" in content, "Deduplication cache not initialized"
+    assert "_sms_dedup_window = 15" in content, "Deduplication window not set"
+    assert "global _sms_dedup_cache" in content, "Cache not declared as global"
 
 
-if __name__ == '__main__':
-    pytest.main([__file__, '-v'])
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/addon-test-pavelve/mqtt_publisher.py
+++ b/addon-test-pavelve/mqtt_publisher.py
@@ -3,29 +3,33 @@ MQTT Publisher for SMS Gammu Gateway
 Publishes SMS and device status to MQTT broker with Home Assistant auto-discovery
 """
 
-import json
-import time
-import logging
-import threading
-import os
-import requests
-from typing import Optional, Dict, Any
-import paho.mqtt.client as mqtt
 import concurrent.futures
+import json
+import logging
+import os
+import threading
+import time
+from typing import Any, Dict, Optional
+
+import paho.mqtt.client as mqtt
+import requests
+
 from network_codes import get_network_name
 
 logger = logging.getLogger(__name__)
 
 # SMS counter persistence file
-SMS_COUNTER_FILE = '/data/sms_counter.json'
+SMS_COUNTER_FILE = "/data/sms_counter.json"
+
 
 def detect_unicode_needed(text: str) -> bool:
     """Detect if text contains non-ASCII characters requiring Unicode encoding"""
     try:
-        text.encode('ascii')
+        text.encode("ascii")
         return False
     except UnicodeEncodeError:
         return True
+
 
 class SMSCounter:
     """Tracks sent SMS count with persistent storage"""
@@ -39,9 +43,9 @@ class SMSCounter:
         """Load counter from JSON file"""
         try:
             if os.path.exists(self.counter_file):
-                with open(self.counter_file, 'r') as f:
+                with open(self.counter_file, "r") as f:
                     data = json.load(f)
-                    self.sent_count = data.get('sent_count', 0)
+                    self.sent_count = data.get("sent_count", 0)
                     logger.info(f"📊 Loaded SMS counter from file: {self.sent_count}")
             else:
                 logger.info("📊 SMS counter file not found, starting from 0")
@@ -55,8 +59,8 @@ class SMSCounter:
             # Ensure /data directory exists
             os.makedirs(os.path.dirname(self.counter_file), exist_ok=True)
 
-            data = {'sent_count': self.sent_count}
-            with open(self.counter_file, 'w') as f:
+            data = {"sent_count": self.sent_count}
+            with open(self.counter_file, "w") as f:
                 json.dump(data, f)
             logger.debug(f"📊 Saved SMS counter to file: {self.sent_count}")
         except Exception as e:
@@ -79,10 +83,13 @@ class SMSCounter:
         """Get current count"""
         return self.sent_count
 
+
 class DeviceConnectivityTracker:
     """Tracks USB GSM device connectivity status based on gammu communication"""
 
-    def __init__(self, offline_timeout_seconds=900):  # 15 minutes default (increased from 10)
+    def __init__(
+        self, offline_timeout_seconds=900
+    ):  # 15 minutes default (increased from 10)
         self.last_success_time = None
         self.consecutive_failures = 0
         self.last_error = None
@@ -90,27 +97,31 @@ class DeviceConnectivityTracker:
         self.total_operations = 0
         self.successful_operations = 0
         self.initial_check_done = False  # Track if we've done initial modem check
-        
+
     def record_success(self):
         """Record successful gammu operation"""
         self.last_success_time = time.time()
 
         # Only reset consecutive failures if we had them logged
         if self.consecutive_failures > 0:
-            logger.info(f"✅ Device recovery: resetting consecutive_failures from {self.consecutive_failures} to 0")
+            logger.info(
+                f"✅ Device recovery: resetting consecutive_failures from {self.consecutive_failures} to 0"
+            )
             self.consecutive_failures = 0
 
         self.last_error = None
         self.total_operations += 1
         self.successful_operations += 1
         self.initial_check_done = True  # Mark initial check as done on first success
-        
+
     def record_failure(self, error_message=None):
         """Record failed gammu operation"""
         self.consecutive_failures += 1
-        self.last_error = str(error_message) if error_message else "Communication failed"
+        self.last_error = (
+            str(error_message) if error_message else "Communication failed"
+        )
         self.total_operations += 1
-        
+
     def get_status(self):
         """Get current device connectivity status"""
         # If we haven't done initial check yet, assume offline
@@ -131,27 +142,32 @@ class DeviceConnectivityTracker:
 
         # Recent success and < 3 failures = online
         return "online"
-            
+
     def get_status_data(self):
         """Get detailed status information"""
         status = self.get_status()
-        
+
         data = {
             "status": status,
             "consecutive_failures": self.consecutive_failures,
             "total_operations": self.total_operations,
             "successful_operations": self.successful_operations,
-            "last_error": self.last_error
+            "last_error": self.last_error,
         }
-        
+
         if self.last_success_time:
-            data["last_seen"] = time.strftime("%Y-%m-%d %H:%M:%S", time.localtime(self.last_success_time))
-            data["seconds_since_last_success"] = int(time.time() - self.last_success_time)
+            data["last_seen"] = time.strftime(
+                "%Y-%m-%d %H:%M:%S", time.localtime(self.last_success_time)
+            )
+            data["seconds_since_last_success"] = int(
+                time.time() - self.last_success_time
+            )
         else:
             data["last_seen"] = None
             data["seconds_since_last_success"] = None
-            
+
         return data
+
 
 class MQTTPublisher:
     def __init__(self, config: Dict[str, Any]):
@@ -159,47 +175,60 @@ class MQTTPublisher:
         self.client: Optional[mqtt.Client] = None
         self.connected = False
         self.disconnecting = False  # Flag to prevent multiple disconnect calls
-        self.topic_prefix = config.get('mqtt_topic_prefix', 'homeassistant/sensor/sms_gateway')
-        self.availability_topic = f"{self.topic_prefix}/availability"  # Shared availability for all entities
+        self.topic_prefix = config.get(
+            "mqtt_topic_prefix", "homeassistant/sensor/sms_gateway"
+        )
+        self.availability_topic = (
+            f"{self.topic_prefix}/availability"  # Shared availability for all entities
+        )
         self.gammu_machine = None  # Will be set externally
-        self.gammu_lock = threading.Lock()  # Serialize all Gammu operations to prevent race conditions
+        self.gammu_lock = (
+            threading.Lock()
+        )  # Serialize all Gammu operations to prevent race conditions
         self.current_phone_number = ""  # Current phone number from text input
         self.current_message_text = ""  # Current message text from text input
-        self.device_tracker = DeviceConnectivityTracker()  # USB device connectivity tracking
+        self.device_tracker = (
+            DeviceConnectivityTracker()
+        )  # USB device connectivity tracking
         self.sms_counter = SMSCounter()  # SMS counter with persistence
 
-        if config.get('mqtt_enabled', False):
+        if config.get("mqtt_enabled", False):
             self._setup_client()
-    
+
     def set_gammu_machine(self, machine):
         """Set gammu machine for SMS sending"""
         self.gammu_machine = machine
         logger.info("Gammu machine set for MQTT SMS sending")
-    
+
     def _setup_client(self):
         """Setup MQTT client with configuration"""
         try:
             # Create client with unique ID for better connection tracking
             import socket
+
             client_id = f"sms_gateway_{socket.gethostname()}"
             self.client = mqtt.Client(client_id=client_id, clean_session=True)
 
             # Set credentials ONLY if username is provided and not empty
-            username = self.config.get('mqtt_username', '')
-            password = self.config.get('mqtt_password', '')
+            username = self.config.get("mqtt_username", "")
+            password = self.config.get("mqtt_password", "")
 
             # Ensure username is a string and strip whitespace
             if username is None:
-                username = ''
+                username = ""
             username = str(username).strip()
 
             # Only set credentials if username has actual content
-            if username and username != '':
+            if username and username != "":
                 self.client.username_pw_set(username, password)
-                logger.info(f"MQTT: Client ID: {client_id}, Using authentication with username: '{username}'")
+                logger.info(
+                    f"MQTT: Client ID: {client_id}, Using authentication with username: '{username}'"
+                )
             else:
-                logger.info(f"MQTT: Client ID: {client_id}, Connecting without authentication (local broker mode)")
-            
+                logger.info(
+                    f"MQTT: Client ID: {client_id}, Connecting without authentication (local broker mode)"
+                )
+
             # Set callbacks
             self.client.on_connect = self._on_connect
             self.client.on_disconnect = self._on_disconnect
@@ -209,19 +238,21 @@ class MQTTPublisher:
             # Set Last Will and Testament - published if connection lost unexpectedly
             # This makes ALL entities unavailable in HA when addon crashes/stops
             self.client.will_set(self.availability_topic, "offline", qos=1, retain=True)
-            logger.info("📡 MQTT Last Will set: all entities will be unavailable if connection lost")
+            logger.info(
+                "📡 MQTT Last Will set: all entities will be unavailable if connection lost"
+            )
 
             # Connect to broker
-            host = self.config.get('mqtt_host', 'core-mosquitto')
-            port = self.config.get('mqtt_port', 1883)
+            host = self.config.get("mqtt_host", "core-mosquitto")
+            port = self.config.get("mqtt_port", 1883)
 
             logger.info(f"Connecting to MQTT broker: {host}:{port}")
             self.client.connect(host, port, 60)
             self.client.loop_start()
-            
+
         except Exception as e:
             logger.error(f"Failed to setup MQTT client: {e}")
-    
+
     def _on_connect(self, client, userdata, flags, rc):
         """Callback for MQTT connection"""
         if rc == 0:
@@ -263,24 +294,26 @@ class MQTTPublisher:
             client.subscribe(message_topic)
             client.subscribe(phone_state_topic)  # Subscribe to state topics too
             client.subscribe(message_state_topic)
-            logger.info(f"Subscribed to text input topics: {phone_topic}, {message_topic}, {phone_state_topic}, {message_state_topic}")
+            logger.info(
+                f"Subscribed to text input topics: {phone_topic}, {message_topic}, {phone_state_topic}, {message_state_topic}"
+            )
         else:
             logger.error(f"Failed to connect to MQTT broker: {rc}")
-    
+
     def _on_disconnect(self, client, userdata, rc):
         """Callback for MQTT disconnection"""
         self.connected = False
         logger.warning("Disconnected from MQTT broker")
-    
+
     def _on_publish(self, client, userdata, mid):
         """Callback for published messages"""
         pass
-    
+
     def _on_message(self, client, userdata, msg):
         """Callback for received MQTT messages"""
         try:
             topic = msg.topic
-            payload = msg.payload.decode('utf-8')
+            payload = msg.payload.decode("utf-8")
             logger.info(f"Received MQTT message on topic {topic}: {payload}")
 
             # Check message topic and handle accordingly
@@ -333,39 +366,43 @@ class MQTTPublisher:
                         "status": "error",
                         "message": f"Command processing failed: {str(e)}",
                         "topic": msg.topic,
-                        "timestamp": time.strftime("%Y-%m-%d %H:%M:%S")
+                        "timestamp": time.strftime("%Y-%m-%d %H:%M:%S"),
                     }
-                    self.client.publish(status_topic, json.dumps(status_data), retain=False)
+                    self.client.publish(
+                        status_topic, json.dumps(status_data), retain=False
+                    )
                 except Exception as pub_err:
                     logger.error(f"Failed to publish error status: {pub_err}")
-    
+
     def _handle_sms_send_command(self, payload):
         """Handle SMS send command from MQTT"""
         try:
             # Parse JSON payload
             data = json.loads(payload)
-            number = data.get('number')
-            text = data.get('text')
+            number = data.get("number")
+            text = data.get("text")
             # If 'unicode' is explicitly provided, use it; otherwise use None for auto-detection
-            unicode_mode = data.get('unicode') if 'unicode' in data else None
+            unicode_mode = data.get("unicode") if "unicode" in data else None
 
             if not number or not text:
                 logger.error("SMS send command missing required fields: number or text")
                 return
 
-            logger.info(f"Processing SMS send command: {number} -> {text} (unicode: {unicode_mode if unicode_mode is not None else 'auto'})")
+            logger.info(
+                f"Processing SMS send command: {number} -> {text} (unicode: {unicode_mode if unicode_mode is not None else 'auto'})"
+            )
 
             # Send SMS via gammu machine (will be set externally)
-            if hasattr(self, 'gammu_machine') and self.gammu_machine:
+            if hasattr(self, "gammu_machine") and self.gammu_machine:
                 self._send_sms_via_gammu(number, text, unicode_mode)
             else:
                 logger.error("Gammu machine not available for SMS sending")
-                
+
         except json.JSONDecodeError as e:
             logger.error(f"Invalid JSON in SMS send command: {e}")
         except Exception as e:
             logger.error(f"Error handling SMS send command: {e}")
-    
+
     def _send_sms_via_gammu(self, number, text, unicode_mode=None):
         """Send SMS using gammu machine
 
@@ -382,7 +419,9 @@ class MQTTPublisher:
             if unicode_mode is None:
                 unicode_mode = detect_unicode_needed(text)
                 if unicode_mode:
-                    logger.info(f"🔤 Auto-detected non-ASCII characters, using Unicode mode")
+                    logger.info(
+                        f"🔤 Auto-detected non-ASCII characters, using Unicode mode"
+                    )
 
             # Prepare SMS info
             smsinfo = {
@@ -400,17 +439,19 @@ class MQTTPublisher:
             messages = encodeSms(smsinfo)
             for message in messages:
                 # Use same SMSC logic as REST API
-                config_smsc = self.config.get('smsc_number', '').strip()
+                config_smsc = self.config.get("smsc_number", "").strip()
                 if config_smsc:
-                    message["SMSC"] = {'Number': config_smsc}
+                    message["SMSC"] = {"Number": config_smsc}
                     logger.info(f"Using configured SMSC: {config_smsc}")
                 else:
                     # Use Location 1 (same as REST API when no SMSC provided)
-                    message["SMSC"] = {'Location': 1}
+                    message["SMSC"] = {"Location": 1}
                     logger.info("Using SMSC from Location 1 (same as REST API)")
 
                 message["Number"] = number
-                result = self.track_gammu_operation("SendSMS", self.gammu_machine.SendSMS, message)
+                result = self.track_gammu_operation(
+                    "SendSMS", self.gammu_machine.SendSMS, message
+                )
                 logger.info(f"SMS sent successfully: {result}")
 
             # Increment SMS counter and publish
@@ -425,10 +466,10 @@ class MQTTPublisher:
                     "status": "success",
                     "number": number,
                     "text": text,
-                    "timestamp": time.strftime("%Y-%m-%d %H:%M:%S")
+                    "timestamp": time.strftime("%Y-%m-%d %H:%M:%S"),
                 }
                 self.client.publish(status_topic, json.dumps(status_data), retain=False)
-                
+
         except Exception as e:
             error_msg = str(e)
             # Try to extract useful error message from gammu error
@@ -440,7 +481,7 @@ class MQTTPublisher:
                 user_error = "SMSC number not found - configure SMS center number in SIM settings"
             else:
                 user_error = f"SMS sending error: {error_msg}"
-            
+
             logger.error(f"Failed to send SMS via gammu: {error_msg}")
             # Publish error status with user-friendly message
             if self.connected:
@@ -450,40 +491,51 @@ class MQTTPublisher:
                     "error": user_error,
                     "number": number,
                     "text": text,
-                    "timestamp": time.strftime("%Y-%m-%d %H:%M:%S")
+                    "timestamp": time.strftime("%Y-%m-%d %H:%M:%S"),
                 }
                 self.client.publish(status_topic, json.dumps(status_data), retain=False)
-    
+
     def _handle_button_sms_send(self):
         """Handle SMS send when button is pressed using current text inputs"""
         # Log current state for debugging
-        logger.info(f"Button pressed - current state: phone='{self.current_phone_number}', message='{self.current_message_text}'")
+        logger.info(
+            f"Button pressed - current state: phone='{self.current_phone_number}', message='{self.current_message_text}'"
+        )
 
-        if not self.current_phone_number.strip() or not self.current_message_text.strip():
+        if (
+            not self.current_phone_number.strip()
+            or not self.current_message_text.strip()
+        ):
             # If fields are empty, show instruction
             if self.connected:
                 status_topic = f"{self.topic_prefix}/send_status"
                 status_data = {
                     "status": "missing_fields",
                     "message": f"Please fill in phone number and message text first. Current: phone='{self.current_phone_number}', message='{self.current_message_text}'",
-                    "timestamp": time.strftime("%Y-%m-%d %H:%M:%S")
+                    "timestamp": time.strftime("%Y-%m-%d %H:%M:%S"),
                 }
                 self.client.publish(status_topic, json.dumps(status_data), retain=False)
-            logger.warning(f"Button pressed but fields empty: phone='{self.current_phone_number}', message='{self.current_message_text}'")
+            logger.warning(
+                f"Button pressed but fields empty: phone='{self.current_phone_number}', message='{self.current_message_text}'"
+            )
             return
 
         # Send SMS using current values
-        logger.info(f"Button SMS send: {self.current_phone_number} -> {self.current_message_text}")
-        if hasattr(self, 'gammu_machine') and self.gammu_machine:
+        logger.info(
+            f"Button SMS send: {self.current_phone_number} -> {self.current_message_text}"
+        )
+        if hasattr(self, "gammu_machine") and self.gammu_machine:
             # Use unicode_mode=None for auto-detection
-            self._send_sms_via_gammu(self.current_phone_number, self.current_message_text, unicode_mode=None)
+            self._send_sms_via_gammu(
+                self.current_phone_number, self.current_message_text, unicode_mode=None
+            )
             # Always clear fields after send attempt (success or failure)
             self._clear_text_fields()
         else:
             logger.error("Gammu machine not available for SMS sending")
             # Clear fields even if gammu not available
             self._clear_text_fields()
-    
+
     def _handle_reset_counter(self):
         """Handle reset counter button press"""
         logger.info("🔄 Reset counter button pressed")
@@ -495,14 +547,16 @@ class MQTTPublisher:
         """Handle delete all SMS button press - with fallback for corrupted SMS"""
         logger.info("🗑️ Delete all SMS button pressed")
         try:
-            if hasattr(self, 'gammu_machine') and self.gammu_machine:
-                from support import retrieveAllSms, deleteSms
+            if hasattr(self, "gammu_machine") and self.gammu_machine:
+                from support import deleteSms, retrieveAllSms
 
                 deleted_count = 0
 
                 # Try method 1: Retrieve and delete SMS one by one
                 try:
-                    all_sms = self.track_gammu_operation("retrieveAllSms", retrieveAllSms, self.gammu_machine)
+                    all_sms = self.track_gammu_operation(
+                        "retrieveAllSms", retrieveAllSms, self.gammu_machine
+                    )
                     count = len(all_sms)
 
                     logger.info(f"📋 Found {count} SMS to delete")
@@ -510,12 +564,18 @@ class MQTTPublisher:
                     # Delete each SMS
                     for sms in all_sms:
                         try:
-                            self.track_gammu_operation("deleteSms", deleteSms, self.gammu_machine, sms)
+                            self.track_gammu_operation(
+                                "deleteSms", deleteSms, self.gammu_machine, sms
+                            )
                             deleted_count += 1
                         except Exception as e:
-                            logger.warning(f"Could not delete SMS at location {sms.get('Location', 'unknown')}: {e}")
+                            logger.warning(
+                                f"Could not delete SMS at location {sms.get('Location', 'unknown')}: {e}"
+                            )
 
-                    logger.info(f"✅ Method 1: Deleted {deleted_count}/{count} SMS messages")
+                    logger.info(
+                        f"✅ Method 1: Deleted {deleted_count}/{count} SMS messages"
+                    )
 
                 except Exception as e:
                     # Method 1 failed (likely corrupted SMS) - try method 2
@@ -524,10 +584,14 @@ class MQTTPublisher:
 
                     # Method 2: Get SMS capacity and delete by location
                     try:
-                        capacity = self.track_gammu_operation("GetSMSStatus", self.gammu_machine.GetSMSStatus)
-                        sim_size = capacity.get('SIMSize', 50)  # Default 50 if unknown
+                        capacity = self.track_gammu_operation(
+                            "GetSMSStatus", self.gammu_machine.GetSMSStatus
+                        )
+                        sim_size = capacity.get("SIMSize", 50)  # Default 50 if unknown
 
-                        logger.info(f"📋 Attempting to delete SMS from {sim_size} locations")
+                        logger.info(
+                            f"📋 Attempting to delete SMS from {sim_size} locations"
+                        )
 
                         # Try to delete each location (even corrupted ones)
                         # Use multiple folder IDs to catch SMS in different folders
@@ -540,33 +604,52 @@ class MQTTPublisher:
                                     self.gammu_machine.DeleteSMS(folder, location)
                                     deleted_count += 1
                                     deleted_this_location = True
-                                    logger.info(f"✅ Deleted SMS at folder={folder}, location={location}")
+                                    logger.info(
+                                        f"✅ Deleted SMS at folder={folder}, location={location}"
+                                    )
                                     break  # Success - don't try other folders for this location
                                 except Exception as loc_err:
                                     error_msg = str(loc_err)
                                     # Only log if it's not just "empty location"
-                                    if "Empty" not in error_msg and "InvalidLocation" not in error_msg:
-                                        logger.debug(f"Folder {folder}, Location {location}: {error_msg}")
+                                    if (
+                                        "Empty" not in error_msg
+                                        and "InvalidLocation" not in error_msg
+                                    ):
+                                        logger.debug(
+                                            f"Folder {folder}, Location {location}: {error_msg}"
+                                        )
 
                             if not deleted_this_location:
-                                logger.debug(f"Location {location}: no SMS found in any folder")
+                                logger.debug(
+                                    f"Location {location}: no SMS found in any folder"
+                                )
 
-                        logger.info(f"✅ Method 2: Processed {sim_size} locations, deleted {deleted_count} SMS")
+                        logger.info(
+                            f"✅ Method 2: Processed {sim_size} locations, deleted {deleted_count} SMS"
+                        )
 
                     except Exception as capacity_err:
                         logger.error(f"Method 2 also failed: {capacity_err}")
-                        raise Exception(f"Both deletion methods failed. Last error: {capacity_err}")
+                        raise Exception(
+                            f"Both deletion methods failed. Last error: {capacity_err}"
+                        )
 
                 # Give modem time to process bulk deletion (prevents Code 27 errors)
                 if deleted_count > 0:
-                    logger.info("⏳ Waiting for modem to stabilize after bulk deletion...")
+                    logger.info(
+                        "⏳ Waiting for modem to stabilize after bulk deletion..."
+                    )
                     time.sleep(3)  # 3 second pause
 
                 # Update SMS capacity after deletion
                 try:
-                    capacity = self.track_gammu_operation("GetSMSStatus", self.gammu_machine.GetSMSStatus)
+                    capacity = self.track_gammu_operation(
+                        "GetSMSStatus", self.gammu_machine.GetSMSStatus
+                    )
                     self.publish_sms_capacity(capacity)
-                    logger.info(f"📊 Updated SMS capacity: {capacity.get('SIMUsed', 0)}/{capacity.get('SIMSize', 0)}")
+                    logger.info(
+                        f"📊 Updated SMS capacity: {capacity.get('SIMUsed', 0)}/{capacity.get('SIMSize', 0)}"
+                    )
                 except Exception as e:
                     logger.warning(f"Could not update SMS capacity: {e}")
 
@@ -577,9 +660,11 @@ class MQTTPublisher:
                         "status": "success",
                         "deleted_count": deleted_count,
                         "message": f"Deleted {deleted_count} SMS messages from SIM",
-                        "timestamp": time.strftime("%Y-%m-%d %H:%M:%S")
+                        "timestamp": time.strftime("%Y-%m-%d %H:%M:%S"),
                     }
-                    self.client.publish(status_topic, json.dumps(status_data), retain=False)
+                    self.client.publish(
+                        status_topic, json.dumps(status_data), retain=False
+                    )
             else:
                 logger.error("Gammu machine not available for deleting SMS")
         except Exception as e:
@@ -589,7 +674,7 @@ class MQTTPublisher:
                 status_data = {
                     "status": "error",
                     "error": str(e),
-                    "timestamp": time.strftime("%Y-%m-%d %H:%M:%S")
+                    "timestamp": time.strftime("%Y-%m-%d %H:%M:%S"),
                 }
                 self.client.publish(status_topic, json.dumps(status_data), retain=False)
 
@@ -609,12 +694,14 @@ class MQTTPublisher:
                 self.client.publish(phone_state_topic, "", retain=True, qos=1)
                 self.client.publish(message_state_topic, "", retain=True, qos=1)
 
-                logger.info("🧹 Cleared both phone and message text fields after sending SMS")
+                logger.info(
+                    "🧹 Cleared both phone and message text fields after sending SMS"
+                )
             except Exception as e:
                 logger.warning(f"Could not clear text fields in UI: {e}")
         else:
             logger.info("🧹 Cleared both text fields (internal state only)")
-    
+
     def _publish_phone_state(self, value):
         """Publish phone number state"""
         if self.connected:
@@ -626,7 +713,7 @@ class MQTTPublisher:
         if self.connected:
             state_topic = f"{self.topic_prefix}/message_text/state"
             self.client.publish(state_topic, value, retain=True, qos=1)
-    
+
     def _publish_discovery_configs(self):
         """Publish Home Assistant auto-discovery configurations"""
         if not self.connected:
@@ -637,14 +724,14 @@ class MQTTPublisher:
             "identifiers": ["sms_gateway"],
             "name": "SMS Gateway",
             "model": "GSM Modem",
-            "manufacturer": "Gammu Gateway"
+            "manufacturer": "Gammu Gateway",
         }
 
         # Common availability config - all entities share same availability topic
         AVAILABILITY_CONFIG = {
             "availability_topic": self.availability_topic,
             "payload_available": "online",
-            "payload_not_available": "offline"
+            "payload_not_available": "offline",
         }
 
         # Signal strength sensor (original from PavelVe)
@@ -656,9 +743,9 @@ class MQTTPublisher:
             "unit_of_measurement": "%",
             "icon": "mdi:signal-cellular-3",
             "device": DEVICE_CONFIG,
-            **AVAILABILITY_CONFIG
+            **AVAILABILITY_CONFIG,
         }
-        
+
         # Signal strength dBm sensor (diagnostic - shows actual dBm value, not percent)
         signal_dbm_config = {
             "name": "GSM Signal Strength",
@@ -671,9 +758,9 @@ class MQTTPublisher:
             "icon": "mdi:signal",
             "state_class": "measurement",
             "device": DEVICE_CONFIG,
-            **AVAILABILITY_CONFIG
+            **AVAILABILITY_CONFIG,
         }
-        
+
         # Bit Error Rate sensor (diagnostic)
         ber_config = {
             "name": "GSM Bit Error Rate",
@@ -685,9 +772,9 @@ class MQTTPublisher:
             "icon": "mdi:gauge",
             "state_class": "measurement",
             "device": DEVICE_CONFIG,
-            **AVAILABILITY_CONFIG
+            **AVAILABILITY_CONFIG,
         }
-        
+
         # Network info sensor (original from PavelVe)
         network_config = {
             "name": "GSM Network",
@@ -696,9 +783,9 @@ class MQTTPublisher:
             "value_template": "{{ value_json.NetworkName }}",
             "icon": "mdi:network",
             "device": DEVICE_CONFIG,
-            **AVAILABILITY_CONFIG
+            **AVAILABILITY_CONFIG,
         }
-        
+
         # Network registration state sensor (main display)
         network_state_config = {
             "name": "GSM Network State",
@@ -707,9 +794,9 @@ class MQTTPublisher:
             "value_template": "{{ value_json.State }}",
             "icon": "mdi:signal-variant",
             "device": DEVICE_CONFIG,
-            **AVAILABILITY_CONFIG
+            **AVAILABILITY_CONFIG,
         }
-        
+
         # Network code (MCC+MNC) sensor (diagnostic)
         network_code_config = {
             "name": "GSM Network Code",
@@ -719,9 +806,9 @@ class MQTTPublisher:
             "icon": "mdi:network",
             "entity_category": "diagnostic",
             "device": DEVICE_CONFIG,
-            **AVAILABILITY_CONFIG
+            **AVAILABILITY_CONFIG,
         }
-        
+
         # Cell ID sensor
         cid_config = {
             "name": "GSM Cell ID",
@@ -731,9 +818,9 @@ class MQTTPublisher:
             "icon": "mdi:radio-tower",
             "entity_category": "diagnostic",
             "device": DEVICE_CONFIG,
-            **AVAILABILITY_CONFIG
+            **AVAILABILITY_CONFIG,
         }
-        
+
         # Location Area Code sensor
         lac_config = {
             "name": "GSM Location Area Code",
@@ -743,7 +830,7 @@ class MQTTPublisher:
             "icon": "mdi:map-marker-radius",
             "entity_category": "diagnostic",
             "device": DEVICE_CONFIG,
-            **AVAILABILITY_CONFIG
+            **AVAILABILITY_CONFIG,
         }
 
         # Last SMS sensor
@@ -755,7 +842,7 @@ class MQTTPublisher:
             "json_attributes_topic": f"{self.topic_prefix}/sms/state",
             "icon": "mdi:message-text",
             "device": DEVICE_CONFIG,
-            **AVAILABILITY_CONFIG
+            **AVAILABILITY_CONFIG,
         }
 
         # SMS send status sensor
@@ -767,7 +854,7 @@ class MQTTPublisher:
             "json_attributes_topic": f"{self.topic_prefix}/send_status",
             "icon": "mdi:send",
             "device": DEVICE_CONFIG,
-            **AVAILABILITY_CONFIG
+            **AVAILABILITY_CONFIG,
         }
 
         # SMS delete status sensor
@@ -779,7 +866,7 @@ class MQTTPublisher:
             "json_attributes_topic": f"{self.topic_prefix}/delete_sms_status",
             "icon": "mdi:delete-sweep",
             "device": DEVICE_CONFIG,
-            **AVAILABILITY_CONFIG
+            **AVAILABILITY_CONFIG,
         }
 
         # SMS send button
@@ -790,7 +877,7 @@ class MQTTPublisher:
             "payload_press": "PRESS",
             "icon": "mdi:message-plus",
             "device": DEVICE_CONFIG,
-            **AVAILABILITY_CONFIG
+            **AVAILABILITY_CONFIG,
         }
 
         # Phone number input text
@@ -803,7 +890,7 @@ class MQTTPublisher:
             "mode": "text",
             "pattern": r"^\+?[\d\s\-\(\)]*$",  # Allow empty string with *
             "device": DEVICE_CONFIG,
-            **AVAILABILITY_CONFIG
+            **AVAILABILITY_CONFIG,
         }
 
         # Message input text
@@ -816,7 +903,7 @@ class MQTTPublisher:
             "mode": "text",
             "max": 255,  # HA text entity max length (Gammu will still split long messages into multiple SMS)
             "device": DEVICE_CONFIG,
-            **AVAILABILITY_CONFIG
+            **AVAILABILITY_CONFIG,
         }
 
         # Modem Status sensor
@@ -828,7 +915,7 @@ class MQTTPublisher:
             "json_attributes_topic": f"{self.topic_prefix}/device_status/state",
             "icon": "mdi:connection",
             "device": DEVICE_CONFIG,
-            **AVAILABILITY_CONFIG
+            **AVAILABILITY_CONFIG,
         }
 
         # SMS Counter sensor
@@ -840,11 +927,11 @@ class MQTTPublisher:
             "icon": "mdi:counter",
             "state_class": "total_increasing",
             "device": DEVICE_CONFIG,
-            **AVAILABILITY_CONFIG
+            **AVAILABILITY_CONFIG,
         }
 
         # SMS Cost sensor (only if cost > 0)
-        sms_cost_per_message = self.config.get('sms_cost_per_message', 0.0)
+        sms_cost_per_message = self.config.get("sms_cost_per_message", 0.0)
 
         # Reset counter button
         reset_counter_button_config = {
@@ -854,7 +941,7 @@ class MQTTPublisher:
             "payload_press": "PRESS",
             "icon": "mdi:restart",
             "device": DEVICE_CONFIG,
-            **AVAILABILITY_CONFIG
+            **AVAILABILITY_CONFIG,
         }
 
         # Delete all SMS button
@@ -865,7 +952,7 @@ class MQTTPublisher:
             "payload_press": "PRESS",
             "icon": "mdi:delete-sweep",
             "device": DEVICE_CONFIG,
-            **AVAILABILITY_CONFIG
+            **AVAILABILITY_CONFIG,
         }
 
         # Modem IMEI sensor
@@ -876,7 +963,7 @@ class MQTTPublisher:
             "value_template": "{{ value_json.IMEI }}",
             "icon": "mdi:identifier",
             "device": DEVICE_CONFIG,
-            **AVAILABILITY_CONFIG
+            **AVAILABILITY_CONFIG,
         }
 
         # Modem Model sensor
@@ -887,7 +974,7 @@ class MQTTPublisher:
             "value_template": "{{ value_json.Manufacturer }} {{ value_json.Model }}",
             "icon": "mdi:cellphone",
             "device": DEVICE_CONFIG,
-            **AVAILABILITY_CONFIG
+            **AVAILABILITY_CONFIG,
         }
 
         # SIM IMSI sensor
@@ -898,7 +985,7 @@ class MQTTPublisher:
             "value_template": "{{ value_json.IMSI }}",
             "icon": "mdi:sim",
             "device": DEVICE_CONFIG,
-            **AVAILABILITY_CONFIG
+            **AVAILABILITY_CONFIG,
         }
 
         # SMS Capacity sensor
@@ -911,7 +998,7 @@ class MQTTPublisher:
             "unit_of_measurement": "messages",
             "icon": "mdi:email-multiple",
             "device": DEVICE_CONFIG,
-            **AVAILABILITY_CONFIG
+            **AVAILABILITY_CONFIG,
         }
 
         # Publish discovery configs - all using consistent node_id "sms_gateway" for proper grouping
@@ -922,32 +1009,53 @@ class MQTTPublisher:
             ("homeassistant/sensor/sms_gateway/ber/config", ber_config),
             # Network sensors
             ("homeassistant/sensor/sms_gateway/network/config", network_config),
-            ("homeassistant/sensor/sms_gateway/network_state/config", network_state_config),
-            ("homeassistant/sensor/sms_gateway/network_code/config", network_code_config),
+            (
+                "homeassistant/sensor/sms_gateway/network_state/config",
+                network_state_config,
+            ),
+            (
+                "homeassistant/sensor/sms_gateway/network_code/config",
+                network_code_config,
+            ),
             ("homeassistant/sensor/sms_gateway/cid/config", cid_config),
             ("homeassistant/sensor/sms_gateway/lac/config", lac_config),
             # SMS sensors
             ("homeassistant/sensor/sms_gateway/last_sms/config", sms_config),
             ("homeassistant/sensor/sms_gateway/send_status/config", send_status_config),
-            ("homeassistant/sensor/sms_gateway/delete_status/config", delete_status_config),
+            (
+                "homeassistant/sensor/sms_gateway/delete_status/config",
+                delete_status_config,
+            ),
             ("homeassistant/sensor/sms_gateway/sent_count/config", sms_counter_config),
-            ("homeassistant/sensor/sms_gateway/sms_capacity/config", sms_capacity_config),
+            (
+                "homeassistant/sensor/sms_gateway/sms_capacity/config",
+                sms_capacity_config,
+            ),
             # Modem/SIM sensors
-            ("homeassistant/sensor/sms_gateway/modem_status/config", device_status_config),
+            (
+                "homeassistant/sensor/sms_gateway/modem_status/config",
+                device_status_config,
+            ),
             ("homeassistant/sensor/sms_gateway/modem_imei/config", modem_imei_config),
             ("homeassistant/sensor/sms_gateway/modem_model/config", modem_model_config),
             ("homeassistant/sensor/sms_gateway/sim_imsi/config", sim_imsi_config),
             # Controls
             ("homeassistant/button/sms_gateway/send_button/config", button_config),
-            ("homeassistant/button/sms_gateway/reset_counter/config", reset_counter_button_config),
-            ("homeassistant/button/sms_gateway/delete_all_sms/config", delete_all_sms_button_config),
+            (
+                "homeassistant/button/sms_gateway/reset_counter/config",
+                reset_counter_button_config,
+            ),
+            (
+                "homeassistant/button/sms_gateway/delete_all_sms/config",
+                delete_all_sms_button_config,
+            ),
             ("homeassistant/text/sms_gateway/phone_number/config", phone_text_config),
-            ("homeassistant/text/sms_gateway/message_text/config", message_text_config)
+            ("homeassistant/text/sms_gateway/message_text/config", message_text_config),
         ]
 
         # Add cost sensor only if cost is configured (> 0)
         if sms_cost_per_message > 0:
-            sms_cost_currency = self.config.get('sms_cost_currency', 'CZK')
+            sms_cost_currency = self.config.get("sms_cost_currency", "CZK")
             sms_cost_config = {
                 "name": "SMS Total Cost",
                 "unique_id": "sms_gateway_total_cost",
@@ -957,127 +1065,159 @@ class MQTTPublisher:
                 "unit_of_measurement": sms_cost_currency,
                 "state_class": "total",
                 "device": DEVICE_CONFIG,
-                **AVAILABILITY_CONFIG
+                **AVAILABILITY_CONFIG,
             }
-            discoveries.append(("homeassistant/sensor/sms_gateway/total_cost/config", sms_cost_config))
-        
+            discoveries.append(
+                ("homeassistant/sensor/sms_gateway/total_cost/config", sms_cost_config)
+            )
+
         for topic, config in discoveries:
             self.client.publish(topic, json.dumps(config), retain=True, qos=1)
-        
+
         logger.info("Published MQTT discovery configurations including SMS send button")
-        
+
         # Publish initial states immediately after discovery
         self._publish_initial_states()
 
         # Give HA a moment to process discovery and send retained state messages back to us
         import time
+
         time.sleep(1)
-    
+
     def publish_signal_strength(self, signal_data: Dict[str, Any]):
         """Publish signal strength data"""
         if not self.connected:
             return
-            
+
         topic = f"{self.topic_prefix}/signal/state"
         self.client.publish(topic, json.dumps(signal_data), retain=True)
-        logger.info(f"📡 Published signal strength to MQTT: {signal_data.get('SignalPercent', 'N/A')}%")
-    
+        logger.info(
+            f"📡 Published signal strength to MQTT: {signal_data.get('SignalPercent', 'N/A')}%"
+        )
+
     def publish_network_info(self, network_data: Dict[str, Any]):
         """Publish network information"""
         if not self.connected:
             return
-            
+
         topic = f"{self.topic_prefix}/network/state"
         self.client.publish(topic, json.dumps(network_data), retain=True)
-        logger.info(f"📡 Published network info to MQTT: {network_data.get('NetworkName', 'Unknown')}")
-    
+        logger.info(
+            f"📡 Published network info to MQTT: {network_data.get('NetworkName', 'Unknown')}"
+        )
+
     def publish_sms_received(self, sms_data: Dict[str, Any]):
         """Publish received SMS data and fire Home Assistant event"""
         if not self.connected:
             return
-            
+
         # Add timestamp
-        sms_data['timestamp'] = time.strftime('%Y-%m-%d %H:%M:%S')
-        
+        sms_data["timestamp"] = time.strftime("%Y-%m-%d %H:%M:%S")
+
         topic = f"{self.topic_prefix}/sms/state"
         self.client.publish(topic, json.dumps(sms_data), qos=1)
-        
+
         # Fire Home Assistant event for reliable automation triggering
         self.fire_ha_event(sms_data)
-        
-        logger.info(f"📡 Published SMS to MQTT: {sms_data.get('Number', 'Unknown')} -> {sms_data.get('Text', '')}")
-    
+
+        logger.info(
+            f"📡 Published SMS to MQTT: {sms_data.get('Number', 'Unknown')} -> {sms_data.get('Text', '')}"
+        )
+
     def fire_ha_event(self, sms_data: Dict[str, Any]):
         """Fire a Home Assistant event for received SMS using HTTP API"""
         # Prepare event data - field names match deprecated legacy_gsm_sms integration
         # for backwards compatibility: phone, text, date (+ timestamp, state for extra info)
         event_data = {
-            "phone": sms_data.get('Number', 'Unknown'),  # Matches deprecated integration
-            "text": sms_data.get('Text', ''),            # Matches deprecated integration
-            "date": sms_data.get('Date', ''),            # Matches deprecated integration
-            "timestamp": sms_data.get('timestamp', ''),  # Additional field for unix timestamp
-            "state": sms_data.get('State', 'UnRead')     # Additional field for SMS state
+            "phone": sms_data.get(
+                "Number", "Unknown"
+            ),  # Matches deprecated integration
+            "text": sms_data.get("Text", ""),  # Matches deprecated integration
+            "date": sms_data.get("Date", ""),  # Matches deprecated integration
+            "timestamp": sms_data.get(
+                "timestamp", ""
+            ),  # Additional field for unix timestamp
+            "state": sms_data.get("State", "UnRead"),  # Additional field for SMS state
         }
-        
-        logger.info(f"🔔 Attempting to fire HA event for SMS from {event_data['phone']}")
-        
+
+        logger.info(
+            f"🔔 Attempting to fire HA event for SMS from {event_data['phone']}"
+        )
+
         try:
             # Use Home Assistant API - requires homeassistant_api: true in config.yaml
-            ha_token = os.environ.get('SUPERVISOR_TOKEN', '')
+            ha_token = os.environ.get("SUPERVISOR_TOKEN", "")
             if not ha_token:
                 logger.error("❌ No SUPERVISOR_TOKEN found - cannot fire HA event")
                 return
-            
+
             # Use supervisor proxy to HA Core API (same as standalone addon)
             ha_url = "http://supervisor/core/api"
             url = f"{ha_url}/events/sms_gateway_message_received"
             headers = {
-                'Authorization': f'Bearer {ha_token}',
-                'Content-Type': 'application/json'
+                "Authorization": f"Bearer {ha_token}",
+                "Content-Type": "application/json",
             }
-            
+
             logger.debug(f"Posting to {url} with token length: {len(ha_token)}")
             response = requests.post(url, headers=headers, json=event_data, timeout=5)
-            
+
             if response.status_code in [200, 201]:
-                logger.info(f"✅ Successfully fired Home Assistant event: sms_gateway_message_received from {event_data['phone']}")
+                logger.info(
+                    f"✅ Successfully fired Home Assistant event: sms_gateway_message_received from {event_data['phone']}"
+                )
             else:
-                logger.error(f"❌ Failed to fire HA event: HTTP {response.status_code} - {response.text}")
-                
+                logger.error(
+                    f"❌ Failed to fire HA event: HTTP {response.status_code} - {response.text}"
+                )
+
         except requests.exceptions.RequestException as e:
             logger.error(f"❌ Network error firing HA event: {e}")
         except Exception as e:
             logger.error(f"❌ Unexpected error firing HA event: {e}", exc_info=True)
-    
+
     def publish_device_status(self):
         """Publish USB device connectivity status"""
         status_data = self.device_tracker.get_status_data()
-        status = status_data.get('status')
+        status = status_data.get("status")
 
         # Always log status changes, even if MQTT is disconnected
-        if hasattr(self, '_last_device_status') and self._last_device_status != status:
-            if status == 'online':
-                logger.info(f"📶 Modem: ONLINE (after {status_data.get('consecutive_failures', 0)} failures)")
-            elif status == 'offline':
-                logger.warning(f"❌ Modem: OFFLINE (no response for {status_data.get('seconds_since_last_success', 0)}s)")
-            elif status == 'unknown':
+        if hasattr(self, "_last_device_status") and self._last_device_status != status:
+            if status == "online":
+                logger.info(
+                    f"📶 Modem: ONLINE (after {status_data.get('consecutive_failures', 0)} failures)"
+                )
+            elif status == "offline":
+                logger.warning(
+                    f"❌ Modem: OFFLINE (no response for {status_data.get('seconds_since_last_success', 0)}s)"
+                )
+            elif status == "unknown":
                 logger.info("❓ Modem: UNKNOWN (no communication attempts yet)")
 
         self._last_device_status = status
 
         # Skip MQTT publish if status data hasn't changed (optimization)
-        if hasattr(self, '_last_published_status_data') and self._last_published_status_data == status_data:
-            logger.debug("Device status data unchanged, skipping redundant MQTT publish")
+        if (
+            hasattr(self, "_last_published_status_data")
+            and self._last_published_status_data == status_data
+        ):
+            logger.debug(
+                "Device status data unchanged, skipping redundant MQTT publish"
+            )
             return
 
         # Publish to MQTT if connected
         if self.connected:
             topic = f"{self.topic_prefix}/device_status/state"
             self.client.publish(topic, json.dumps(status_data), retain=True, qos=1)
-            self._last_published_status_data = status_data.copy()  # Cache published data
+            self._last_published_status_data = (
+                status_data.copy()
+            )  # Cache published data
             logger.debug(f"📡 Published device status to MQTT: {status}")
         else:
-            logger.debug("Device status changed but MQTT not connected, skipping publish")
+            logger.debug(
+                "Device status changed but MQTT not connected, skipping publish"
+            )
 
     def publish_sms_counter(self):
         """Publish SMS counter and cost data"""
@@ -1085,13 +1225,10 @@ class MQTTPublisher:
             return
 
         count = self.sms_counter.get_count()
-        sms_cost_per_message = self.config.get('sms_cost_per_message', 0.0)
+        sms_cost_per_message = self.config.get("sms_cost_per_message", 0.0)
         total_cost = count * sms_cost_per_message
 
-        counter_data = {
-            "count": count,
-            "cost": round(total_cost, 2)
-        }
+        counter_data = {"count": count, "cost": round(total_cost, 2)}
 
         topic = f"{self.topic_prefix}/sms_counter/state"
         self.client.publish(topic, json.dumps(counter_data), retain=True)
@@ -1104,7 +1241,9 @@ class MQTTPublisher:
 
         topic = f"{self.topic_prefix}/modem_info/state"
         self.client.publish(topic, json.dumps(modem_data), retain=True)
-        logger.info(f"📡 Published modem info to MQTT: {modem_data.get('Manufacturer', 'Unknown')} {modem_data.get('Model', 'Unknown')}")
+        logger.info(
+            f"📡 Published modem info to MQTT: {modem_data.get('Manufacturer', 'Unknown')} {modem_data.get('Model', 'Unknown')}"
+        )
 
     def publish_sim_info(self, sim_data: Dict[str, Any]):
         """Publish SIM card information"""
@@ -1113,7 +1252,9 @@ class MQTTPublisher:
 
         topic = f"{self.topic_prefix}/sim_info/state"
         self.client.publish(topic, json.dumps(sim_data), retain=True)
-        logger.info(f"📡 Published SIM info to MQTT: IMSI={sim_data.get('IMSI', 'Unknown')}")
+        logger.info(
+            f"📡 Published SIM info to MQTT: IMSI={sim_data.get('IMSI', 'Unknown')}"
+        )
 
     def publish_sms_capacity(self, capacity_data: Dict[str, Any]):
         """Publish SMS storage capacity"""
@@ -1122,8 +1263,10 @@ class MQTTPublisher:
 
         topic = f"{self.topic_prefix}/sms_capacity/state"
         self.client.publish(topic, json.dumps(capacity_data), retain=True)
-        logger.info(f"📡 Published SMS capacity to MQTT: {capacity_data.get('SIMUsed', 0)}/{capacity_data.get('SIMSize', 0)}")
-        
+        logger.info(
+            f"📡 Published SMS capacity to MQTT: {capacity_data.get('SIMUsed', 0)}/{capacity_data.get('SIMSize', 0)}"
+        )
+
     def track_gammu_operation(self, operation_name, gammu_function, *args, **kwargs):
         """Execute gammu operation with connectivity tracking, thread safety, and Python-level timeout"""
         # Use lock to serialize all Gammu operations (prevent race conditions on serial port)
@@ -1145,16 +1288,22 @@ class MQTTPublisher:
                     return result
                 except concurrent.futures.TimeoutError:
                     # Operation timed out at Python level
-                    self.device_tracker.record_failure(f"{operation_name}: Python timeout (15s)")
+                    self.device_tracker.record_failure(
+                        f"{operation_name}: Python timeout (15s)"
+                    )
                     self.publish_device_status()
-                    logger.error(f"⏱️ Gammu operation '{operation_name}' timed out after 15s")
-                    raise TimeoutError(f"Gammu operation '{operation_name}' timed out after 15s")
+                    logger.error(
+                        f"⏱️ Gammu operation '{operation_name}' timed out after 15s"
+                    )
+                    raise TimeoutError(
+                        f"Gammu operation '{operation_name}' timed out after 15s"
+                    )
                 except Exception as e:
                     # All other errors (including Gammu commtimeout errors)
                     self.device_tracker.record_failure(f"{operation_name}: {str(e)}")
                     self.publish_device_status()
                     raise
-    
+
     def _publish_initial_states(self):
         """Publish initial sensor states on startup"""
         if self.connected:
@@ -1168,6 +1317,7 @@ class MQTTPublisher:
 
             # Small delay to ensure deletion is processed
             import time
+
             time.sleep(0.1)
 
             # Now publish empty string as initial value (creates entity in HA)
@@ -1178,28 +1328,36 @@ class MQTTPublisher:
             self.current_phone_number = ""
             self.current_message_text = ""
 
-            logger.info("📡 Published initial text field states: cleared both phone and message fields")
+            logger.info(
+                "📡 Published initial text field states: cleared both phone and message fields"
+            )
 
             # Publish initial send_status as "ready"
             send_status_topic = f"{self.topic_prefix}/send_status"
             send_status_data = {
                 "status": "ready",
                 "message": "SMS Gateway ready to send messages",
-                "timestamp": time.strftime("%Y-%m-%d %H:%M:%S")
+                "timestamp": time.strftime("%Y-%m-%d %H:%M:%S"),
             }
-            self.client.publish(send_status_topic, json.dumps(send_status_data), retain=False)
+            self.client.publish(
+                send_status_topic, json.dumps(send_status_data), retain=False
+            )
 
             # Publish initial delete_status as "idle"
             delete_status_topic = f"{self.topic_prefix}/delete_sms_status"
             delete_status_data = {
                 "status": "idle",
                 "message": "No delete operations yet",
-                "timestamp": time.strftime("%Y-%m-%d %H:%M:%S")
+                "timestamp": time.strftime("%Y-%m-%d %H:%M:%S"),
             }
-            self.client.publish(delete_status_topic, json.dumps(delete_status_data), retain=False)
+            self.client.publish(
+                delete_status_topic, json.dumps(delete_status_data), retain=False
+            )
 
-            logger.info("📡 Published initial status states (send_status: ready, delete_status: idle)")
-    
+            logger.info(
+                "📡 Published initial status states (send_status: ready, delete_status: idle)"
+            )
+
     def publish_initial_states_with_machine(self, gammu_machine):
         """Publish initial states with gammu machine access"""
         if not self.connected:
@@ -1211,30 +1369,36 @@ class MQTTPublisher:
 
             # Publish initial offline status (will change to online on first successful operation)
             self.publish_device_status()
-            logger.info("📡 Published initial modem status: offline (waiting for first successful communication)")
+            logger.info(
+                "📡 Published initial modem status: offline (waiting for first successful communication)"
+            )
 
             # Publish initial signal strength with connectivity tracking
-            signal = self.track_gammu_operation("GetSignalQuality", gammu_machine.GetSignalQuality)
+            signal = self.track_gammu_operation(
+                "GetSignalQuality", gammu_machine.GetSignalQuality
+            )
             # Filter out invalid BER value (-1 means not available)
             if signal.get("BitErrorRate") == -1:
                 signal["BitErrorRate"] = None
             self.publish_signal_strength(signal)
 
             # Publish initial network info with connectivity tracking
-            network = self.track_gammu_operation("GetNetworkInfo", gammu_machine.GetNetworkInfo)
+            network = self.track_gammu_operation(
+                "GetNetworkInfo", gammu_machine.GetNetworkInfo
+            )
             network_code = network.get("NetworkCode", "")
             network_name = network.get("NetworkName")
-            
+
             # Try multiple lookup methods if name is empty (Gammu bug: https://github.com/gammu/python-gammu/issues/31)
             if not network_name and network_code:
                 # First try our comprehensive database
                 network_name = get_network_name(network_code)
                 # Fallback to Gammu's database
                 if not network_name:
-                    network_name = GSMNetworks.get(network_code, 'Unknown')
-            
-            network["NetworkName"] = network_name or 'Unknown'
-            
+                    network_name = GSMNetworks.get(network_code, "Unknown")
+
+            network["NetworkName"] = network_name or "Unknown"
+
             # Map Gammu's state to human-readable format
             state = network.get("State", "Unknown")
             state_map = {
@@ -1246,7 +1410,7 @@ class MQTTPublisher:
                 "Unknown": "Unknown",
             }
             network["State"] = state_map.get(state, state)
-            
+
             self.publish_network_info(network)
 
             # Don't publish empty SMS state on startup - it would overwrite the last real SMS
@@ -1254,7 +1418,9 @@ class MQTTPublisher:
             # 1. A new SMS arrives (SMS monitoring)
             # 2. User retrieves SMS via API
             # This preserves the last SMS value across restarts
-            logger.info("📡 Skipping empty SMS state publish (preserves last SMS across restarts)")
+            logger.info(
+                "📡 Skipping empty SMS state publish (preserves last SMS across restarts)"
+            )
 
             # Publish initial SMS counter
             self.publish_sms_counter()
@@ -1262,12 +1428,20 @@ class MQTTPublisher:
             # Publish modem info
             try:
                 modem_info = {
-                    "IMEI": self.track_gammu_operation("GetIMEI", gammu_machine.GetIMEI),
-                    "Manufacturer": self.track_gammu_operation("GetManufacturer", gammu_machine.GetManufacturer),
-                    "Model": self.track_gammu_operation("GetModel", gammu_machine.GetModel)
+                    "IMEI": self.track_gammu_operation(
+                        "GetIMEI", gammu_machine.GetIMEI
+                    ),
+                    "Manufacturer": self.track_gammu_operation(
+                        "GetManufacturer", gammu_machine.GetManufacturer
+                    ),
+                    "Model": self.track_gammu_operation(
+                        "GetModel", gammu_machine.GetModel
+                    ),
                 }
                 try:
-                    modem_info["Firmware"] = self.track_gammu_operation("GetFirmware", gammu_machine.GetFirmware)[0]
+                    modem_info["Firmware"] = self.track_gammu_operation(
+                        "GetFirmware", gammu_machine.GetFirmware
+                    )[0]
                 except:
                     modem_info["Firmware"] = "Unknown"
                 self.publish_modem_info(modem_info)
@@ -1276,14 +1450,20 @@ class MQTTPublisher:
 
             # Publish SIM info
             try:
-                sim_info = {"IMSI": self.track_gammu_operation("GetSIMIMSI", gammu_machine.GetSIMIMSI)}
+                sim_info = {
+                    "IMSI": self.track_gammu_operation(
+                        "GetSIMIMSI", gammu_machine.GetSIMIMSI
+                    )
+                }
                 self.publish_sim_info(sim_info)
             except Exception as e:
                 logger.warning(f"Could not publish SIM info: {e}")
 
             # Publish SMS capacity
             try:
-                capacity = self.track_gammu_operation("GetSMSStatus", gammu_machine.GetSMSStatus)
+                capacity = self.track_gammu_operation(
+                    "GetSMSStatus", gammu_machine.GetSMSStatus
+                )
                 self.publish_sms_capacity(capacity)
             except Exception as e:
                 logger.warning(f"Could not publish SMS capacity: {e}")
@@ -1292,12 +1472,12 @@ class MQTTPublisher:
 
         except Exception as e:
             logger.error(f"Error publishing initial states: {e}")
-    
+
     def start_sms_monitoring(self, gammu_machine, check_interval=10):
         """Start SMS monitoring in background thread"""
         if not self.connected:
             return
-            
+
         def _sms_monitor_loop():
             logger.info(f"📱 Started SMS monitoring (check every {check_interval}s)")
 
@@ -1306,26 +1486,38 @@ class MQTTPublisher:
             first_run = True
 
             while self.connected and not self.disconnecting:
-                from support import retrieveAllSms, deleteSms
+                from support import deleteSms, retrieveAllSms
 
                 # Check for new SMS with connectivity tracking (this will handle errors and update status)
                 try:
-                    all_sms = self.track_gammu_operation("retrieveAllSms", retrieveAllSms, gammu_machine)
+                    all_sms = self.track_gammu_operation(
+                        "retrieveAllSms", retrieveAllSms, gammu_machine
+                    )
                     current_count = len(all_sms)
-                    logger.info(f"✅ SMS monitoring cycle OK: {current_count} messages on SIM")
+                    logger.info(
+                        f"✅ SMS monitoring cycle OK: {current_count} messages on SIM"
+                    )
                 except Exception as e:
                     # track_gammu_operation already recorded the failure and published status
-                    logger.warning(f"❌ SMS monitoring cycle failed (modem offline): {e}")
+                    logger.warning(
+                        f"❌ SMS monitoring cycle failed (modem offline): {e}"
+                    )
 
                     # After 2 consecutive failures, attempt soft reset to recover connection
                     # Then retry every 5 failures (5, 10, 15, 20...)
                     failures = self.device_tracker.consecutive_failures
                     if failures == 2 or (failures > 2 and failures % 5 == 0):
-                        logger.warning(f"🔄 Attempting modem soft reset after {failures} failures...")
+                        logger.warning(
+                            f"🔄 Attempting modem soft reset after {failures} failures..."
+                        )
                         try:
                             # Soft reset: AT+CFUN=1,1 (restart modem software, keep SIM state)
-                            self.track_gammu_operation("Reset", gammu_machine.Reset, False)
-                            logger.info("✅ Modem soft reset completed, waiting 5s for recovery...")
+                            self.track_gammu_operation(
+                                "Reset", gammu_machine.Reset, False
+                            )
+                            logger.info(
+                                "✅ Modem soft reset completed, waiting 5s for recovery..."
+                            )
                             time.sleep(5)
                         except Exception as reset_err:
                             logger.error(f"❌ Modem soft reset failed: {reset_err}")
@@ -1336,17 +1528,21 @@ class MQTTPublisher:
                 try:
                     if first_run:
                         # On first run, publish only unread SMS
-                        logger.info(f"📱 Initial SMS check: {current_count} total SMS on SIM")
+                        logger.info(
+                            f"📱 Initial SMS check: {current_count} total SMS on SIM"
+                        )
                         unread_count = 0
                         for sms in all_sms:
-                            if sms.get('State') == 'UnRead':
+                            if sms.get("State") == "UnRead":
                                 sms_copy = sms.copy()
                                 sms_copy.pop("Locations", None)
                                 self.publish_sms_received(sms_copy)
                                 unread_count += 1
 
                         if unread_count > 0:
-                            logger.info(f"📱 Published {unread_count} unread SMS messages")
+                            logger.info(
+                                f"📱 Published {unread_count} unread SMS messages"
+                            )
                         else:
                             logger.info(f"📱 No unread SMS messages to publish")
 
@@ -1354,10 +1550,12 @@ class MQTTPublisher:
                         first_run = False
                     elif current_count > last_sms_count:
                         # On subsequent runs, publish all new SMS
-                        logger.info(f"📱 Detected {current_count - last_sms_count} new SMS messages")
+                        logger.info(
+                            f"📱 Detected {current_count - last_sms_count} new SMS messages"
+                        )
 
                         deleted_count = 0
-                        auto_delete = self.config.get('auto_delete_read_sms', False)
+                        auto_delete = self.config.get("auto_delete_read_sms", False)
 
                         # Process new SMS (from the end, newest first)
                         for i in range(last_sms_count, current_count):
@@ -1369,10 +1567,20 @@ class MQTTPublisher:
                                 self.publish_sms_received(sms)
 
                                 # Auto-delete if enabled and SMS is read
-                                if auto_delete and sms.get('State') in ['Read', 'UnRead']:
+                                if auto_delete and sms.get("State") in [
+                                    "Read",
+                                    "UnRead",
+                                ]:
                                     try:
-                                        self.track_gammu_operation("deleteSms", deleteSms, gammu_machine, all_sms[i])
-                                        logger.info(f"🗑️ Auto-deleted SMS from {sms.get('Number', 'Unknown')}")
+                                        self.track_gammu_operation(
+                                            "deleteSms",
+                                            deleteSms,
+                                            gammu_machine,
+                                            all_sms[i],
+                                        )
+                                        logger.info(
+                                            f"🗑️ Auto-deleted SMS from {sms.get('Number', 'Unknown')}"
+                                        )
                                         deleted_count += 1
                                     except Exception as e:
                                         logger.error(f"Error auto-deleting SMS: {e}")
@@ -1380,13 +1588,21 @@ class MQTTPublisher:
                         # If we auto-deleted any SMS, update capacity and get new count
                         if auto_delete and deleted_count > 0:
                             try:
-                                capacity = self.track_gammu_operation("GetSMSStatus", gammu_machine.GetSMSStatus)
+                                capacity = self.track_gammu_operation(
+                                    "GetSMSStatus", gammu_machine.GetSMSStatus
+                                )
                                 self.publish_sms_capacity(capacity)
                                 # Update count to reflect deleted SMS
-                                current_count = capacity.get('SIMUsed', 0) + capacity.get('PhoneUsed', 0)
-                                logger.info(f"📊 After auto-delete: {current_count} SMS remaining on SIM")
+                                current_count = capacity.get(
+                                    "SIMUsed", 0
+                                ) + capacity.get("PhoneUsed", 0)
+                                logger.info(
+                                    f"📊 After auto-delete: {current_count} SMS remaining on SIM"
+                                )
                             except Exception as e:
-                                logger.warning(f"Could not update SMS capacity after auto-delete: {e}")
+                                logger.warning(
+                                    f"Could not update SMS capacity after auto-delete: {e}"
+                                )
 
                     last_sms_count = current_count
 
@@ -1395,23 +1611,26 @@ class MQTTPublisher:
                     logger.error(f"Error processing SMS data: {e}")
 
                 time.sleep(check_interval)
-        
-        # Only start if both MQTT and SMS monitoring are enabled  
-        if (self.config.get('mqtt_enabled', False) and 
-            self.config.get('sms_monitoring_enabled', True)):
+
+        # Only start if both MQTT and SMS monitoring are enabled
+        if self.config.get("mqtt_enabled", False) and self.config.get(
+            "sms_monitoring_enabled", True
+        ):
             thread = threading.Thread(target=_sms_monitor_loop, daemon=True)
             thread.start()
-    
+
     def publish_status_periodic(self, gammu_machine, interval=60):
         """Publish status data periodically in background thread"""
         if not self.connected:
             return
-            
+
         def _publish_loop():
             while self.connected and not self.disconnecting:
                 # Publish signal strength with connectivity tracking
                 try:
-                    signal = self.track_gammu_operation("GetSignalQuality", gammu_machine.GetSignalQuality)
+                    signal = self.track_gammu_operation(
+                        "GetSignalQuality", gammu_machine.GetSignalQuality
+                    )
                     # Filter out invalid BER value (-1 means not available)
                     if signal.get("BitErrorRate") == -1:
                         signal["BitErrorRate"] = None
@@ -1423,20 +1642,23 @@ class MQTTPublisher:
                 # Publish network info with connectivity tracking
                 try:
                     from gammu import GSMNetworks
-                    network = self.track_gammu_operation("GetNetworkInfo", gammu_machine.GetNetworkInfo)
+
+                    network = self.track_gammu_operation(
+                        "GetNetworkInfo", gammu_machine.GetNetworkInfo
+                    )
                     network_code = network.get("NetworkCode", "")
                     network_name = network.get("NetworkName")
-                    
+
                     # Try multiple lookup methods if name is empty (Gammu bug: https://github.com/gammu/python-gammu/issues/31)
                     if not network_name and network_code:
                         # First try our comprehensive database
                         network_name = get_network_name(network_code)
                         # Fallback to Gammu's database
                         if not network_name:
-                            network_name = GSMNetworks.get(network_code, 'Unknown')
-                    
-                    network["NetworkName"] = network_name or 'Unknown'
-                    
+                            network_name = GSMNetworks.get(network_code, "Unknown")
+
+                    network["NetworkName"] = network_name or "Unknown"
+
                     # Map Gammu's state to human-readable format
                     state = network.get("State", "Unknown")
                     state_map = {
@@ -1448,19 +1670,19 @@ class MQTTPublisher:
                         "Unknown": "Unknown",
                     }
                     network["State"] = state_map.get(state, state)
-                    
+
                     self.publish_network_info(network)
                 except Exception as e:
                     # track_gammu_operation already recorded the failure
                     pass  # Warning already logged by track_gammu_operation
 
                 time.sleep(interval)
-        
-        if self.config.get('mqtt_enabled', False):
+
+        if self.config.get("mqtt_enabled", False):
             thread = threading.Thread(target=_publish_loop, daemon=True)
             thread.start()
             logger.info(f"Started MQTT periodic publishing (interval: {interval}s)")
-    
+
     def disconnect(self):
         """Disconnect from MQTT broker - thread-safe with duplicate call prevention"""
         if self.disconnecting:
@@ -1472,8 +1694,12 @@ class MQTTPublisher:
         if self.client and self.connected:
             # Publish offline availability - makes ALL entities unavailable in HA
             try:
-                self.client.publish(self.availability_topic, "offline", qos=1, retain=True)
-                logger.info("📡 Published availability: offline (all entities now unavailable)")
+                self.client.publish(
+                    self.availability_topic, "offline", qos=1, retain=True
+                )
+                logger.info(
+                    "📡 Published availability: offline (all entities now unavailable)"
+                )
                 time.sleep(0.5)  # Give time for message to be sent
             except Exception as e:
                 logger.warning(f"Could not publish offline availability: {e}")

--- a/addon-test-pavelve/mqtt_publisher_old.py
+++ b/addon-test-pavelve/mqtt_publisher_old.py
@@ -4,25 +4,28 @@ Publishes SMS and device status to MQTT broker with Home Assistant auto-discover
 """
 
 import json
-import time
 import logging
-import threading
 import os
-from typing import Optional, Dict, Any
+import threading
+import time
+from typing import Any, Dict, Optional
+
 import paho.mqtt.client as mqtt
 
 logger = logging.getLogger(__name__)
 
 # SMS counter persistence file
-SMS_COUNTER_FILE = '/data/sms_counter.json'
+SMS_COUNTER_FILE = "/data/sms_counter.json"
+
 
 def detect_unicode_needed(text: str) -> bool:
     """Detect if text contains non-ASCII characters requiring Unicode encoding"""
     try:
-        text.encode('ascii')
+        text.encode("ascii")
         return False
     except UnicodeEncodeError:
         return True
+
 
 class SMSCounter:
     """Tracks sent SMS count with persistent storage"""
@@ -36,9 +39,9 @@ class SMSCounter:
         """Load counter from JSON file"""
         try:
             if os.path.exists(self.counter_file):
-                with open(self.counter_file, 'r') as f:
+                with open(self.counter_file, "r") as f:
                     data = json.load(f)
-                    self.sent_count = data.get('sent_count', 0)
+                    self.sent_count = data.get("sent_count", 0)
                     logger.info(f"📊 Loaded SMS counter from file: {self.sent_count}")
             else:
                 logger.info("📊 SMS counter file not found, starting from 0")
@@ -52,8 +55,8 @@ class SMSCounter:
             # Ensure /data directory exists
             os.makedirs(os.path.dirname(self.counter_file), exist_ok=True)
 
-            data = {'sent_count': self.sent_count}
-            with open(self.counter_file, 'w') as f:
+            data = {"sent_count": self.sent_count}
+            with open(self.counter_file, "w") as f:
                 json.dump(data, f)
             logger.debug(f"📊 Saved SMS counter to file: {self.sent_count}")
         except Exception as e:
@@ -76,6 +79,7 @@ class SMSCounter:
         """Get current count"""
         return self.sent_count
 
+
 class DeviceConnectivityTracker:
     """Tracks USB GSM device connectivity status based on gammu communication"""
 
@@ -87,7 +91,7 @@ class DeviceConnectivityTracker:
         self.total_operations = 0
         self.successful_operations = 0
         self.initial_check_done = False  # Track if we've done initial modem check
-        
+
     def record_success(self):
         """Record successful gammu operation"""
         self.last_success_time = time.time()
@@ -96,13 +100,15 @@ class DeviceConnectivityTracker:
         self.total_operations += 1
         self.successful_operations += 1
         self.initial_check_done = True  # Mark initial check as done on first success
-        
+
     def record_failure(self, error_message=None):
         """Record failed gammu operation"""
         self.consecutive_failures += 1
-        self.last_error = str(error_message) if error_message else "Communication failed"
+        self.last_error = (
+            str(error_message) if error_message else "Communication failed"
+        )
         self.total_operations += 1
-        
+
     def get_status(self):
         """Get current device connectivity status"""
         # If we haven't done initial check yet, assume offline
@@ -117,79 +123,88 @@ class DeviceConnectivityTracker:
             return "offline"
         else:
             return "online"
-            
+
     def get_status_data(self):
         """Get detailed status information"""
         status = self.get_status()
-        
+
         data = {
             "status": status,
             "consecutive_failures": self.consecutive_failures,
             "total_operations": self.total_operations,
             "successful_operations": self.successful_operations,
-            "last_error": self.last_error
+            "last_error": self.last_error,
         }
-        
+
         if self.last_success_time:
-            data["last_seen"] = time.strftime("%Y-%m-%d %H:%M:%S", time.localtime(self.last_success_time))
-            data["seconds_since_last_success"] = int(time.time() - self.last_success_time)
+            data["last_seen"] = time.strftime(
+                "%Y-%m-%d %H:%M:%S", time.localtime(self.last_success_time)
+            )
+            data["seconds_since_last_success"] = int(
+                time.time() - self.last_success_time
+            )
         else:
             data["last_seen"] = None
             data["seconds_since_last_success"] = None
-            
+
         return data
+
 
 class MQTTPublisher:
     def __init__(self, config: Dict[str, Any]):
         self.config = config
         self.client: Optional[mqtt.Client] = None
         self.connected = False
-        self.topic_prefix = config.get('mqtt_topic_prefix', 'homeassistant/sensor/sms_gateway')
+        self.topic_prefix = config.get(
+            "mqtt_topic_prefix", "homeassistant/sensor/sms_gateway"
+        )
         self.gammu_machine = None  # Will be set externally
         self.current_phone_number = ""  # Current phone number from text input
         self.current_message_text = ""  # Current message text from text input
-        self.device_tracker = DeviceConnectivityTracker()  # USB device connectivity tracking
+        self.device_tracker = (
+            DeviceConnectivityTracker()
+        )  # USB device connectivity tracking
         self.sms_counter = SMSCounter()  # SMS counter with persistence
 
-        if config.get('mqtt_enabled', False):
+        if config.get("mqtt_enabled", False):
             self._setup_client()
-    
+
     def set_gammu_machine(self, machine):
         """Set gammu machine for SMS sending"""
         self.gammu_machine = machine
         logger.info("Gammu machine set for MQTT SMS sending")
-    
+
     def _setup_client(self):
         """Setup MQTT client with configuration"""
         try:
             self.client = mqtt.Client()
 
             # Set credentials ONLY if username is provided and not empty
-            username = self.config.get('mqtt_username', '').strip()
-            password = self.config.get('mqtt_password', '')
+            username = self.config.get("mqtt_username", "").strip()
+            password = self.config.get("mqtt_password", "")
             if username:  # Only set credentials if username is not empty
                 self.client.username_pw_set(username, password)
                 logger.info(f"MQTT: Using authentication with username: {username}")
             else:
                 logger.info("MQTT: Connecting without authentication (local broker)")
-            
+
             # Set callbacks
             self.client.on_connect = self._on_connect
             self.client.on_disconnect = self._on_disconnect
             self.client.on_publish = self._on_publish
             self.client.on_message = self._on_message
-            
+
             # Connect to broker
-            host = self.config.get('mqtt_host', 'core-mosquitto')
-            port = self.config.get('mqtt_port', 1883)
-            
+            host = self.config.get("mqtt_host", "core-mosquitto")
+            port = self.config.get("mqtt_port", 1883)
+
             logger.info(f"Connecting to MQTT broker: {host}:{port}")
             self.client.connect(host, port, 60)
             self.client.loop_start()
-            
+
         except Exception as e:
             logger.error(f"Failed to setup MQTT client: {e}")
-    
+
     def _on_connect(self, client, userdata, flags, rc):
         """Callback for MQTT connection"""
         if rc == 0:
@@ -226,24 +241,26 @@ class MQTTPublisher:
             client.subscribe(message_topic)
             client.subscribe(phone_state_topic)  # Subscribe to state topics too
             client.subscribe(message_state_topic)
-            logger.info(f"Subscribed to text input topics: {phone_topic}, {message_topic}, {phone_state_topic}, {message_state_topic}")
+            logger.info(
+                f"Subscribed to text input topics: {phone_topic}, {message_topic}, {phone_state_topic}, {message_state_topic}"
+            )
         else:
             logger.error(f"Failed to connect to MQTT broker: {rc}")
-    
+
     def _on_disconnect(self, client, userdata, rc):
         """Callback for MQTT disconnection"""
         self.connected = False
         logger.warning("Disconnected from MQTT broker")
-    
+
     def _on_publish(self, client, userdata, mid):
         """Callback for published messages"""
         pass
-    
+
     def _on_message(self, client, userdata, msg):
         """Callback for received MQTT messages"""
         try:
             topic = msg.topic
-            payload = msg.payload.decode('utf-8')
+            payload = msg.payload.decode("utf-8")
             logger.info(f"Received MQTT message on topic {topic}: {payload}")
 
             # Check message topic and handle accordingly
@@ -288,34 +305,36 @@ class MQTTPublisher:
 
         except Exception as e:
             logger.error(f"Error processing MQTT message: {e}")
-    
+
     def _handle_sms_send_command(self, payload):
         """Handle SMS send command from MQTT"""
         try:
             # Parse JSON payload
             data = json.loads(payload)
-            number = data.get('number')
-            text = data.get('text')
+            number = data.get("number")
+            text = data.get("text")
             # If 'unicode' is explicitly provided, use it; otherwise use None for auto-detection
-            unicode_mode = data.get('unicode') if 'unicode' in data else None
+            unicode_mode = data.get("unicode") if "unicode" in data else None
 
             if not number or not text:
                 logger.error("SMS send command missing required fields: number or text")
                 return
 
-            logger.info(f"Processing SMS send command: {number} -> {text} (unicode: {unicode_mode if unicode_mode is not None else 'auto'})")
+            logger.info(
+                f"Processing SMS send command: {number} -> {text} (unicode: {unicode_mode if unicode_mode is not None else 'auto'})"
+            )
 
             # Send SMS via gammu machine (will be set externally)
-            if hasattr(self, 'gammu_machine') and self.gammu_machine:
+            if hasattr(self, "gammu_machine") and self.gammu_machine:
                 self._send_sms_via_gammu(number, text, unicode_mode)
             else:
                 logger.error("Gammu machine not available for SMS sending")
-                
+
         except json.JSONDecodeError as e:
             logger.error(f"Invalid JSON in SMS send command: {e}")
         except Exception as e:
             logger.error(f"Error handling SMS send command: {e}")
-    
+
     def _send_sms_via_gammu(self, number, text, unicode_mode=None):
         """Send SMS using gammu machine
 
@@ -332,7 +351,9 @@ class MQTTPublisher:
             if unicode_mode is None:
                 unicode_mode = detect_unicode_needed(text)
                 if unicode_mode:
-                    logger.info(f"🔤 Auto-detected non-ASCII characters, using Unicode mode")
+                    logger.info(
+                        f"🔤 Auto-detected non-ASCII characters, using Unicode mode"
+                    )
 
             # Prepare SMS info
             smsinfo = {
@@ -350,17 +371,19 @@ class MQTTPublisher:
             messages = encodeSms(smsinfo)
             for message in messages:
                 # Use same SMSC logic as REST API
-                config_smsc = self.config.get('smsc_number', '').strip()
+                config_smsc = self.config.get("smsc_number", "").strip()
                 if config_smsc:
-                    message["SMSC"] = {'Number': config_smsc}
+                    message["SMSC"] = {"Number": config_smsc}
                     logger.info(f"Using configured SMSC: {config_smsc}")
                 else:
                     # Use Location 1 (same as REST API when no SMSC provided)
-                    message["SMSC"] = {'Location': 1}
+                    message["SMSC"] = {"Location": 1}
                     logger.info("Using SMSC from Location 1 (same as REST API)")
 
                 message["Number"] = number
-                result = self.track_gammu_operation("SendSMS", self.gammu_machine.SendSMS, message)
+                result = self.track_gammu_operation(
+                    "SendSMS", self.gammu_machine.SendSMS, message
+                )
                 logger.info(f"SMS sent successfully: {result}")
 
             # Increment SMS counter and publish
@@ -375,10 +398,10 @@ class MQTTPublisher:
                     "status": "success",
                     "number": number,
                     "text": text,
-                    "timestamp": time.strftime("%Y-%m-%d %H:%M:%S")
+                    "timestamp": time.strftime("%Y-%m-%d %H:%M:%S"),
                 }
                 self.client.publish(status_topic, json.dumps(status_data), retain=False)
-                
+
         except Exception as e:
             error_msg = str(e)
             # Try to extract useful error message from gammu error
@@ -390,7 +413,7 @@ class MQTTPublisher:
                 user_error = "SMSC number not found - configure SMS center number in SIM settings"
             else:
                 user_error = f"SMS sending error: {error_msg}"
-            
+
             logger.error(f"Failed to send SMS via gammu: {error_msg}")
             # Publish error status with user-friendly message
             if self.connected:
@@ -400,40 +423,51 @@ class MQTTPublisher:
                     "error": user_error,
                     "number": number,
                     "text": text,
-                    "timestamp": time.strftime("%Y-%m-%d %H:%M:%S")
+                    "timestamp": time.strftime("%Y-%m-%d %H:%M:%S"),
                 }
                 self.client.publish(status_topic, json.dumps(status_data), retain=False)
-    
+
     def _handle_button_sms_send(self):
         """Handle SMS send when button is pressed using current text inputs"""
         # Log current state for debugging
-        logger.info(f"Button pressed - current state: phone='{self.current_phone_number}', message='{self.current_message_text}'")
+        logger.info(
+            f"Button pressed - current state: phone='{self.current_phone_number}', message='{self.current_message_text}'"
+        )
 
-        if not self.current_phone_number.strip() or not self.current_message_text.strip():
+        if (
+            not self.current_phone_number.strip()
+            or not self.current_message_text.strip()
+        ):
             # If fields are empty, show instruction
             if self.connected:
                 status_topic = f"{self.topic_prefix}/send_status"
                 status_data = {
                     "status": "missing_fields",
                     "message": f"Please fill in phone number and message text first. Current: phone='{self.current_phone_number}', message='{self.current_message_text}'",
-                    "timestamp": time.strftime("%Y-%m-%d %H:%M:%S")
+                    "timestamp": time.strftime("%Y-%m-%d %H:%M:%S"),
                 }
                 self.client.publish(status_topic, json.dumps(status_data), retain=False)
-            logger.warning(f"Button pressed but fields empty: phone='{self.current_phone_number}', message='{self.current_message_text}'")
+            logger.warning(
+                f"Button pressed but fields empty: phone='{self.current_phone_number}', message='{self.current_message_text}'"
+            )
             return
 
         # Send SMS using current values
-        logger.info(f"Button SMS send: {self.current_phone_number} -> {self.current_message_text}")
-        if hasattr(self, 'gammu_machine') and self.gammu_machine:
+        logger.info(
+            f"Button SMS send: {self.current_phone_number} -> {self.current_message_text}"
+        )
+        if hasattr(self, "gammu_machine") and self.gammu_machine:
             # Use unicode_mode=None for auto-detection
-            self._send_sms_via_gammu(self.current_phone_number, self.current_message_text, unicode_mode=None)
+            self._send_sms_via_gammu(
+                self.current_phone_number, self.current_message_text, unicode_mode=None
+            )
             # Always clear fields after send attempt (success or failure)
             self._clear_text_fields()
         else:
             logger.error("Gammu machine not available for SMS sending")
             # Clear fields even if gammu not available
             self._clear_text_fields()
-    
+
     def _handle_reset_counter(self):
         """Handle reset counter button press"""
         logger.info("🔄 Reset counter button pressed")
@@ -445,24 +479,32 @@ class MQTTPublisher:
         """Handle delete all SMS button press"""
         logger.info("🗑️ Delete all SMS button pressed")
         try:
-            if hasattr(self, 'gammu_machine') and self.gammu_machine:
-                from support import retrieveAllSms, deleteSms
+            if hasattr(self, "gammu_machine") and self.gammu_machine:
+                from support import deleteSms, retrieveAllSms
 
                 # Get all SMS
-                all_sms = self.track_gammu_operation("retrieveAllSms", retrieveAllSms, self.gammu_machine)
+                all_sms = self.track_gammu_operation(
+                    "retrieveAllSms", retrieveAllSms, self.gammu_machine
+                )
                 count = len(all_sms)
 
                 # Delete each SMS
                 for sms in all_sms:
-                    self.track_gammu_operation("deleteSms", deleteSms, self.gammu_machine, sms)
+                    self.track_gammu_operation(
+                        "deleteSms", deleteSms, self.gammu_machine, sms
+                    )
 
                 logger.info(f"✅ Deleted {count} SMS messages from SIM")
 
                 # Update SMS capacity after deletion
                 try:
-                    capacity = self.track_gammu_operation("GetSMSStatus", self.gammu_machine.GetSMSStatus)
+                    capacity = self.track_gammu_operation(
+                        "GetSMSStatus", self.gammu_machine.GetSMSStatus
+                    )
                     self.publish_sms_capacity(capacity)
-                    logger.info(f"📊 Updated SMS capacity: {capacity.get('SIMUsed', 0)}/{capacity.get('SIMSize', 0)}")
+                    logger.info(
+                        f"📊 Updated SMS capacity: {capacity.get('SIMUsed', 0)}/{capacity.get('SIMSize', 0)}"
+                    )
                 except Exception as e:
                     logger.warning(f"Could not update SMS capacity: {e}")
 
@@ -472,9 +514,11 @@ class MQTTPublisher:
                     status_data = {
                         "status": "success",
                         "deleted_count": count,
-                        "timestamp": time.strftime("%Y-%m-%d %H:%M:%S")
+                        "timestamp": time.strftime("%Y-%m-%d %H:%M:%S"),
                     }
-                    self.client.publish(status_topic, json.dumps(status_data), retain=False)
+                    self.client.publish(
+                        status_topic, json.dumps(status_data), retain=False
+                    )
             else:
                 logger.error("Gammu machine not available for deleting SMS")
         except Exception as e:
@@ -484,7 +528,7 @@ class MQTTPublisher:
                 status_data = {
                     "status": "error",
                     "error": str(e),
-                    "timestamp": time.strftime("%Y-%m-%d %H:%M:%S")
+                    "timestamp": time.strftime("%Y-%m-%d %H:%M:%S"),
                 }
                 self.client.publish(status_topic, json.dumps(status_data), retain=False)
 
@@ -499,42 +543,46 @@ class MQTTPublisher:
                 message_state_topic = f"{self.topic_prefix}/message_text/state"
                 # Clear only message field with retain=True
                 self.client.publish(message_state_topic, "", retain=True)
-                logger.info("🧹 Cleared message text field (keeping phone number for convenience)")
+                logger.info(
+                    "🧹 Cleared message text field (keeping phone number for convenience)"
+                )
             except Exception as e:
                 logger.warning(f"Could not clear message field in UI: {e}")
         else:
             logger.info("🧹 Cleared message text field (internal state only)")
-    
+
     def _publish_phone_state(self, value):
         """Publish phone number state"""
         if self.connected:
             state_topic = f"{self.topic_prefix}/phone_number/state"
             self.client.publish(state_topic, value, retain=False)
-    
+
     def _publish_message_state(self, value):
         """Publish message text state"""
         if self.connected:
             state_topic = f"{self.topic_prefix}/message_text/state"
             self.client.publish(state_topic, value, retain=False)
-    
+
     def _publish_empty_text_fields(self):
         """Initialize message field to empty on startup, let phone number persist"""
         if self.connected:
             message_state_topic = f"{self.topic_prefix}/message_text/state"
-            
+
             # Force only message to empty state with retain=True
             self.client.publish(message_state_topic, "", retain=True)
-            
+
             # Clear only message internally, phone number will sync from HA
             self.current_message_text = ""
-            
-            logger.info("🔄 Initialized message field to empty (phone number persists from last session)")
-    
+
+            logger.info(
+                "🔄 Initialized message field to empty (phone number persists from last session)"
+            )
+
     def _publish_discovery_configs(self):
         """Publish Home Assistant auto-discovery configurations"""
         if not self.connected:
             return
-            
+
         # Signal strength sensor
         signal_config = {
             "name": "GSM Signal Strength",
@@ -547,10 +595,10 @@ class MQTTPublisher:
                 "identifiers": ["sms_gateway"],
                 "name": "SMS Gateway",
                 "model": "GSM Modem",
-                "manufacturer": "Gammu Gateway"
-            }
+                "manufacturer": "Gammu Gateway",
+            },
         }
-        
+
         # Network info sensor
         network_config = {
             "name": "GSM Network",
@@ -561,11 +609,11 @@ class MQTTPublisher:
             "device": {
                 "identifiers": ["sms_gateway"],
                 "name": "SMS Gateway",
-                "model": "GSM Modem", 
-                "manufacturer": "Gammu Gateway"
-            }
+                "model": "GSM Modem",
+                "manufacturer": "Gammu Gateway",
+            },
         }
-        
+
         # Last SMS sensor
         sms_config = {
             "name": "Last SMS Received",
@@ -578,10 +626,10 @@ class MQTTPublisher:
                 "identifiers": ["sms_gateway"],
                 "name": "SMS Gateway",
                 "model": "GSM Modem",
-                "manufacturer": "Gammu Gateway"
-            }
+                "manufacturer": "Gammu Gateway",
+            },
         }
-        
+
         # SMS send status sensor
         send_status_config = {
             "name": "SMS Send Status",
@@ -594,10 +642,10 @@ class MQTTPublisher:
                 "identifiers": ["sms_gateway"],
                 "name": "SMS Gateway",
                 "model": "GSM Modem",
-                "manufacturer": "Gammu Gateway"
-            }
+                "manufacturer": "Gammu Gateway",
+            },
         }
-        
+
         # SMS send button
         button_config = {
             "name": "Send SMS",
@@ -609,10 +657,10 @@ class MQTTPublisher:
                 "identifiers": ["sms_gateway"],
                 "name": "SMS Gateway",
                 "model": "GSM Modem",
-                "manufacturer": "Gammu Gateway"
-            }
+                "manufacturer": "Gammu Gateway",
+            },
         }
-        
+
         # Phone number input text
         phone_text_config = {
             "name": "Phone Number",
@@ -626,10 +674,10 @@ class MQTTPublisher:
                 "identifiers": ["sms_gateway"],
                 "name": "SMS Gateway",
                 "model": "GSM Modem",
-                "manufacturer": "Gammu Gateway"
-            }
+                "manufacturer": "Gammu Gateway",
+            },
         }
-        
+
         # Message input text
         message_text_config = {
             "name": "Message Text",
@@ -643,10 +691,10 @@ class MQTTPublisher:
                 "identifiers": ["sms_gateway"],
                 "name": "SMS Gateway",
                 "model": "GSM Modem",
-                "manufacturer": "Gammu Gateway"
-            }
+                "manufacturer": "Gammu Gateway",
+            },
         }
-        
+
         # Modem Status sensor
         device_status_config = {
             "name": "Modem Status",
@@ -659,8 +707,8 @@ class MQTTPublisher:
                 "identifiers": ["sms_gateway"],
                 "name": "SMS Gateway",
                 "model": "GSM Modem",
-                "manufacturer": "Gammu Gateway"
-            }
+                "manufacturer": "Gammu Gateway",
+            },
         }
 
         # SMS Counter sensor
@@ -675,12 +723,12 @@ class MQTTPublisher:
                 "identifiers": ["sms_gateway"],
                 "name": "SMS Gateway",
                 "model": "GSM Modem",
-                "manufacturer": "Gammu Gateway"
-            }
+                "manufacturer": "Gammu Gateway",
+            },
         }
 
         # SMS Cost sensor (only if cost > 0)
-        sms_cost_per_message = self.config.get('sms_cost_per_message', 0.0)
+        sms_cost_per_message = self.config.get("sms_cost_per_message", 0.0)
 
         # Reset counter button
         reset_counter_button_config = {
@@ -693,8 +741,8 @@ class MQTTPublisher:
                 "identifiers": ["sms_gateway"],
                 "name": "SMS Gateway",
                 "model": "GSM Modem",
-                "manufacturer": "Gammu Gateway"
-            }
+                "manufacturer": "Gammu Gateway",
+            },
         }
 
         # Delete all SMS button
@@ -708,8 +756,8 @@ class MQTTPublisher:
                 "identifiers": ["sms_gateway"],
                 "name": "SMS Gateway",
                 "model": "GSM Modem",
-                "manufacturer": "Gammu Gateway"
-            }
+                "manufacturer": "Gammu Gateway",
+            },
         }
 
         # Modem IMEI sensor
@@ -723,8 +771,8 @@ class MQTTPublisher:
                 "identifiers": ["sms_gateway"],
                 "name": "SMS Gateway",
                 "model": "GSM Modem",
-                "manufacturer": "Gammu Gateway"
-            }
+                "manufacturer": "Gammu Gateway",
+            },
         }
 
         # Modem Model sensor
@@ -738,8 +786,8 @@ class MQTTPublisher:
                 "identifiers": ["sms_gateway"],
                 "name": "SMS Gateway",
                 "model": "GSM Modem",
-                "manufacturer": "Gammu Gateway"
-            }
+                "manufacturer": "Gammu Gateway",
+            },
         }
 
         # SIM IMSI sensor
@@ -753,8 +801,8 @@ class MQTTPublisher:
                 "identifiers": ["sms_gateway"],
                 "name": "SMS Gateway",
                 "model": "GSM Modem",
-                "manufacturer": "Gammu Gateway"
-            }
+                "manufacturer": "Gammu Gateway",
+            },
         }
 
         # SMS Capacity sensor
@@ -770,8 +818,8 @@ class MQTTPublisher:
                 "identifiers": ["sms_gateway"],
                 "name": "SMS Gateway",
                 "model": "GSM Modem",
-                "manufacturer": "Gammu Gateway"
-            }
+                "manufacturer": "Gammu Gateway",
+            },
         }
 
         # Publish discovery configs
@@ -780,22 +828,34 @@ class MQTTPublisher:
             ("homeassistant/sensor/sms_gateway_network/config", network_config),
             ("homeassistant/sensor/sms_gateway_last_sms/config", sms_config),
             ("homeassistant/sensor/sms_gateway_send_status/config", send_status_config),
-            ("homeassistant/sensor/sms_gateway_modem_status/config", device_status_config),
+            (
+                "homeassistant/sensor/sms_gateway_modem_status/config",
+                device_status_config,
+            ),
             ("homeassistant/sensor/sms_gateway_sent_count/config", sms_counter_config),
             ("homeassistant/sensor/sms_gateway_modem_imei/config", modem_imei_config),
             ("homeassistant/sensor/sms_gateway_modem_model/config", modem_model_config),
             ("homeassistant/sensor/sms_gateway_sim_imsi/config", sim_imsi_config),
-            ("homeassistant/sensor/sms_gateway_sms_capacity/config", sms_capacity_config),
+            (
+                "homeassistant/sensor/sms_gateway_sms_capacity/config",
+                sms_capacity_config,
+            ),
             ("homeassistant/button/sms_gateway_send_button/config", button_config),
-            ("homeassistant/button/sms_gateway_reset_counter/config", reset_counter_button_config),
-            ("homeassistant/button/sms_gateway_delete_all_sms/config", delete_all_sms_button_config),
+            (
+                "homeassistant/button/sms_gateway_reset_counter/config",
+                reset_counter_button_config,
+            ),
+            (
+                "homeassistant/button/sms_gateway_delete_all_sms/config",
+                delete_all_sms_button_config,
+            ),
             ("homeassistant/text/sms_gateway_phone_number/config", phone_text_config),
-            ("homeassistant/text/sms_gateway_message_text/config", message_text_config)
+            ("homeassistant/text/sms_gateway_message_text/config", message_text_config),
         ]
 
         # Add cost sensor only if cost is configured (> 0)
         if sms_cost_per_message > 0:
-            sms_cost_currency = self.config.get('sms_cost_currency', 'CZK')
+            sms_cost_currency = self.config.get("sms_cost_currency", "CZK")
             sms_cost_config = {
                 "name": "SMS Total Cost",
                 "unique_id": "sms_gateway_total_cost",
@@ -808,58 +868,67 @@ class MQTTPublisher:
                     "identifiers": ["sms_gateway"],
                     "name": "SMS Gateway",
                     "model": "GSM Modem",
-                    "manufacturer": "Gammu Gateway"
-                }
+                    "manufacturer": "Gammu Gateway",
+                },
             }
-            discoveries.append(("homeassistant/sensor/sms_gateway_total_cost/config", sms_cost_config))
-        
+            discoveries.append(
+                ("homeassistant/sensor/sms_gateway_total_cost/config", sms_cost_config)
+            )
+
         for topic, config in discoveries:
             self.client.publish(topic, json.dumps(config), retain=True)
-        
+
         logger.info("Published MQTT discovery configurations including SMS send button")
-        
+
         # Publish initial states immediately after discovery
         self._publish_initial_states()
-        
+
         # Wait a moment for HA to process discovery, then force empty text fields
         import time
+
         time.sleep(1)
         self._publish_empty_text_fields()
-        
+
         # Give HA another moment to send retained state messages back to us
         time.sleep(0.5)
-    
+
     def publish_signal_strength(self, signal_data: Dict[str, Any]):
         """Publish signal strength data"""
         if not self.connected:
             return
-            
+
         topic = f"{self.topic_prefix}/signal/state"
         self.client.publish(topic, json.dumps(signal_data), retain=True)
-        logger.info(f"📡 Published signal strength to MQTT: {signal_data.get('SignalPercent', 'N/A')}%")
-    
+        logger.info(
+            f"📡 Published signal strength to MQTT: {signal_data.get('SignalPercent', 'N/A')}%"
+        )
+
     def publish_network_info(self, network_data: Dict[str, Any]):
         """Publish network information"""
         if not self.connected:
             return
-            
+
         topic = f"{self.topic_prefix}/network/state"
         self.client.publish(topic, json.dumps(network_data), retain=True)
-        logger.info(f"📡 Published network info to MQTT: {network_data.get('NetworkName', 'Unknown')}")
-    
+        logger.info(
+            f"📡 Published network info to MQTT: {network_data.get('NetworkName', 'Unknown')}"
+        )
+
     def publish_sms_received(self, sms_data: Dict[str, Any]):
         """Publish received SMS data"""
         if not self.connected:
             return
-            
+
         # Add timestamp
-        sms_data['timestamp'] = time.strftime('%Y-%m-%d %H:%M:%S')
-        
+        sms_data["timestamp"] = time.strftime("%Y-%m-%d %H:%M:%S")
+
         topic = f"{self.topic_prefix}/sms/state"
         self.client.publish(topic, json.dumps(sms_data))
-        
-        logger.info(f"📡 Published SMS to MQTT: {sms_data.get('Number', 'Unknown')} -> {sms_data.get('Text', '')}")
-    
+
+        logger.info(
+            f"📡 Published SMS to MQTT: {sms_data.get('Number', 'Unknown')} -> {sms_data.get('Text', '')}"
+        )
+
     def publish_device_status(self):
         """Publish USB device connectivity status"""
         if not self.connected:
@@ -871,13 +940,17 @@ class MQTTPublisher:
         self.client.publish(topic, json.dumps(status_data), retain=True)
 
         # Log status changes
-        status = status_data.get('status')
-        if hasattr(self, '_last_device_status') and self._last_device_status != status:
-            if status == 'online':
-                logger.info(f"📶 Modem: ONLINE (after {status_data.get('consecutive_failures', 0)} failures)")
-            elif status == 'offline':
-                logger.warning(f"❌ Modem: OFFLINE (no response for {status_data.get('seconds_since_last_success', 0)}s)")
-            elif status == 'unknown':
+        status = status_data.get("status")
+        if hasattr(self, "_last_device_status") and self._last_device_status != status:
+            if status == "online":
+                logger.info(
+                    f"📶 Modem: ONLINE (after {status_data.get('consecutive_failures', 0)} failures)"
+                )
+            elif status == "offline":
+                logger.warning(
+                    f"❌ Modem: OFFLINE (no response for {status_data.get('seconds_since_last_success', 0)}s)"
+                )
+            elif status == "unknown":
                 logger.info("❓ Modem: UNKNOWN (no communication attempts yet)")
 
         self._last_device_status = status
@@ -888,13 +961,10 @@ class MQTTPublisher:
             return
 
         count = self.sms_counter.get_count()
-        sms_cost_per_message = self.config.get('sms_cost_per_message', 0.0)
+        sms_cost_per_message = self.config.get("sms_cost_per_message", 0.0)
         total_cost = count * sms_cost_per_message
 
-        counter_data = {
-            "count": count,
-            "cost": round(total_cost, 2)
-        }
+        counter_data = {"count": count, "cost": round(total_cost, 2)}
 
         topic = f"{self.topic_prefix}/sms_counter/state"
         self.client.publish(topic, json.dumps(counter_data), retain=True)
@@ -907,7 +977,9 @@ class MQTTPublisher:
 
         topic = f"{self.topic_prefix}/modem_info/state"
         self.client.publish(topic, json.dumps(modem_data), retain=True)
-        logger.info(f"📡 Published modem info to MQTT: {modem_data.get('Manufacturer', 'Unknown')} {modem_data.get('Model', 'Unknown')}")
+        logger.info(
+            f"📡 Published modem info to MQTT: {modem_data.get('Manufacturer', 'Unknown')} {modem_data.get('Model', 'Unknown')}"
+        )
 
     def publish_sim_info(self, sim_data: Dict[str, Any]):
         """Publish SIM card information"""
@@ -916,7 +988,9 @@ class MQTTPublisher:
 
         topic = f"{self.topic_prefix}/sim_info/state"
         self.client.publish(topic, json.dumps(sim_data), retain=True)
-        logger.info(f"📡 Published SIM info to MQTT: IMSI={sim_data.get('IMSI', 'Unknown')}")
+        logger.info(
+            f"📡 Published SIM info to MQTT: IMSI={sim_data.get('IMSI', 'Unknown')}"
+        )
 
     def publish_sms_capacity(self, capacity_data: Dict[str, Any]):
         """Publish SMS storage capacity"""
@@ -925,8 +999,10 @@ class MQTTPublisher:
 
         topic = f"{self.topic_prefix}/sms_capacity/state"
         self.client.publish(topic, json.dumps(capacity_data), retain=True)
-        logger.info(f"📡 Published SMS capacity to MQTT: {capacity_data.get('SIMUsed', 0)}/{capacity_data.get('SIMSize', 0)}")
-        
+        logger.info(
+            f"📡 Published SMS capacity to MQTT: {capacity_data.get('SIMUsed', 0)}/{capacity_data.get('SIMSize', 0)}"
+        )
+
     def track_gammu_operation(self, operation_name, gammu_function, *args, **kwargs):
         """Execute gammu operation with connectivity tracking"""
         try:
@@ -940,12 +1016,12 @@ class MQTTPublisher:
             self.publish_device_status()
             logger.warning(f"❌ Gammu operation '{operation_name}' failed: {e}")
             raise
-    
+
     def _publish_initial_states(self):
         """Publish initial sensor states on startup"""
         # This will be called from the main thread with access to gammu machine
         pass
-    
+
     def publish_initial_states_with_machine(self, gammu_machine):
         """Publish initial states with gammu machine access"""
         if not self.connected:
@@ -957,15 +1033,23 @@ class MQTTPublisher:
 
             # Publish initial offline status (will change to online on first successful operation)
             self.publish_device_status()
-            logger.info("📡 Published initial modem status: offline (waiting for first successful communication)")
+            logger.info(
+                "📡 Published initial modem status: offline (waiting for first successful communication)"
+            )
 
             # Publish initial signal strength with connectivity tracking
-            signal = self.track_gammu_operation("GetSignalQuality", gammu_machine.GetSignalQuality)
+            signal = self.track_gammu_operation(
+                "GetSignalQuality", gammu_machine.GetSignalQuality
+            )
             self.publish_signal_strength(signal)
 
             # Publish initial network info with connectivity tracking
-            network = self.track_gammu_operation("GetNetworkInfo", gammu_machine.GetNetworkInfo)
-            network["NetworkName"] = GSMNetworks.get(network.get("NetworkCode", ""), 'Unknown')
+            network = self.track_gammu_operation(
+                "GetNetworkInfo", gammu_machine.GetNetworkInfo
+            )
+            network["NetworkName"] = GSMNetworks.get(
+                network.get("NetworkCode", ""), "Unknown"
+            )
             self.publish_network_info(network)
 
             # Don't publish empty SMS state on startup - it would overwrite the last real SMS
@@ -973,7 +1057,9 @@ class MQTTPublisher:
             # 1. A new SMS arrives (SMS monitoring)
             # 2. User retrieves SMS via API
             # This preserves the last SMS value across restarts
-            logger.info("📡 Skipping empty SMS state publish (preserves last SMS across restarts)")
+            logger.info(
+                "📡 Skipping empty SMS state publish (preserves last SMS across restarts)"
+            )
 
             # Publish initial SMS counter
             self.publish_sms_counter()
@@ -981,12 +1067,20 @@ class MQTTPublisher:
             # Publish modem info
             try:
                 modem_info = {
-                    "IMEI": self.track_gammu_operation("GetIMEI", gammu_machine.GetIMEI),
-                    "Manufacturer": self.track_gammu_operation("GetManufacturer", gammu_machine.GetManufacturer),
-                    "Model": self.track_gammu_operation("GetModel", gammu_machine.GetModel)
+                    "IMEI": self.track_gammu_operation(
+                        "GetIMEI", gammu_machine.GetIMEI
+                    ),
+                    "Manufacturer": self.track_gammu_operation(
+                        "GetManufacturer", gammu_machine.GetManufacturer
+                    ),
+                    "Model": self.track_gammu_operation(
+                        "GetModel", gammu_machine.GetModel
+                    ),
                 }
                 try:
-                    modem_info["Firmware"] = self.track_gammu_operation("GetFirmware", gammu_machine.GetFirmware)[0]
+                    modem_info["Firmware"] = self.track_gammu_operation(
+                        "GetFirmware", gammu_machine.GetFirmware
+                    )[0]
                 except:
                     modem_info["Firmware"] = "Unknown"
                 self.publish_modem_info(modem_info)
@@ -995,14 +1089,20 @@ class MQTTPublisher:
 
             # Publish SIM info
             try:
-                sim_info = {"IMSI": self.track_gammu_operation("GetSIMIMSI", gammu_machine.GetSIMIMSI)}
+                sim_info = {
+                    "IMSI": self.track_gammu_operation(
+                        "GetSIMIMSI", gammu_machine.GetSIMIMSI
+                    )
+                }
                 self.publish_sim_info(sim_info)
             except Exception as e:
                 logger.warning(f"Could not publish SIM info: {e}")
 
             # Publish SMS capacity
             try:
-                capacity = self.track_gammu_operation("GetSMSStatus", gammu_machine.GetSMSStatus)
+                capacity = self.track_gammu_operation(
+                    "GetSMSStatus", gammu_machine.GetSMSStatus
+                )
                 self.publish_sms_capacity(capacity)
             except Exception as e:
                 logger.warning(f"Could not publish SMS capacity: {e}")
@@ -1011,12 +1111,12 @@ class MQTTPublisher:
 
         except Exception as e:
             logger.error(f"Error publishing initial states: {e}")
-    
+
     def start_sms_monitoring(self, gammu_machine, check_interval=30):
         """Start SMS monitoring in background thread"""
         if not self.connected:
             return
-            
+
         def _sms_monitor_loop():
             logger.info(f"📱 Started SMS monitoring (check every {check_interval}s)")
 
@@ -1026,25 +1126,31 @@ class MQTTPublisher:
 
             while self.connected:
                 try:
-                    from support import retrieveAllSms, deleteSms
+                    from support import deleteSms, retrieveAllSms
 
                     # Check for new SMS with connectivity tracking
-                    all_sms = self.track_gammu_operation("retrieveAllSms", retrieveAllSms, gammu_machine)
+                    all_sms = self.track_gammu_operation(
+                        "retrieveAllSms", retrieveAllSms, gammu_machine
+                    )
                     current_count = len(all_sms)
 
                     if first_run:
                         # On first run, publish only unread SMS
-                        logger.info(f"📱 Initial SMS check: {current_count} total SMS on SIM")
+                        logger.info(
+                            f"📱 Initial SMS check: {current_count} total SMS on SIM"
+                        )
                         unread_count = 0
                         for sms in all_sms:
-                            if sms.get('State') == 'UnRead':
+                            if sms.get("State") == "UnRead":
                                 sms_copy = sms.copy()
                                 sms_copy.pop("Locations", None)
                                 self.publish_sms_received(sms_copy)
                                 unread_count += 1
 
                         if unread_count > 0:
-                            logger.info(f"📱 Published {unread_count} unread SMS messages")
+                            logger.info(
+                                f"📱 Published {unread_count} unread SMS messages"
+                            )
                         else:
                             logger.info(f"📱 No unread SMS messages to publish")
 
@@ -1052,7 +1158,9 @@ class MQTTPublisher:
                         first_run = False
                     elif current_count > last_sms_count:
                         # On subsequent runs, publish all new SMS
-                        logger.info(f"📱 Detected {current_count - last_sms_count} new SMS messages")
+                        logger.info(
+                            f"📱 Detected {current_count - last_sms_count} new SMS messages"
+                        )
 
                         # Process new SMS (from the end, newest first)
                         for i in range(last_sms_count, current_count):
@@ -1064,63 +1172,91 @@ class MQTTPublisher:
                                 self.publish_sms_received(sms)
 
                                 # Auto-delete if enabled and SMS is read
-                                auto_delete = self.config.get('auto_delete_read_sms', False)
-                                if auto_delete and sms.get('State') in ['Read', 'UnRead']:
+                                auto_delete = self.config.get(
+                                    "auto_delete_read_sms", False
+                                )
+                                if auto_delete and sms.get("State") in [
+                                    "Read",
+                                    "UnRead",
+                                ]:
                                     try:
-                                        self.track_gammu_operation("deleteSms", deleteSms, gammu_machine, all_sms[i])
-                                        logger.info(f"🗑️ Auto-deleted SMS from {sms.get('Number', 'Unknown')}")
+                                        self.track_gammu_operation(
+                                            "deleteSms",
+                                            deleteSms,
+                                            gammu_machine,
+                                            all_sms[i],
+                                        )
+                                        logger.info(
+                                            f"🗑️ Auto-deleted SMS from {sms.get('Number', 'Unknown')}"
+                                        )
                                     except Exception as e:
                                         logger.error(f"Error auto-deleting SMS: {e}")
 
                         # If we auto-deleted any SMS, update capacity
                         if auto_delete and current_count > 0:
                             try:
-                                capacity = self.track_gammu_operation("GetSMSStatus", gammu_machine.GetSMSStatus)
+                                capacity = self.track_gammu_operation(
+                                    "GetSMSStatus", gammu_machine.GetSMSStatus
+                                )
                                 self.publish_sms_capacity(capacity)
                             except Exception as e:
-                                logger.warning(f"Could not update SMS capacity after auto-delete: {e}")
+                                logger.warning(
+                                    f"Could not update SMS capacity after auto-delete: {e}"
+                                )
 
-                    last_sms_count = current_count if not self.config.get('auto_delete_read_sms', False) else 0
-                    
+                    last_sms_count = (
+                        current_count
+                        if not self.config.get("auto_delete_read_sms", False)
+                        else 0
+                    )
+
                 except Exception as e:
                     logger.error(f"Error monitoring SMS: {e}")
-                
+
                 time.sleep(check_interval)
-        
-        # Only start if both MQTT and SMS monitoring are enabled  
-        if (self.config.get('mqtt_enabled', False) and 
-            self.config.get('sms_monitoring_enabled', True)):
+
+        # Only start if both MQTT and SMS monitoring are enabled
+        if self.config.get("mqtt_enabled", False) and self.config.get(
+            "sms_monitoring_enabled", True
+        ):
             thread = threading.Thread(target=_sms_monitor_loop, daemon=True)
             thread.start()
-    
+
     def publish_status_periodic(self, gammu_machine, interval=60):
         """Publish status data periodically in background thread"""
         if not self.connected:
             return
-            
+
         def _publish_loop():
             while self.connected:
                 try:
                     # Publish signal strength with connectivity tracking
-                    signal = self.track_gammu_operation("GetSignalQuality", gammu_machine.GetSignalQuality)
+                    signal = self.track_gammu_operation(
+                        "GetSignalQuality", gammu_machine.GetSignalQuality
+                    )
                     self.publish_signal_strength(signal)
-                    
+
                     # Publish network info with connectivity tracking
                     from gammu import GSMNetworks
-                    network = self.track_gammu_operation("GetNetworkInfo", gammu_machine.GetNetworkInfo)
-                    network["NetworkName"] = GSMNetworks.get(network.get("NetworkCode", ""), 'Unknown')
+
+                    network = self.track_gammu_operation(
+                        "GetNetworkInfo", gammu_machine.GetNetworkInfo
+                    )
+                    network["NetworkName"] = GSMNetworks.get(
+                        network.get("NetworkCode", ""), "Unknown"
+                    )
                     self.publish_network_info(network)
-                    
+
                 except Exception as e:
                     logger.error(f"Error publishing periodic status: {e}")
-                
+
                 time.sleep(interval)
-        
-        if self.config.get('mqtt_enabled', False):
+
+        if self.config.get("mqtt_enabled", False):
             thread = threading.Thread(target=_publish_loop, daemon=True)
             thread.start()
             logger.info(f"Started MQTT periodic publishing (interval: {interval}s)")
-    
+
     def disconnect(self):
         """Disconnect from MQTT broker"""
         if self.client and self.connected:

--- a/addon-test-pavelve/network_codes.py
+++ b/addon-test-pavelve/network_codes.py
@@ -15,8 +15,6 @@ Auto-update: Monthly via GitHub Actions
 # Comprehensive database of mobile network operators by MCC+MNC
 # Format: "MCCMNC": "Operator Name"
 NETWORK_OPERATORS = {
-
-
     # United States (MCC 310-316)
     "310005": "Verizon",
     "310006": "Verizon",
@@ -352,7 +350,6 @@ NETWORK_OPERATORS = {
     "310970": "Globalstar",
     "310980": "Peoples Telephone",
     "310990": "Evolve Broadband",
-
     # US MVNOs with unique codes
     "310032": "IT&E Wireless",
     "310053": "Virgin Mobile",
@@ -483,7 +480,6 @@ NETWORK_OPERATORS = {
     "313970": "Tycrhron",
     "313980": "Next Generation Application LLC",
     "313990": "Ericsson US",
-
     # Canada (MCC 302)
     "302100": "dotmobile",
     "302130": "Xplore",
@@ -566,7 +562,6 @@ NETWORK_OPERATORS = {
     "302996": "Powertech Labs",
     "302997": "Powertech Labs",
     "302998": "Institut de Recherche d’Hydro-Québec",
-
     # United Kingdom (MCC 234, 235)
     "23400": "BT",
     "23401": "Vectone Mobile",
@@ -631,7 +626,6 @@ NETWORK_OPERATORS = {
     "23479": "UKTL",
     "23486": "EE",
     "23488": "telet",
-
     # Germany (MCC 262)
     "26201": "Telekom",
     "26202": "Vodafone",
@@ -675,7 +669,6 @@ NETWORK_OPERATORS = {
     "26279": "ng4T GmbH",
     "26292": "Nash Technologies",
     "26298": "private networks",
-
     # France (MCC 208)
     "20801": "Orange",
     "20802": "Orange",
@@ -753,7 +746,6 @@ NETWORK_OPERATORS = {
     "20896": "Région Bourgogne-Franche-Comté",
     "20897": "Thales Communications & Security SAS",
     "20898": "Société Air France",
-
     # Spain (MCC 214)
     "21401": "Vodafone",
     "21402": "Fibracat",
@@ -796,7 +788,6 @@ NETWORK_OPERATORS = {
     "21451": "ADIF",
     "214700": "Iberdrola",
     "214701": "Endesa",
-
     # Italy (MCC 222)
     "22201": "TIM",
     "22202": "Elsacom",
@@ -827,7 +818,6 @@ NETWORK_OPERATORS = {
     "22288": "WINDTRE",
     "22298": "BLU",
     "22299": "WINDTRE",
-
     # Netherlands (MCC 204)
     "20400": "Intovoice B.V.",
     "20401": "RadioAccess Network Services",
@@ -873,7 +863,6 @@ NETWORK_OPERATORS = {
     "20468": "Roamware (Netherlands) B.V.",
     "20469": "KPN Mobile The Netherlands B.V.",
     "20491": "Enexis Netbeheer B.V.",
-
     # Australia (MCC 505)
     "50501": "Telstra",
     "50502": "Optus",
@@ -936,7 +925,6 @@ NETWORK_OPERATORS = {
     "50588": "Pivotel Group Pty Ltd",
     "50590": "Optus",
     "50599": "One.Tel",
-
     # China (MCC 460, 461)
     "46000": "China Mobile",
     "46001": "China Unicom",
@@ -951,7 +939,6 @@ NETWORK_OPERATORS = {
     "46011": "China Telecom",
     "46015": "China Broadnet",
     "46020": "China Tietong",
-
     # Japan (MCC 440, 441)
     "44000": "Y!Mobile",
     "44001": "KDDI Corporation",
@@ -990,7 +977,6 @@ NETWORK_OPERATORS = {
     "44075": "au",
     "44076": "au",
     "44078": "au",
-
     # India (MCC 404, 405)
     "40401": "Vi India",
     "40402": "AirTel",
@@ -1080,7 +1066,6 @@ NETWORK_OPERATORS = {
     "40496": "AirTel",
     "40497": "AirTel",
     "40498": "AirTel",
-
     # Brazil (MCC 724)
     "72400": "Nextel",
     "72401": "SISTEER DO BRASIL TELECOMUNICAÇÔES",
@@ -1113,7 +1098,6 @@ NETWORK_OPERATORS = {
     "72439": "Nextel",
     "72454": "Conecta",
     "72499": "Local",
-
     # Mexico (MCC 334)
     "334001": "Comunicaciones Digitales Del Norte, S.A. de C.V.",
     "334010": "AT&T",
@@ -1143,7 +1127,6 @@ NETWORK_OPERATORS = {
     "334200": "Virgin Mobile",
     "334210": "YO Mobile",
     "334220": "Megamóvil",
-
     # Russia (MCC 250)
     "25001": "MTS",
     "25002": "MegaFon",
@@ -1194,7 +1177,6 @@ NETWORK_OPERATORS = {
     "25096": "+7Telecom",
     "25097": "Phoenix",
     "25099": "Beeline",
-
     # South Africa (MCC 655)
     "65501": "Vodacom",
     "65502": "Telkom",
@@ -1235,9 +1217,7 @@ NETWORK_OPERATORS = {
     "65575": "ACSA",
     "65576": "Comsol Networks (Pty) Ltd",
     "65577": "Umoja Connect",
-
     # Add more countries as needed...
-
     # Additional network codes
     "001001": "TEST",
     "00101": "TEST",
@@ -3114,10 +3094,10 @@ NETWORK_OPERATORS = {
 
 def get_network_name(network_code: str):
     """Get network operator name from MCC+MNC code.
-    
+
     Args:
         network_code: MCC+MNC code (e.g., "310260" for T-Mobile USA)
-        
+
     Returns:
         Network operator name or None if not found
     """

--- a/addon-test-pavelve/run.py
+++ b/addon-test-pavelve/run.py
@@ -7,71 +7,83 @@ Based on: https://github.com/pajikos/sms-gammu-gateway
 Licensed under Apache License 2.0
 """
 
-import os
 import json
 import logging
+import os
 import signal
 import sys
+
 from flask import Flask, request
 from flask_httpauth import HTTPBasicAuth
 from flask_restx import Api, Resource, fields, reqparse
-
-from support import init_state_machine, retrieveAllSms, deleteSms, encodeSms
-from mqtt_publisher import MQTTPublisher
 from gammu import GSMNetworks
+from mqtt_publisher import MQTTPublisher
+from support import deleteSms, encodeSms, init_state_machine, retrieveAllSms
+
 from network_codes import get_network_name
 
 # Configure logging with timestamp
 logging.basicConfig(
     level=logging.INFO,
-    format='[%(asctime)s] %(levelname)s: %(message)s',
-    datefmt='%H:%M:%S'
+    format="[%(asctime)s] %(levelname)s: %(message)s",
+    datefmt="%H:%M:%S",
 )
-mqtt_logger = logging.getLogger('mqtt_publisher')
+mqtt_logger = logging.getLogger("mqtt_publisher")
 mqtt_logger.setLevel(logging.INFO)
 
 # Suppress Flask development server warnings
-log = logging.getLogger('werkzeug')
+log = logging.getLogger("werkzeug")
 log.setLevel(logging.ERROR)
 
 # Monkey-patch click.echo to suppress Flask CLI startup messages
 import click
+
 _original_echo = click.echo
+
+
 def _silent_echo(message=None, **kwargs):
     # Only suppress Flask's "Debug mode:" and "Serving Flask app" messages
     if message and isinstance(message, str):
-        if 'Debug mode:' in message or 'Serving Flask app' in message:
+        if "Debug mode:" in message or "Serving Flask app" in message:
             return
     _original_echo(message, **kwargs)
+
+
 click.echo = _silent_echo
+
 
 def load_version():
     """Load version from config.json"""
     try:
         # Try multiple possible locations
         possible_paths = [
-            '/data/options.json',
-            os.path.join(os.path.dirname(__file__), 'config.json'),
-            '/config.json',
+            "/data/options.json",
+            os.path.join(os.path.dirname(__file__), "config.json"),
+            "/config.json",
         ]
 
         # Try to read from addon info API first (most reliable in HA)
         try:
             import requests
-            response = requests.get('http://supervisor/addons/self/info',
-                                   headers={'Authorization': f'Bearer {os.environ.get("SUPERVISOR_TOKEN", "")}'},
-                                   timeout=1)
+
+            response = requests.get(
+                "http://supervisor/addons/self/info",
+                headers={
+                    "Authorization": f'Bearer {os.environ.get("SUPERVISOR_TOKEN", "")}'
+                },
+                timeout=1,
+            )
             if response.status_code == 200:
-                return response.json().get('data', {}).get('version', 'unknown')
+                return response.json().get("data", {}).get("version", "unknown")
         except:
             pass
 
         # Fallback: try to find config.json
         for config_path in possible_paths:
             if os.path.exists(config_path):
-                with open(config_path, 'r') as f:
+                with open(config_path, "r") as f:
                     config_json = json.load(f)
-                    version = config_json.get('version')
+                    version = config_json.get("version")
                     if version:
                         return version
 
@@ -80,63 +92,71 @@ def load_version():
         logging.warning(f"Could not read version: {e}")
         return "unknown"
 
+
 def load_ha_config():
     """Load Home Assistant add-on configuration"""
-    config_path = '/data/options.json'
+    config_path = "/data/options.json"
     if os.path.exists(config_path):
-        with open(config_path, 'r') as f:
+        with open(config_path, "r") as f:
             return json.load(f)
     else:
         # Default values for testing outside HA
         return {
-            'device_path': '/dev/ttyUSB0',
-            'pin': '',
-            'port': 5000,
-            'ssl': False,
-            'username': 'admin',
-            'password': 'password',
-            'mqtt_enabled': True,
-            'mqtt_host': 'localhost',
-            'mqtt_port': 1883,
-            'mqtt_username': '',
-            'mqtt_password': '',
-            'mqtt_topic_prefix': 'homeassistant/sensor/sms_gateway',
-            'sms_monitoring_enabled': True,
-            'sms_check_interval': 60,
-            'sms_cost_per_message': 0.0,
-            'sms_cost_currency': 'CZK',
-            'auto_delete_read_sms': False
+            "device_path": "/dev/ttyUSB0",
+            "pin": "",
+            "port": 5000,
+            "ssl": False,
+            "username": "admin",
+            "password": "password",
+            "mqtt_enabled": True,
+            "mqtt_host": "localhost",
+            "mqtt_port": 1883,
+            "mqtt_username": "",
+            "mqtt_password": "",
+            "mqtt_topic_prefix": "homeassistant/sensor/sms_gateway",
+            "sms_monitoring_enabled": True,
+            "sms_check_interval": 60,
+            "sms_cost_per_message": 0.0,
+            "sms_cost_currency": "CZK",
+            "auto_delete_read_sms": False,
         }
+
 
 # Load version and configuration
 VERSION = load_version()
 config = load_ha_config()
-pin = config.get('pin') if config.get('pin') else None
-ssl = config.get('ssl', False)
-port = config.get('port', 5000)
-username = config.get('username', 'admin')
-password = config.get('password', 'password')
-device_path = config.get('device_path', '/dev/ttyUSB0')
+pin = config.get("pin") if config.get("pin") else None
+ssl = config.get("ssl", False)
+port = config.get("port", 5000)
+username = config.get("username", "admin")
+password = config.get("password", "password")
+device_path = config.get("device_path", "/dev/ttyUSB0")
 
 # Log device path and check accessibility
 logging.info(f"📱 Configured device path: {device_path}")
 
 # Check if it's a by-id symlink
-if '/dev/serial/by-id/' in device_path:
+if "/dev/serial/by-id/" in device_path:
     if os.path.islink(device_path):
         resolved_path = os.path.realpath(device_path)
         logging.info(f"🔗 By-ID symlink resolves to: {resolved_path}")
-        
+
         # Check if resolved device exists and is accessible
         if os.path.exists(resolved_path):
             logging.info(f"✅ Resolved device {resolved_path} is accessible")
         else:
-            logging.error(f"❌ ERROR: Resolved device {resolved_path} is NOT accessible!")
-            logging.error(f"💡 TIP: Add '{resolved_path}' to the 'devices' list in config.yaml")
+            logging.error(
+                f"❌ ERROR: Resolved device {resolved_path} is NOT accessible!"
+            )
+            logging.error(
+                f"💡 TIP: Add '{resolved_path}' to the 'devices' list in config.yaml"
+            )
     else:
         logging.error(f"❌ ERROR: {device_path} is not a valid symlink!")
         if not os.path.exists(device_path):
-            logging.error(f"💡 TIP: Check if /dev/serial/by-id is mounted (add to 'devices' list)")
+            logging.error(
+                f"💡 TIP: Check if /dev/serial/by-id is mounted (add to 'devices' list)"
+            )
 elif os.path.exists(device_path):
     logging.info(f"✅ Device {device_path} is accessible")
 else:
@@ -159,6 +179,7 @@ machine = init_state_machine(pin, device_path)
 # Set gammu machine for MQTT SMS sending
 mqtt_publisher.set_gammu_machine(machine)
 
+
 # Setup signal handlers for graceful shutdown
 def signal_handler(signum, frame):
     """Handle shutdown signals (SIGTERM, SIGINT)"""
@@ -171,11 +192,14 @@ def signal_handler(signum, frame):
     finally:
         sys.exit(0)
 
+
 signal.signal(signal.SIGTERM, signal_handler)
 signal.signal(signal.SIGINT, signal_handler)
 
 # Register atexit handler as backup
 import atexit
+
+
 def cleanup():
     """Cleanup function called on normal exit"""
     logging.info("🧹 Cleanup: Publishing offline status...")
@@ -184,20 +208,25 @@ def cleanup():
     except Exception as e:
         logging.error(f"Error during cleanup: {e}")
 
+
 atexit.register(cleanup)
 
 app = Flask(__name__)
 
 # Check if running under Ingress
 import os
-ingress_path = os.environ.get('INGRESS_PATH', '')
+
+ingress_path = os.environ.get("INGRESS_PATH", "")
+
 
 # Create simple HTML page for Ingress
-@app.route('/')
+@app.route("/")
 def home():
     """Simple status page for Home Assistant Ingress"""
     from flask import Response, request
-    html = '''
+
+    html = (
+        """
     <!DOCTYPE html>
     <html>
     <head>
@@ -264,7 +293,9 @@ def home():
                 Version: {VERSION}
             </div>
             
-            <a href="http://''' + request.host.split(':')[0] + ''':5000/docs/" 
+            <a href="http://"""
+        + request.host.split(":")[0]
+        + """:5000/docs/" 
                class="swagger-link" target="_blank">
                 📋 Open Swagger API Documentation
             </a>
@@ -284,29 +315,28 @@ def home():
         </div>
     </body>
     </html>
-    '''
-    return Response(html.replace('{VERSION}', VERSION), mimetype='text/html')
+    """
+    )
+    return Response(html.replace("{VERSION}", VERSION), mimetype="text/html")
+
 
 # Swagger UI Configuration
 # Put Swagger UI on /docs/ path for direct access via port 5000
 api = Api(
     app,
     version=VERSION,
-    title='SMS Gammu Gateway API',
-    description='REST API for sending and receiving SMS messages via USB GSM modems (SIM800L, Huawei, etc.). Modern replacement for deprecated SMS notifications via GSM-modem integration.',
-    doc='/docs/',  # Swagger UI on /docs/ path
-    prefix='',
+    title="SMS Gammu Gateway API",
+    description="REST API for sending and receiving SMS messages via USB GSM modems (SIM800L, Huawei, etc.). Modern replacement for deprecated SMS notifications via GSM-modem integration.",
+    doc="/docs/",  # Swagger UI on /docs/ path
+    prefix="",
     authorizations={
-        'basicAuth': {
-            'type': 'basic',
-            'in': 'header',
-            'name': 'Authorization'
-        }
+        "basicAuth": {"type": "basic", "in": "header", "name": "Authorization"}
     },
-    security='basicAuth'
+    security="basicAuth",
 )
 
 auth = HTTPBasicAuth()
+
 
 @auth.verify_password
 def verify(user, pwd):
@@ -314,143 +344,230 @@ def verify(user, pwd):
         return False
     return user == username and pwd == password
 
+
 # API Models for Swagger documentation
-sms_model = api.model('SMS', {
-    'text': fields.String(required=True, description='SMS message text', example='Hello, how are you?'),
-    'number': fields.String(required=True, description='Phone number (international format)', example='+420123456789'),
-    'smsc': fields.String(required=False, description='SMS Center number (optional)', example='+420603052000'),
-    'unicode': fields.Boolean(required=False, description='Use Unicode encoding', default=False)
-})
+sms_model = api.model(
+    "SMS",
+    {
+        "text": fields.String(
+            required=True, description="SMS message text", example="Hello, how are you?"
+        ),
+        "number": fields.String(
+            required=True,
+            description="Phone number (international format)",
+            example="+420123456789",
+        ),
+        "smsc": fields.String(
+            required=False,
+            description="SMS Center number (optional)",
+            example="+420603052000",
+        ),
+        "unicode": fields.Boolean(
+            required=False, description="Use Unicode encoding", default=False
+        ),
+    },
+)
 
-sms_response = api.model('SMS Response', {
-    'Date': fields.String(description='Date and time received', example='2025-01-19 14:30:00'),
-    'Number': fields.String(description='Sender phone number', example='+420123456789'),
-    'State': fields.String(description='SMS state', example='UnRead'),
-    'Text': fields.String(description='SMS message text', example='Hello World!')
-})
+sms_response = api.model(
+    "SMS Response",
+    {
+        "Date": fields.String(
+            description="Date and time received", example="2025-01-19 14:30:00"
+        ),
+        "Number": fields.String(
+            description="Sender phone number", example="+420123456789"
+        ),
+        "State": fields.String(description="SMS state", example="UnRead"),
+        "Text": fields.String(description="SMS message text", example="Hello World!"),
+    },
+)
 
-signal_response = api.model('Signal Quality', {
-    'SignalStrength': fields.Integer(description='Signal strength in dBm', example=-75),
-    'SignalPercent': fields.Integer(description='Signal strength percentage', example=65),
-    'BitErrorRate': fields.Integer(description='Bit error rate', example=-1)
-})
+signal_response = api.model(
+    "Signal Quality",
+    {
+        "SignalStrength": fields.Integer(
+            description="Signal strength in dBm", example=-75
+        ),
+        "SignalPercent": fields.Integer(
+            description="Signal strength percentage", example=65
+        ),
+        "BitErrorRate": fields.Integer(description="Bit error rate", example=-1),
+    },
+)
 
-network_response = api.model('Network Info', {
-    'NetworkName': fields.String(description='Network operator name', example='T-Mobile'),
-    'State': fields.String(description='Network registration state', example='HomeNetwork'),
-    'NetworkCode': fields.String(description='Network operator code', example='230 01'),
-    'CID': fields.String(description='Cell ID', example='0A1B2C3D'),
-    'LAC': fields.String(description='Location Area Code', example='1234')
-})
+network_response = api.model(
+    "Network Info",
+    {
+        "NetworkName": fields.String(
+            description="Network operator name", example="T-Mobile"
+        ),
+        "State": fields.String(
+            description="Network registration state", example="HomeNetwork"
+        ),
+        "NetworkCode": fields.String(
+            description="Network operator code", example="230 01"
+        ),
+        "CID": fields.String(description="Cell ID", example="0A1B2C3D"),
+        "LAC": fields.String(description="Location Area Code", example="1234"),
+    },
+)
 
-send_response = api.model('Send Response', {
-    'status': fields.Integer(description='HTTP status code', example=200),
-    'message': fields.String(description='Response message', example='[1]')
-})
+send_response = api.model(
+    "Send Response",
+    {
+        "status": fields.Integer(description="HTTP status code", example=200),
+        "message": fields.String(description="Response message", example="[1]"),
+    },
+)
 
-reset_response = api.model('Reset Response', {
-    'status': fields.Integer(description='HTTP status code', example=200),
-    'message': fields.String(description='Reset message', example='Reset done')
-})
+reset_response = api.model(
+    "Reset Response",
+    {
+        "status": fields.Integer(description="HTTP status code", example=200),
+        "message": fields.String(description="Reset message", example="Reset done"),
+    },
+)
 
-modem_info_response = api.model('Modem Info', {
-    'IMEI': fields.String(description='Modem IMEI number', example='123456789012345'),
-    'Manufacturer': fields.String(description='Modem manufacturer', example='Huawei'),
-    'Model': fields.String(description='Modem model', example='E3372'),
-    'Firmware': fields.String(description='Firmware version', example='22.323.62.00.143')
-})
+modem_info_response = api.model(
+    "Modem Info",
+    {
+        "IMEI": fields.String(
+            description="Modem IMEI number", example="123456789012345"
+        ),
+        "Manufacturer": fields.String(
+            description="Modem manufacturer", example="Huawei"
+        ),
+        "Model": fields.String(description="Modem model", example="E3372"),
+        "Firmware": fields.String(
+            description="Firmware version", example="22.323.62.00.143"
+        ),
+    },
+)
 
-sim_info_response = api.model('SIM Info', {
-    'IMSI': fields.String(description='SIM IMSI number', example='230011234567890')
-})
+sim_info_response = api.model(
+    "SIM Info",
+    {"IMSI": fields.String(description="SIM IMSI number", example="230011234567890")},
+)
 
-sms_capacity_response = api.model('SMS Capacity', {
-    'SIMUsed': fields.Integer(description='SMS count in SIM memory', example=5),
-    'SIMSize': fields.Integer(description='SIM total capacity', example=50),
-    'PhoneUsed': fields.Integer(description='SMS count in phone memory', example=0),
-    'PhoneSize': fields.Integer(description='Phone memory capacity', example=100),
-    'TemplatesUsed': fields.Integer(description='SMS templates used', example=0)
-})
+sms_capacity_response = api.model(
+    "SMS Capacity",
+    {
+        "SIMUsed": fields.Integer(description="SMS count in SIM memory", example=5),
+        "SIMSize": fields.Integer(description="SIM total capacity", example=50),
+        "PhoneUsed": fields.Integer(description="SMS count in phone memory", example=0),
+        "PhoneSize": fields.Integer(description="Phone memory capacity", example=100),
+        "TemplatesUsed": fields.Integer(description="SMS templates used", example=0),
+    },
+)
 
 # API Namespaces
-ns_sms = api.namespace('sms', description='SMS operations (requires authentication)')
-ns_status = api.namespace('status', description='Device status and information (public)')
+ns_sms = api.namespace("sms", description="SMS operations (requires authentication)")
+ns_status = api.namespace(
+    "status", description="Device status and information (public)"
+)
 
-@ns_sms.route('')
-@ns_sms.doc('sms_operations')
+
+@ns_sms.route("")
+@ns_sms.doc("sms_operations")
 class SmsCollection(Resource):
-    @ns_sms.doc('get_all_sms')
+    @ns_sms.doc("get_all_sms")
     @ns_sms.marshal_list_with(sms_response, code=200)
-    @ns_sms.doc(security='basicAuth')
+    @ns_sms.doc(security="basicAuth")
     @auth.login_required
     def get(self):
         """Get all SMS messages from SIM/device memory"""
-        allSms = mqtt_publisher.track_gammu_operation("retrieveAllSms", retrieveAllSms, machine)
+        allSms = mqtt_publisher.track_gammu_operation(
+            "retrieveAllSms", retrieveAllSms, machine
+        )
         list(map(lambda sms: sms.pop("Locations", None), allSms))
         return allSms
 
-    @ns_sms.doc('send_sms')
+    @ns_sms.doc("send_sms")
     @ns_sms.expect(sms_model)
     @ns_sms.marshal_with(send_response, code=200)
-    @ns_sms.doc(security='basicAuth')
+    @ns_sms.doc(security="basicAuth")
     @auth.login_required
     def post(self):
         """Send SMS message(s)"""
         # Use request.get_json() to handle JSON arrays properly instead of reqparse
         data = request.get_json() or {}
-        
+
         # Also check query parameters and form data as fallback
         if not data:
             parser = reqparse.RequestParser()
-            parser.add_argument('text', required=False, help='SMS message text')
-            parser.add_argument('message', required=False, help='SMS message text (alias for text)')
-            parser.add_argument('number', required=False, help='Phone number(s), comma separated')
-            parser.add_argument('target', required=False, help='Phone number (alias for number)')
-            parser.add_argument('smsc', required=False, help='SMS Center number (optional)')
-            parser.add_argument('unicode', type=bool, required=False, default=False, help='Use Unicode encoding')
+            parser.add_argument("text", required=False, help="SMS message text")
+            parser.add_argument(
+                "message", required=False, help="SMS message text (alias for text)"
+            )
+            parser.add_argument(
+                "number", required=False, help="Phone number(s), comma separated"
+            )
+            parser.add_argument(
+                "target", required=False, help="Phone number (alias for number)"
+            )
+            parser.add_argument(
+                "smsc", required=False, help="SMS Center number (optional)"
+            )
+            parser.add_argument(
+                "unicode",
+                type=bool,
+                required=False,
+                default=False,
+                help="Use Unicode encoding",
+            )
             data = parser.parse_args()
         else:
             # Ensure unicode has a default value when using JSON
-            data.setdefault('unicode', False)
-        
+            data.setdefault("unicode", False)
+
         # Support both 'text' and 'message' parameters
-        sms_text = data.get('text') or data.get('message')
+        sms_text = data.get("text") or data.get("message")
         if not sms_text:
-            return {"status": 400, "message": "Missing required field: text or message"}, 400
-        
+            return {
+                "status": 400,
+                "message": "Missing required field: text or message",
+            }, 400
+
         # Support both 'number' and 'target' parameters
-        sms_number = data.get('number') or data.get('target')
+        sms_number = data.get("number") or data.get("target")
         if not sms_number:
-            return {"status": 400, "message": "Missing required field: number or target"}, 400
-        
-        logging.info(f"SMS send request - Text: '{sms_text}', Numbers: '{sms_number}', Type: {type(sms_number)}")
-        
+            return {
+                "status": 400,
+                "message": "Missing required field: number or target",
+            }, 400
+
+        logging.info(
+            f"SMS send request - Text: '{sms_text}', Numbers: '{sms_number}', Type: {type(sms_number)}"
+        )
+
         # Handle both string (comma-separated) and list formats
         if isinstance(sms_number, list):
             numbers = sms_number
         else:
             # Check if it's a string representation of a list (e.g., "['phone1', 'phone2']")
             sms_number_str = str(sms_number).strip()
-            if sms_number_str.startswith('[') and sms_number_str.endswith(']'):
+            if sms_number_str.startswith("[") and sms_number_str.endswith("]"):
                 try:
                     # Try to parse as JSON array first
                     import json
+
                     numbers = json.loads(sms_number_str)
                 except:
                     # If JSON parsing fails, try Python literal eval
                     try:
                         import ast
+
                         numbers = ast.literal_eval(sms_number_str)
                     except:
                         # Fall back to treating as single number
                         numbers = [sms_number_str]
             else:
                 # Comma-separated string
-                numbers = [n.strip() for n in sms_number_str.split(',')]
-        
+                numbers = [n.strip() for n in sms_number_str.split(",")]
+
         smsinfo = {
             "Class": -1,
-            "Unicode": data.get('unicode', False),
+            "Unicode": data.get("unicode", False),
             "Entries": [
                 {
                     "ID": "ConcatenatedTextLong",
@@ -461,10 +578,17 @@ class SmsCollection(Resource):
         messages = []
         for number in numbers:
             for message in encodeSms(smsinfo):
-                message["SMSC"] = {'Number': data.get("smsc")} if data.get("smsc") else {'Location': 1}
+                message["SMSC"] = (
+                    {"Number": data.get("smsc")}
+                    if data.get("smsc")
+                    else {"Location": 1}
+                )
                 message["Number"] = number.strip()
                 messages.append(message)
-        result = [mqtt_publisher.track_gammu_operation("SendSMS", machine.SendSMS, message) for message in messages]
+        result = [
+            mqtt_publisher.track_gammu_operation("SendSMS", machine.SendSMS, message)
+            for message in messages
+        ]
 
         # Increment SMS counter for each sent message
         for _ in messages:
@@ -473,43 +597,53 @@ class SmsCollection(Resource):
 
         return {"status": 200, "message": str(result)}, 200
 
-@ns_sms.route('/<int:id>')
-@ns_sms.doc('sms_by_id')
+
+@ns_sms.route("/<int:id>")
+@ns_sms.doc("sms_by_id")
 class SmsItem(Resource):
-    @ns_sms.doc('get_sms_by_id')
+    @ns_sms.doc("get_sms_by_id")
     @ns_sms.marshal_with(sms_response, code=200)
-    @ns_sms.doc(security='basicAuth')
+    @ns_sms.doc(security="basicAuth")
     @auth.login_required
     def get(self, id):
         """Get specific SMS by ID"""
-        allSms = mqtt_publisher.track_gammu_operation("retrieveAllSms", retrieveAllSms, machine)
+        allSms = mqtt_publisher.track_gammu_operation(
+            "retrieveAllSms", retrieveAllSms, machine
+        )
         if id < 0 or id >= len(allSms):
             api.abort(404, f"SMS with id '{id}' not found")
         sms = allSms[id]
         sms.pop("Locations", None)
         return sms
 
-    @ns_sms.doc('delete_sms_by_id')
-    @ns_sms.doc(security='basicAuth')
+    @ns_sms.doc("delete_sms_by_id")
+    @ns_sms.doc(security="basicAuth")
     @auth.login_required
     def delete(self, id):
         """Delete SMS by ID"""
-        allSms = mqtt_publisher.track_gammu_operation("retrieveAllSms", retrieveAllSms, machine)
+        allSms = mqtt_publisher.track_gammu_operation(
+            "retrieveAllSms", retrieveAllSms, machine
+        )
         if id < 0 or id >= len(allSms):
             api.abort(404, f"SMS with id '{id}' not found")
-        mqtt_publisher.track_gammu_operation("deleteSms", deleteSms, machine, allSms[id])
-        return '', 204
+        mqtt_publisher.track_gammu_operation(
+            "deleteSms", deleteSms, machine, allSms[id]
+        )
+        return "", 204
 
-@ns_sms.route('/getsms')
-@ns_sms.doc('get_and_delete_first_sms')
+
+@ns_sms.route("/getsms")
+@ns_sms.doc("get_and_delete_first_sms")
 class GetSms(Resource):
-    @ns_sms.doc('pop_first_sms')
+    @ns_sms.doc("pop_first_sms")
     @ns_sms.marshal_with(sms_response, code=200)
-    @ns_sms.doc(security='basicAuth')
+    @ns_sms.doc(security="basicAuth")
     @auth.login_required
     def get(self):
         """Get first SMS and delete it from memory"""
-        allSms = mqtt_publisher.track_gammu_operation("retrieveAllSms", retrieveAllSms, machine)
+        allSms = mqtt_publisher.track_gammu_operation(
+            "retrieveAllSms", retrieveAllSms, machine
+        )
         sms = {"Date": "", "Number": "", "State": "", "Text": ""}
         if len(allSms) > 0:
             sms = allSms[0]
@@ -520,53 +654,62 @@ class GetSms(Resource):
                 mqtt_publisher.publish_sms_received(sms)
         return sms
 
-@ns_sms.route('/deleteall')
-@ns_sms.doc('delete_all_sms')
+
+@ns_sms.route("/deleteall")
+@ns_sms.doc("delete_all_sms")
 class DeleteAllSms(Resource):
-    @ns_sms.doc('delete_all_messages')
-    @ns_sms.doc(security='basicAuth')
+    @ns_sms.doc("delete_all_messages")
+    @ns_sms.doc(security="basicAuth")
     @auth.login_required
     def delete(self):
         """Delete all SMS messages from SIM/device memory"""
-        allSms = mqtt_publisher.track_gammu_operation("retrieveAllSms", retrieveAllSms, machine)
+        allSms = mqtt_publisher.track_gammu_operation(
+            "retrieveAllSms", retrieveAllSms, machine
+        )
         count = len(allSms)
         for sms in allSms:
             mqtt_publisher.track_gammu_operation("deleteSms", deleteSms, machine, sms)
         return {"status": 200, "message": f"Deleted {count} SMS messages"}, 200
 
-@ns_status.route('/signal')
-@ns_status.doc('get_signal_quality')
+
+@ns_status.route("/signal")
+@ns_status.doc("get_signal_quality")
 class Signal(Resource):
-    @ns_status.doc('signal_strength')
+    @ns_status.doc("signal_strength")
     @ns_status.marshal_with(signal_response)
     def get(self):
         """Get GSM signal strength and quality"""
-        signal_data = mqtt_publisher.track_gammu_operation("GetSignalQuality", machine.GetSignalQuality)
+        signal_data = mqtt_publisher.track_gammu_operation(
+            "GetSignalQuality", machine.GetSignalQuality
+        )
         # Publish to MQTT if enabled
         mqtt_publisher.publish_signal_strength(signal_data)
         return signal_data
 
-@ns_status.route('/network')
-@ns_status.doc('get_network_info')
+
+@ns_status.route("/network")
+@ns_status.doc("get_network_info")
 class Network(Resource):
-    @ns_status.doc('network_information')
+    @ns_status.doc("network_information")
     @ns_status.marshal_with(network_response)
     def get(self):
         """Get network operator and registration information"""
-        network = mqtt_publisher.track_gammu_operation("GetNetworkInfo", machine.GetNetworkInfo)
+        network = mqtt_publisher.track_gammu_operation(
+            "GetNetworkInfo", machine.GetNetworkInfo
+        )
         network_code = network.get("NetworkCode", "")
         network_name = network.get("NetworkName")
-        
+
         # Try multiple lookup methods if name is empty (Gammu bug: https://github.com/gammu/python-gammu/issues/31)
         if not network_name and network_code:
             # First try our comprehensive database
             network_name = get_network_name(network_code)
             # Fallback to Gammu's database
             if not network_name:
-                network_name = GSMNetworks.get(network_code, 'Unknown')
-        
-        network["NetworkName"] = network_name or 'Unknown'
-        
+                network_name = GSMNetworks.get(network_code, "Unknown")
+
+        network["NetworkName"] = network_name or "Unknown"
+
         # Map Gammu's state to human-readable format
         state = network.get("State", "Unknown")
         state_map = {
@@ -578,27 +721,36 @@ class Network(Resource):
             "Unknown": "Unknown",
         }
         network["State"] = state_map.get(state, state)
-        
+
         # Publish to MQTT if enabled
         mqtt_publisher.publish_network_info(network)
         return network
 
-@ns_status.route('/modem')
-@ns_status.doc('get_modem_info')
+
+@ns_status.route("/modem")
+@ns_status.doc("get_modem_info")
 class ModemInfo(Resource):
-    @ns_status.doc('modem_information')
+    @ns_status.doc("modem_information")
     @ns_status.marshal_with(modem_info_response)
     def get(self):
         """Get modem hardware information (IMEI, manufacturer, model, firmware)"""
         try:
             modem_info = {
-                "IMEI": mqtt_publisher.track_gammu_operation("GetIMEI", machine.GetIMEI),
-                "Manufacturer": mqtt_publisher.track_gammu_operation("GetManufacturer", machine.GetManufacturer),
-                "Model": mqtt_publisher.track_gammu_operation("GetModel", machine.GetModel)
+                "IMEI": mqtt_publisher.track_gammu_operation(
+                    "GetIMEI", machine.GetIMEI
+                ),
+                "Manufacturer": mqtt_publisher.track_gammu_operation(
+                    "GetManufacturer", machine.GetManufacturer
+                ),
+                "Model": mqtt_publisher.track_gammu_operation(
+                    "GetModel", machine.GetModel
+                ),
             }
             try:
                 # Firmware can fail on some modems
-                modem_info["Firmware"] = mqtt_publisher.track_gammu_operation("GetFirmware", machine.GetFirmware)[0]
+                modem_info["Firmware"] = mqtt_publisher.track_gammu_operation(
+                    "GetFirmware", machine.GetFirmware
+                )[0]
             except:
                 modem_info["Firmware"] = "Unknown"
 
@@ -608,16 +760,19 @@ class ModemInfo(Resource):
         except Exception as e:
             api.abort(500, f"Failed to get modem info: {str(e)}")
 
-@ns_status.route('/sim')
-@ns_status.doc('get_sim_info')
+
+@ns_status.route("/sim")
+@ns_status.doc("get_sim_info")
 class SimInfo(Resource):
-    @ns_status.doc('sim_information')
+    @ns_status.doc("sim_information")
     @ns_status.marshal_with(sim_info_response)
     def get(self):
         """Get SIM card information (IMSI)"""
         try:
             sim_info = {
-                "IMSI": mqtt_publisher.track_gammu_operation("GetSIMIMSI", machine.GetSIMIMSI)
+                "IMSI": mqtt_publisher.track_gammu_operation(
+                    "GetSIMIMSI", machine.GetSIMIMSI
+                )
             }
             # Publish to MQTT if enabled
             mqtt_publisher.publish_sim_info(sim_info)
@@ -625,66 +780,79 @@ class SimInfo(Resource):
         except Exception as e:
             api.abort(500, f"Failed to get SIM info: {str(e)}")
 
-@ns_status.route('/sms_capacity')
-@ns_status.doc('get_sms_capacity')
+
+@ns_status.route("/sms_capacity")
+@ns_status.doc("get_sms_capacity")
 class SmsCapacity(Resource):
-    @ns_status.doc('sms_storage_capacity')
+    @ns_status.doc("sms_storage_capacity")
     @ns_status.marshal_with(sms_capacity_response)
     def get(self):
         """Get SMS storage capacity and usage"""
         try:
-            capacity = mqtt_publisher.track_gammu_operation("GetSMSStatus", machine.GetSMSStatus)
+            capacity = mqtt_publisher.track_gammu_operation(
+                "GetSMSStatus", machine.GetSMSStatus
+            )
             # Publish to MQTT if enabled
             mqtt_publisher.publish_sms_capacity(capacity)
             return capacity
         except Exception as e:
             api.abort(500, f"Failed to get SMS capacity: {str(e)}")
 
-@ns_status.route('/reset')
-@ns_status.doc('reset_modem')
+
+@ns_status.route("/reset")
+@ns_status.doc("reset_modem")
 class Reset(Resource):
-    @ns_status.doc('modem_reset')
+    @ns_status.doc("modem_reset")
     @ns_status.marshal_with(reset_response)
     def get(self):
         """Reset GSM modem (useful for stuck connections)"""
         mqtt_publisher.track_gammu_operation("Reset", machine.Reset, False)
         return {"status": 200, "message": "Reset done"}, 200
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     print(f"🚀 SMS Gammu Gateway v{VERSION} started successfully!")
     print(f"📱 Device: {device_path}")
     print(f"🌐 API available on port {port}")
     print(f"🏠 Web UI: http://localhost:{port}/")
     print(f"🔒 SSL: {'Enabled' if ssl else 'Disabled'}")
-    
+
     # MQTT info
-    if config.get('mqtt_enabled', False):
-        print(f"📡 MQTT: Enabled -> {config.get('mqtt_host')}:{config.get('mqtt_port')}")
-        
+    if config.get("mqtt_enabled", False):
+        print(
+            f"📡 MQTT: Enabled -> {config.get('mqtt_host')}:{config.get('mqtt_port')}"
+        )
+
         # Wait a moment for MQTT connection, then publish initial states
         import time
+
         time.sleep(2)
         mqtt_publisher.publish_initial_states_with_machine(machine)
-        
+
         # Start periodic MQTT publishing
         mqtt_publisher.publish_status_periodic(machine, interval=300)  # 5 minutes
-        
+
         # Start SMS monitoring if enabled
-        if config.get('sms_monitoring_enabled', True):
-            check_interval = config.get('sms_check_interval', 60)
+        if config.get("sms_monitoring_enabled", True):
+            check_interval = config.get("sms_check_interval", 60)
             mqtt_publisher.start_sms_monitoring(machine, check_interval=check_interval)
             print(f"📱 SMS Monitoring: Enabled (check every {check_interval}s)")
         else:
             print(f"📱 SMS Monitoring: Disabled")
     else:
         print(f"📡 MQTT: Disabled")
-    
+
     print(f"✅ Ready to send/receive SMS messages")
 
     try:
         if ssl:
-            app.run(port=port, host="0.0.0.0", ssl_context=('/ssl/cert.pem', '/ssl/key.pem'),
-                    debug=False, use_reloader=False)
+            app.run(
+                port=port,
+                host="0.0.0.0",
+                ssl_context=("/ssl/cert.pem", "/ssl/key.pem"),
+                debug=False,
+                use_reloader=False,
+            )
         else:
             app.run(port=port, host="0.0.0.0", debug=False, use_reloader=False)
     finally:

--- a/addon-test-pavelve/support.py
+++ b/addon-test-pavelve/support.py
@@ -6,12 +6,13 @@ Based on: https://github.com/pajikos/sms-gammu-gateway
 Licensed under Apache License 2.0
 """
 
-import sys
 import os
+import sys
+
 import gammu
 
 
-def init_state_machine(pin, device_path='/dev/ttyUSB0'):
+def init_state_machine(pin, device_path="/dev/ttyUSB0"):
     """Initialize gammu state machine with HA add-on config"""
     sm = gammu.StateMachine()
 
@@ -23,46 +24,47 @@ commtimeout = 10
 """
 
     # Write config to temporary file
-    config_file = '/tmp/gammu.config'
-    with open(config_file, 'w') as f:
+    config_file = "/tmp/gammu.config"
+    with open(config_file, "w") as f:
         f.write(config_content)
 
     sm.ReadConfig(Filename=config_file)
-    
+
     try:
         sm.Init()
         print(f"Successfully initialized gammu with device: {device_path}")
-        
+
         # Try to check security status
         try:
             security_status = sm.GetSecurityStatus()
             print(f"SIM security status: {security_status}")
-            
-            if security_status == 'PIN':
-                if pin is None or pin == '':
+
+            if security_status == "PIN":
+                if pin is None or pin == "":
                     print("PIN is required but not provided.")
                     sys.exit(1)
                 else:
-                    sm.EnterSecurityCode('PIN', pin)
+                    sm.EnterSecurityCode("PIN", pin)
                     print("PIN entered successfully")
-                    
+
         except Exception as e:
             print(f"Warning: Could not check SIM security status: {e}")
-            
+
     except gammu.ERR_NOSIM:
         print("Warning: SIM card not accessible, but device is connected")
     except Exception as e:
         print(f"Error initializing device: {e}")
         print("Available devices:")
         import os
+
         try:
-            devices = [d for d in os.listdir('/dev/') if d.startswith('tty')]
+            devices = [d for d in os.listdir("/dev/") if d.startswith("tty")]
             for device in sorted(devices):
                 print(f"  /dev/{device}")
         except:
             pass
         raise
-        
+
     return sm
 
 
@@ -70,7 +72,9 @@ def retrieveAllSms(machine):
     """Retrieve all SMS messages from SIM/device memory"""
     try:
         status = machine.GetSMSStatus()
-        allMultiPartSmsCount = status['SIMUsed'] + status['PhoneUsed'] + status['TemplatesUsed']
+        allMultiPartSmsCount = (
+            status["SIMUsed"] + status["PhoneUsed"] + status["TemplatesUsed"]
+        )
 
         allMultiPartSms = []
         start = True
@@ -80,7 +84,9 @@ def retrieveAllSms(machine):
                 currentMultiPartSms = machine.GetNextSMS(Start=True, Folder=0)
                 start = False
             else:
-                currentMultiPartSms = machine.GetNextSMS(Location=currentMultiPartSms[0]['Location'], Folder=0)
+                currentMultiPartSms = machine.GetNextSMS(
+                    Location=currentMultiPartSms[0]["Location"], Folder=0
+                )
             allMultiPartSms.append(currentMultiPartSms)
 
         allSms = gammu.LinkSMS(allMultiPartSms)
@@ -90,10 +96,10 @@ def retrieveAllSms(machine):
             smsPart = sms[0]
 
             result = {
-                "Date": str(smsPart['DateTime']),
-                "Number": smsPart['Number'],
-                "State": smsPart['State'],
-                "Locations": [smsPart['Location'] for smsPart in sms],
+                "Date": str(smsPart["DateTime"]),
+                "Number": smsPart["Number"],
+                "State": smsPart["State"],
+                "Locations": [smsPart["Location"] for smsPart in sms],
             }
 
             # Try to decode SMS - this may fail for MMS notifications or corrupted messages
@@ -101,41 +107,47 @@ def retrieveAllSms(machine):
                 decodedSms = gammu.DecodeSMS(sms)
                 if decodedSms == None:
                     # DecodeSMS returned None - use raw text from SMS part
-                    result["Text"] = smsPart.get('Text', '')
+                    result["Text"] = smsPart.get("Text", "")
                 else:
                     # Successfully decoded - concatenate all text entries
                     text = ""
-                    for entry in decodedSms['Entries']:
-                        if entry.get('Buffer') is not None:
-                            text += entry['Buffer']
-                    result["Text"] = text if text else smsPart.get('Text', '')
+                    for entry in decodedSms["Entries"]:
+                        if entry.get("Buffer") is not None:
+                            text += entry["Buffer"]
+                    result["Text"] = text if text else smsPart.get("Text", "")
 
             except UnicodeDecodeError as e:
                 # MMS notification or binary message that can't be decoded as UTF-8
-                print(f"Warning: Cannot decode SMS as UTF-8 (probably MMS notification): {e}")
+                print(
+                    f"Warning: Cannot decode SMS as UTF-8 (probably MMS notification): {e}"
+                )
                 # Try to get raw text, but handle potential binary data safely
                 try:
-                    raw_text = smsPart.get('Text', '')
+                    raw_text = smsPart.get("Text", "")
                     # If Text is bytes, try to decode with error handling
                     if isinstance(raw_text, bytes):
-                        result["Text"] = raw_text.decode('utf-8', errors='replace')
+                        result["Text"] = raw_text.decode("utf-8", errors="replace")
                     else:
-                        result["Text"] = str(raw_text) if raw_text else '[MMS or binary message]'
+                        result["Text"] = (
+                            str(raw_text) if raw_text else "[MMS or binary message]"
+                        )
                 except Exception:
-                    result["Text"] = '[MMS or binary message - cannot display]'
+                    result["Text"] = "[MMS or binary message - cannot display]"
 
             except Exception as e:
                 # Any other decoding error (corrupted SMS, unknown format, etc.)
                 print(f"Warning: Error decoding SMS: {e}")
                 # Fallback to raw text with safe handling
                 try:
-                    raw_text = smsPart.get('Text', '')
+                    raw_text = smsPart.get("Text", "")
                     if isinstance(raw_text, bytes):
-                        result["Text"] = raw_text.decode('utf-8', errors='replace')
+                        result["Text"] = raw_text.decode("utf-8", errors="replace")
                     else:
-                        result["Text"] = str(raw_text) if raw_text else '[Decoding error]'
+                        result["Text"] = (
+                            str(raw_text) if raw_text else "[Decoding error]"
+                        )
                 except Exception:
-                    result["Text"] = '[Message decoding failed]'
+                    result["Text"] = "[Message decoding failed]"
 
             results.append(result)
 
@@ -149,7 +161,12 @@ def retrieveAllSms(machine):
 def deleteSms(machine, sms):
     """Delete SMS by location"""
     try:
-        list(map(lambda location: machine.DeleteSMS(Folder=0, Location=location), sms["Locations"]))
+        list(
+            map(
+                lambda location: machine.DeleteSMS(Folder=0, Location=location),
+                sms["Locations"],
+            )
+        )
     except Exception as e:
         print(f"Error deleting SMS: {e}")
 

--- a/addon-test-version/rootfs/usr/bin/gsm_sms_service.py
+++ b/addon-test-version/rootfs/usr/bin/gsm_sms_service.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env python3
 """Standalone GSM SMS service for Home Assistant addon."""
 
+from datetime import datetime
 import json
 import logging
 import os
 import sys
 import time
-from datetime import datetime
 
 import gammu
 import requests
@@ -24,8 +24,8 @@ log_level = LOG_LEVELS.get(log_level_str, logging.INFO)
 
 logging.basicConfig(
     level=log_level,
-    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
-    handlers=[logging.StreamHandler(sys.stdout)]
+    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    handlers=[logging.StreamHandler(sys.stdout)],
 )
 
 _LOGGER = logging.getLogger("gsm_sms_service")
@@ -40,7 +40,7 @@ class GSMSMSService:
         self.device = os.environ.get("DEVICE", "/dev/ttyUSB0")
         self.baud_speed = os.environ.get("BAUD_SPEED", "0")
         self.scan_interval = int(os.environ.get("SCAN_INTERVAL", "30"))
-        
+
         # Home Assistant API
         self.ha_url = os.environ.get("SUPERVISOR_API", "http://supervisor/core")
         self.ha_token = os.environ.get("SUPERVISOR_TOKEN", "")
@@ -48,7 +48,7 @@ class GSMSMSService:
             "Authorization": f"Bearer {self.ha_token}",
             "Content-Type": "application/json",
         }
-        
+
         # State
         self.sm = None
         self.connected = False
@@ -56,7 +56,7 @@ class GSMSMSService:
         self.network_name = None
         self.device_manufacturer = None
         self.device_model = None
-        
+
         _LOGGER.info(f"Initialized with device: {self.device}, baud: {self.baud_speed}")
 
     def connect(self):
@@ -65,42 +65,46 @@ class GSMSMSService:
             # First, try to open the device file directly to test permissions
             _LOGGER.info(f"Testing direct access to {self.device}...")
             try:
-                with open(self.device, 'rb') as f:
+                with open(self.device, "rb") as f:
                     _LOGGER.info(f"Successfully opened device file for reading")
-                with open(self.device, 'wb') as f:
+                with open(self.device, "wb") as f:
                     _LOGGER.info(f"Successfully opened device file for writing")
             except Exception as e:
                 _LOGGER.error(f"Cannot access device file directly: {e}")
-                _LOGGER.error(f"This indicates a permissions/security issue at the container level")
+                _LOGGER.error(
+                    f"This indicates a permissions/security issue at the container level"
+                )
                 raise
-            
+
             self.sm = gammu.StateMachine()
-            
+
             # Configure connection
             connection_mode = "at"
             if self.baud_speed != "0":
                 connection_mode += self.baud_speed
-            
+
             config = {
                 "Device": self.device,
                 "Connection": connection_mode,
             }
-            
+
             _LOGGER.info(f"Connecting to modem with config: {config}")
             self.sm.SetConfig(0, config)
             self.sm.Init()
-            
+
             # Get device info
             try:
                 self.device_manufacturer = self.sm.GetManufacturer()
                 self.device_model = self.sm.GetModel()[0]
-                _LOGGER.info(f"Connected to {self.device_manufacturer} {self.device_model}")
+                _LOGGER.info(
+                    f"Connected to {self.device_manufacturer} {self.device_model}"
+                )
             except Exception as e:
                 _LOGGER.warning(f"Could not get device info: {e}")
-            
+
             self.connected = True
             return True
-            
+
         except Exception as e:
             _LOGGER.error(f"Failed to connect to modem: {e}")
             self.connected = False
@@ -110,7 +114,7 @@ class GSMSMSService:
         """Update signal strength."""
         if not self.connected or not self.sm:
             return
-        
+
         try:
             signal = self.sm.GetSignalQuality()
             self.signal_strength = signal.get("SignalPercent", -1)
@@ -123,7 +127,7 @@ class GSMSMSService:
         """Update network information."""
         if not self.connected or not self.sm:
             return
-        
+
         try:
             network = self.sm.GetNetworkInfo()
             self.network_name = network.get("NetworkName", "Unknown")
@@ -136,23 +140,23 @@ class GSMSMSService:
         """Check for new SMS messages."""
         if not self.connected or not self.sm:
             return
-        
+
         try:
             # Get SMS status
             status = self.sm.GetSMSStatus()
             total_messages = status.get("SIMUsed", 0) + status.get("PhoneUsed", 0)
-            
+
             if total_messages == 0:
                 _LOGGER.debug("No messages to read")
                 return
-            
+
             _LOGGER.info(f"Found {total_messages} messages to read")
-            
+
             # Read all messages
             messages = []
             sms = None
             start = True
-            
+
             while True:
                 try:
                     if start:
@@ -162,31 +166,31 @@ class GSMSMSService:
                         if sms is None:
                             break
                         sms = self.sm.GetNextSMS(Folder=0, Location=sms[0]["Location"])
-                    
+
                     messages.append(sms)
-                    
+
                     # Delete the message
                     try:
                         self.sm.DeleteSMS(Folder=0, Location=sms[0]["Location"])
                     except Exception as e:
                         _LOGGER.warning(f"Could not delete message: {e}")
-                        
+
                 except gammu.ERR_EMPTY:
                     break
                 except Exception as e:
                     _LOGGER.error(f"Error reading messages: {e}")
                     break
-            
+
             # Process messages
             for msg_parts in messages:
                 try:
                     # Link multipart messages
                     linked = gammu.LinkSMS([msg_parts])
-                    
+
                     for msg in linked:
                         decoded = gammu.DecodeSMS(msg)
                         sms_info = msg[0]
-                        
+
                         # Extract text
                         if decoded is None:
                             text = sms_info.get("Text", "")
@@ -196,20 +200,22 @@ class GSMSMSService:
                                 for entry in decoded.get("Entries", [])
                                 if entry.get("Buffer")
                             )
-                        
+
                         # Fire event to Home Assistant
                         event_data = {
                             "phone": sms_info.get("Number", "Unknown"),
                             "date": str(sms_info.get("DateTime", datetime.now())),
                             "text": text,
                         }
-                        
-                        _LOGGER.info(f"Received SMS from {event_data['phone']}: {event_data['text']}")
+
+                        _LOGGER.info(
+                            f"Received SMS from {event_data['phone']}: {event_data['text']}"
+                        )
                         self.fire_event("legacy_gsm_sms.incoming_sms", event_data)
-                        
+
                 except Exception as e:
                     _LOGGER.error(f"Error processing message: {e}")
-                    
+
         except Exception as e:
             _LOGGER.error(f"Error checking messages: {e}")
 
@@ -217,13 +223,17 @@ class GSMSMSService:
         """Fire an event to Home Assistant."""
         try:
             url = f"{self.ha_url}/api/events/{event_type}"
-            response = requests.post(url, headers=self.headers, json=event_data, timeout=10)
-            
+            response = requests.post(
+                url, headers=self.headers, json=event_data, timeout=10
+            )
+
             if response.status_code == 200:
                 _LOGGER.debug(f"Event fired successfully: {event_type}")
             else:
-                _LOGGER.error(f"Failed to fire event: {response.status_code} - {response.text}")
-                
+                _LOGGER.error(
+                    f"Failed to fire event: {response.status_code} - {response.text}"
+                )
+
         except Exception as e:
             _LOGGER.error(f"Error firing event: {e}")
 
@@ -231,24 +241,28 @@ class GSMSMSService:
         """Update sensor states in Home Assistant."""
         if not self.connected:
             return
-        
+
         sensors = {
             "sensor.gsm_signal_strength": {
-                "state": self.signal_strength if self.signal_strength is not None else "unknown",
+                "state": (
+                    self.signal_strength
+                    if self.signal_strength is not None
+                    else "unknown"
+                ),
                 "attributes": {
                     "unit_of_measurement": "%",
                     "device_class": "signal_strength",
                     "friendly_name": "GSM Signal Strength",
-                }
+                },
             },
             "sensor.gsm_network": {
                 "state": self.network_name if self.network_name else "unknown",
                 "attributes": {
                     "friendly_name": "GSM Network",
-                }
+                },
             },
         }
-        
+
         for entity_id, data in sensors.items():
             try:
                 url = f"{self.ha_url}/api/states/{entity_id}"
@@ -256,54 +270,60 @@ class GSMSMSService:
                     "state": data["state"],
                     "attributes": data["attributes"],
                 }
-                response = requests.post(url, headers=self.headers, json=payload, timeout=10)
-                
+                response = requests.post(
+                    url, headers=self.headers, json=payload, timeout=10
+                )
+
                 if response.status_code in [200, 201]:
                     _LOGGER.debug(f"Updated {entity_id}")
                 else:
-                    _LOGGER.warning(f"Failed to update {entity_id}: {response.status_code}")
-                    
+                    _LOGGER.warning(
+                        f"Failed to update {entity_id}: {response.status_code}"
+                    )
+
             except Exception as e:
                 _LOGGER.error(f"Error updating sensor {entity_id}: {e}")
 
     def run(self):
         """Run the main service loop."""
         _LOGGER.info("GSM SMS Service starting...")
-        
+
         # Try to connect
         retry_count = 0
         max_retries = 5
-        
+
         while retry_count < max_retries and not self.connected:
             if self.connect():
                 break
-            
+
             retry_count += 1
-            _LOGGER.warning(f"Connection attempt {retry_count}/{max_retries} failed, retrying in 10 seconds...")
+            _LOGGER.warning(
+                f"Connection attempt {retry_count}/{max_retries} failed, retrying in 10 seconds..."
+            )
             time.sleep(10)
-        
+
         if not self.connected:
             _LOGGER.error("Failed to connect to modem after all retries. Exiting.")
             sys.exit(1)
-        
+
         _LOGGER.info("GSM SMS Service running!")
-        
+
         # Main loop
         while True:
             try:
                 # Update modem info
                 self.update_signal_strength()
                 self.update_network_info()
-                
+
                 # Check for messages
                 self.check_messages()
-                
+
                 # Update Home Assistant sensors
                 self.update_sensors()
-                
+
                 # Wait for next scan
                 time.sleep(self.scan_interval)
-                
+
             except KeyboardInterrupt:
                 _LOGGER.info("Shutting down...")
                 break

--- a/addon-test-version/rootfs/usr/bin/gsm_sms_service_pyserial.py
+++ b/addon-test-version/rootfs/usr/bin/gsm_sms_service_pyserial.py
@@ -7,16 +7,16 @@ issue. SMS reception will need to be implemented via unsolicited +CMTI
 notifications in a future update. SMS sending functionality works fine.
 """
 
+from datetime import datetime
 import json
 import logging
 import os
 import sys
+from threading import Lock, Thread
 import time
-from datetime import datetime
-from threading import Thread, Lock
 
-import serial  # type: ignore[import-not-found]
 import requests
+import serial  # type: ignore[import-not-found]
 
 # Configure logging
 LOG_LEVELS = {
@@ -31,8 +31,8 @@ log_level = LOG_LEVELS.get(log_level_str, logging.INFO)
 
 logging.basicConfig(
     level=log_level,
-    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
-    handlers=[logging.StreamHandler(sys.stdout)]
+    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    handlers=[logging.StreamHandler(sys.stdout)],
 )
 
 _LOGGER = logging.getLogger("gsm_sms_service")
@@ -48,7 +48,7 @@ GSM7_ALPHABET = (
 
 class GSMModem:
     """Handle GSM modem communication via serial port."""
-    
+
     def __init__(self, device, baudrate=115200):
         """Initialize modem connection."""
         self.device = device
@@ -61,11 +61,11 @@ class GSMModem:
         self.prompt_received = False
         self.response_lines = []
         self.sms_list = []
-        self.last_sms_text = b''
+        self.last_sms_text = b""
         self.recording_sms = False
-        
+
         _LOGGER.info(f"GSM Modem initialized for device: {device}")
-    
+
     def open(self):
         """Open serial connection to modem."""
         try:
@@ -80,14 +80,14 @@ class GSMModem:
             self.serial.rtscts = False
             self.serial.dsrdtr = False
             self.serial.timeout = 1
-            
+
             self.serial.open()
-            
+
             if self.serial.is_open:
                 self.opened = True
                 self.serial.flush()
                 _LOGGER.info(f"Device opened successfully on {self.device}")
-                
+
                 # Start read thread
                 self.read_thread = Thread(target=self._read_loop, daemon=True)
                 self.read_thread.start()
@@ -95,130 +95,128 @@ class GSMModem:
             else:
                 _LOGGER.error(f"Device failed to open: {self.device}")
                 return False
-                
+
         except Exception as e:
             _LOGGER.error(f"Exception opening device {self.device}: {e}")
             return False
-    
+
     def close(self):
         """Close serial connection."""
         if self.serial and self.serial.is_open:
             _LOGGER.info("Closing GSM device")
             self.serial.close()
             self.opened = False
-    
+
     def _read_loop(self):
         """Background thread to read from serial port."""
-        frame = b''
-        
+        frame = b""
+
         while self.opened and self.serial and self.serial.is_open:
             try:
                 if self.serial.in_waiting >= 1:
                     data = self.serial.read(1)
                     frame += data
-                    
+
                     # Check for prompt (> )
-                    if b'> ' in frame:
+                    if b"> " in frame:
                         self.ok_received = True
                         self.prompt_received = True
-                        frame = b''
-                    
+                        frame = b""
+
                     # Check for line ending
-                    elif b'\r\n' in frame:
-                        line = frame.decode('ascii', errors='ignore').strip()
-                        
-                        if 'OK' in line:
+                    elif b"\r\n" in frame:
+                        line = frame.decode("ascii", errors="ignore").strip()
+
+                        if "OK" in line:
                             self.ok_received = True
                             if self.recording_sms:
                                 # Remove trailing CRLF from SMS text
-                                if self.last_sms_text.endswith(b'\r\n\r\n'):
+                                if self.last_sms_text.endswith(b"\r\n\r\n"):
                                     self.last_sms_text = self.last_sms_text[:-4]
                                 self.recording_sms = False
-                        
-                        elif '+CMGL:' in line:
+
+                        elif "+CMGL:" in line:
                             # SMS list entry
-                            parts = line.split(',')
+                            parts = line.split(",")
                             if len(parts) >= 3:
-                                msg_id = parts[0].split(':')[1].strip()
+                                msg_id = parts[0].split(":")[1].strip()
                                 status = parts[1].strip().strip('"')
                                 number = parts[2].strip().strip('"')
-                                self.sms_list.append({
-                                    'Id': msg_id,
-                                    'Number': number,
-                                    'Status': status
-                                })
-                        
-                        elif '+CMGR:' in line:
+                                self.sms_list.append(
+                                    {"Id": msg_id, "Number": number, "Status": status}
+                                )
+
+                        elif "+CMGR:" in line:
                             # Start recording SMS text
                             self.recording_sms = True
-                            self.last_sms_text = b''
-                        
-                        elif '+CME ERROR:' in line or 'ERROR' in line:
+                            self.last_sms_text = b""
+
+                        elif "+CME ERROR:" in line or "ERROR" in line:
                             _LOGGER.debug(f"Modem error: {line}")
                             self.ok_received = True
-                        
+
                         elif self.recording_sms:
                             # This is SMS text content
                             self.last_sms_text += frame
-                        
-                        frame = b''
-                
+
+                        frame = b""
+
                 else:
                     time.sleep(0.001)
-                    
+
             except Exception as e:
                 _LOGGER.error(f"Error in read loop: {e}")
                 time.sleep(0.1)
-    
+
     def write_command(self, command, timeout=5):
         """Write AT command and wait for OK."""
         if not self.opened or not self.serial:
             return False
-        
+
         self.ok_received = False
-        cmd = command.encode('ascii') + b'\r'
-        
+        cmd = command.encode("ascii") + b"\r"
+
         _LOGGER.debug(f"Sending: {command}")
         try:
             self.serial.write(cmd)
         except Exception as e:
             _LOGGER.error(f"Failed to write command: {e}")
             return False
-        
+
         # Wait for OK response
         start = time.time()
         while not self.ok_received and (time.time() - start) < timeout:
             time.sleep(0.01)
-        
+
         if not self.ok_received:
             _LOGGER.warning(f"Command timeout: {command}")
-        
+
         return self.ok_received
-    
+
     def write_data(self, data):
         """Write raw data to serial port."""
         if self.opened and self.serial:
             self.serial.write(data)
-    
+
     def init_modem(self):
         """Initialize modem with AT commands."""
         _LOGGER.info("Initializing GSM modem...")
-        
+
         # Basic commands only - don't configure SMS storage which might hang
         commands = [
             ("ATZ", "Reset modem", 3),
             ("ATE0", "Disable echo", 2),
             ("AT+CMGF=1", "Set SMS text mode", 2),
         ]
-        
+
         for cmd, desc, timeout in commands:
             _LOGGER.debug(f"{desc}: {cmd}")
             if not self.write_command(cmd, timeout=timeout):
                 _LOGGER.warning(f"Command may have failed: {cmd}")
             time.sleep(0.2)
-        
+
         _LOGGER.info("Modem initialization complete")
-    
+
     def get_signal_strength(self):
         """Get signal strength."""
         try:
@@ -227,50 +225,50 @@ class GSMModem:
         except Exception as e:
             _LOGGER.debug(f"Error getting signal strength: {e}")
         return None
-    
+
     def send_sms(self, number, message):
         """Send SMS message."""
         _LOGGER.info(f"Sending SMS to {number}")
-        
+
         # Set up send command
         self.prompt_received = False
         if not self.write_command(f'AT+CMGS="{number}"'):
             _LOGGER.error("Failed to start SMS send")
             return False
-        
+
         # Wait for prompt
         timeout = 10
         start = time.time()
         while not self.prompt_received and (time.time() - start) < timeout:
             time.sleep(0.01)
-        
+
         if not self.prompt_received:
             _LOGGER.error("Did not receive prompt for SMS text")
             return False
-        
+
         # Send message text with Ctrl-Z terminator
         _LOGGER.debug(f"Sending message text: {message}")
-        message_data = message.encode('ascii', errors='ignore') + b'\x1A'
+        message_data = message.encode("ascii", errors="ignore") + b"\x1a"
         self.write_data(message_data)
-        
+
         # Wait for OK
         timeout = 30
         start = time.time()
         self.ok_received = False
         while not self.ok_received and (time.time() - start) < timeout:
             time.sleep(0.01)
-        
+
         if self.ok_received:
             _LOGGER.info("SMS sent successfully")
             return True
         else:
             _LOGGER.error("SMS send timeout")
             return False
-    
+
     def read_sms(self):
         """Read all SMS messages - simplified to avoid modem hangs."""
         _LOGGER.debug("Checking for SMS messages")
-        
+
         # Skip SMS reading for now to prevent modem crashes
         # This is a known issue with some modems where AT+CMGL hangs
         # We'll implement SMS reception via unsolicited +CMTI notifications instead
@@ -279,7 +277,7 @@ class GSMModem:
 
 class GSMSMSService:
     """Service that manages GSM SMS operations and Home Assistant integration."""
-    
+
     def __init__(self, device_path, baud_speed=115200, scan_interval=30):
         """Initialize the GSM SMS service."""
         self.device_path = device_path
@@ -289,45 +287,50 @@ class GSMSMSService:
         self.modem = None
         self.connected = False
         self.signal_strength = None
-        
+
         # Home Assistant API configuration
         self.ha_url = "http://supervisor/core/api"
-        self.ha_token = os.environ.get('SUPERVISOR_TOKEN', '')
+        self.ha_token = os.environ.get("SUPERVISOR_TOKEN", "")
         self.ha_headers = {
-            'Authorization': f'Bearer {self.ha_token}',
-            'Content-Type': 'application/json'
+            "Authorization": f"Bearer {self.ha_token}",
+            "Content-Type": "application/json",
         }
         self.headers = self.ha_headers  # Alias for compatibility
-        
+
         # Service registration status
         self.service_registered = False
-        
-        _LOGGER.info(f"Initialized with device: {self.device_path}, baud: {self.baud_speed}")
+
+        _LOGGER.info(
+            f"Initialized with device: {self.device_path}, baud: {self.baud_speed}"
+        )
 
     def connect(self):
         """Connect to the GSM modem."""
         try:
             self.modem = GSMModem(self.device, self.baud_speed)
-            
+
             if not self.modem.open():
                 raise Exception("Failed to open modem")
-            
+
             # Initialize modem
             self.modem.init_modem()
-            
+
             # Get signal strength
             self.signal_strength = self.modem.get_signal_strength()
-            
+
             self.connected = True
             _LOGGER.info("Successfully connected to modem")
-            
+
             # Update HA sensor
-            self.update_sensor("connected", {
-                "signal_strength": self.signal_strength,
-            })
-            
+            self.update_sensor(
+                "connected",
+                {
+                    "signal_strength": self.signal_strength,
+                },
+            )
+
             return True
-            
+
         except Exception as e:
             _LOGGER.error(f"Failed to connect to modem: {e}")
             self.connected = False
@@ -348,14 +351,14 @@ class GSMSMSService:
                 "state": state,
                 "attributes": attributes or {},
             }
-            
+
             # Use state API
             url = f"{self.ha_url}/api/states/sensor.gsm_modem_status"
             response = requests.post(url, headers=self.headers, json=data, timeout=5)
-            
+
             if response.status_code not in [200, 201]:
                 _LOGGER.warning(f"Failed to update sensor: {response.status_code}")
-                
+
         except Exception as e:
             _LOGGER.debug(f"Could not update sensor: {e}")
 
@@ -363,11 +366,13 @@ class GSMSMSService:
         """Fire a Home Assistant event."""
         try:
             url = f"{self.ha_url}/api/events/{event_type}"
-            response = requests.post(url, headers=self.headers, json=event_data, timeout=5)
-            
+            response = requests.post(
+                url, headers=self.headers, json=event_data, timeout=5
+            )
+
             if response.status_code not in [200, 201]:
                 _LOGGER.warning(f"Failed to fire event: {response.status_code}")
-                
+
         except Exception as e:
             _LOGGER.debug(f"Could not fire event: {e}")
 
@@ -376,50 +381,59 @@ class GSMSMSService:
         if not self.connected or not self.modem:
             _LOGGER.error("Cannot send SMS - modem not connected")
             return False
-        
+
         try:
             result = self.modem.send_sms(number, message)
             if result:
                 # Fire success event
-                self.fire_event("legacy_gsm_sms_sent", {
-                    "recipient": number,
-                    "message": message,
-                    "timestamp": datetime.now().isoformat(),
-                    "status": "success"
-                })
+                self.fire_event(
+                    "legacy_gsm_sms_sent",
+                    {
+                        "recipient": number,
+                        "message": message,
+                        "timestamp": datetime.now().isoformat(),
+                        "status": "success",
+                    },
+                )
             return result
         except Exception as e:
             _LOGGER.error(f"Error sending SMS: {e}")
-            self.fire_event("legacy_gsm_sms_sent", {
-                "recipient": number,
-                "message": message,
-                "timestamp": datetime.now().isoformat(),
-                "status": "failed",
-                "error": str(e)
-            })
+            self.fire_event(
+                "legacy_gsm_sms_sent",
+                {
+                    "recipient": number,
+                    "message": message,
+                    "timestamp": datetime.now().isoformat(),
+                    "status": "failed",
+                    "error": str(e),
+                },
+            )
             return False
-    
+
     def check_sms(self):
         """Check for new SMS messages."""
         if not self.connected or not self.modem:
             return
-        
+
         try:
             messages = self.modem.read_sms()
-            
+
             for msg in messages:
                 _LOGGER.info(f"Received SMS from {msg['Number']}: {msg['Text']}")
-                
+
                 # Fire event
-                self.fire_event("legacy_gsm_sms_received", {
-                    "sender": msg['Number'],
-                    "message": msg['Text'],
-                    "timestamp": datetime.now().isoformat(),
-                })
-                
+                self.fire_event(
+                    "legacy_gsm_sms_received",
+                    {
+                        "sender": msg["Number"],
+                        "message": msg["Text"],
+                        "timestamp": datetime.now().isoformat(),
+                    },
+                )
+
         except Exception as e:
             _LOGGER.error(f"Error checking SMS: {e}")
-    
+
     def register_service(self):
         """Register the send_sms service with Home Assistant via addon discovery."""
         try:
@@ -427,71 +441,77 @@ class GSMSMSService:
             # This tells HA that we provide a service
             discovery_data = {
                 "addon": "legacy_gsm_sms_test",
-                "config": {
-                    "device": self.device_path
-                },
-                "service": "legacy_gsm_sms.send_sms"
+                "config": {"device": self.device_path},
+                "service": "legacy_gsm_sms.send_sms",
             }
-            
+
             # Create a persistent marker that tells HA about our service
             # HA will expose this as a service that other automations can call
-            _LOGGER.info("Service registration: The addon will handle SMS sending via events")
-            _LOGGER.info("To send SMS, fire a 'legacy_gsm_sms_send' event with 'number' and 'message' data")
-            _LOGGER.info("Example: service: event.fire, data: {event_type: legacy_gsm_sms_send, event_data: {number: '+1234567890', message: 'Hello'}}")
-            
+            _LOGGER.info(
+                "Service registration: The addon will handle SMS sending via events"
+            )
+            _LOGGER.info(
+                "To send SMS, fire a 'legacy_gsm_sms_send' event with 'number' and 'message' data"
+            )
+            _LOGGER.info(
+                "Example: service: event.fire, data: {event_type: legacy_gsm_sms_send, event_data: {number: '+1234567890', message: 'Hello'}}"
+            )
+
             self.service_registered = True
             return True
-                
+
         except Exception as e:
             _LOGGER.error(f"Error in service registration: {e}")
             return False
-    
+
     def check_for_events(self):
         """Check for legacy_gsm_sms_send events from Home Assistant."""
         try:
             # Query recent events from HA
             url = f"{self.ha_url}/events/legacy_gsm_sms_send"
             response = requests.get(url, headers=self.ha_headers, timeout=5)
-            
+
             if response.status_code == 200:
                 events = response.json()
                 for event in events:
-                    event_data = event.get('data', {})
-                    number = event_data.get('number')
-                    message = event_data.get('message')
-                    
+                    event_data = event.get("data", {})
+                    number = event_data.get("number")
+                    message = event_data.get("message")
+
                     if number and message:
                         _LOGGER.info(f"Received event to send SMS to {number}")
                         self.send_sms_message(number, message)
-            
+
         except requests.exceptions.RequestException:
             # Can't connect to HA API, use fallback queue method
             self.check_queue_fallback()
         except Exception as e:
             _LOGGER.debug(f"Error checking events: {e}")
-            
+
     def check_queue_fallback(self):
         """Fallback: Check file-based queue for SMS send requests."""
-        queue_file = '/tmp/gsm_sms_queue.json'
-        
+        queue_file = "/tmp/gsm_sms_queue.json"
+
         try:
             if os.path.exists(queue_file):
-                with open(queue_file, 'r') as f:
+                with open(queue_file, "r") as f:
                     command = json.load(f)
-                
+
                 # Remove the file immediately
                 os.remove(queue_file)
-                
-                if command.get('action') == 'send_sms':
-                    number = command.get('number')
-                    message = command.get('message')
-                    
+
+                if command.get("action") == "send_sms":
+                    number = command.get("number")
+                    message = command.get("message")
+
                     if number and message:
                         _LOGGER.info(f"Processing queued SMS send request to {number}")
                         self.send_sms_message(number, message)
                     else:
-                        _LOGGER.warning("Invalid SMS command - missing number or message")
-                        
+                        _LOGGER.warning(
+                            "Invalid SMS command - missing number or message"
+                        )
+
         except json.JSONDecodeError:
             _LOGGER.error(f"Invalid JSON in queue file")
             try:
@@ -504,50 +524,57 @@ class GSMSMSService:
     def run(self):
         """Run the service main loop."""
         _LOGGER.info("GSM SMS Service starting...")
-        
+
         # Connect with retries
         max_retries = 5
         retry_count = 0
-        
+
         while retry_count < max_retries:
             if self.connect():
                 break
-            
+
             retry_count += 1
             if retry_count < max_retries:
-                _LOGGER.warning(f"Connection attempt {retry_count}/{max_retries} failed, retrying in 10 seconds...")
+                _LOGGER.warning(
+                    f"Connection attempt {retry_count}/{max_retries} failed, retrying in 10 seconds..."
+                )
                 time.sleep(10)
-        
+
         if not self.connected:
             _LOGGER.error("Failed to connect to modem after all retries. Exiting.")
             return
-        
+
         # Main loop
-        _LOGGER.info(f"Entering main loop (scanning every {self.scan_interval} seconds)")
-        
+        _LOGGER.info(
+            f"Entering main loop (scanning every {self.scan_interval} seconds)"
+        )
+
         try:
             last_check = 0
             while True:
                 current_time = time.time()
-                
+
                 # Check for events and queue (fast check every second)
                 self.check_for_events()
-                
+
                 # Check for incoming SMS (slower, based on scan_interval)
                 if current_time - last_check >= self.scan_interval:
                     self.check_sms()
-                    
+
                     # Update sensor
-                    self.update_sensor("connected", {
-                        "signal_strength": self.signal_strength,
-                        "last_check": datetime.now().isoformat(),
-                    })
-                    
+                    self.update_sensor(
+                        "connected",
+                        {
+                            "signal_strength": self.signal_strength,
+                            "last_check": datetime.now().isoformat(),
+                        },
+                    )
+
                     last_check = current_time
-                
+
                 # Sleep briefly
                 time.sleep(1)
-                
+
         except KeyboardInterrupt:
             _LOGGER.info("Service interrupted by user")
         except Exception as e:
@@ -559,10 +586,16 @@ class GSMSMSService:
 if __name__ == "__main__":
     # Get configuration from environment variables
     device = os.environ.get("DEVICE", "/dev/ttyUSB0")
-    baud_speed = int(os.environ.get("BAUD_SPEED", "115200")) if os.environ.get("BAUD_SPEED", "0") != "0" else 115200
+    baud_speed = (
+        int(os.environ.get("BAUD_SPEED", "115200"))
+        if os.environ.get("BAUD_SPEED", "0") != "0"
+        else 115200
+    )
     scan_interval = int(os.environ.get("SCAN_INTERVAL", "30"))
-    
-    _LOGGER.info(f"Starting GSM SMS Service with device={device}, baud={baud_speed}, interval={scan_interval}")
-    
+
+    _LOGGER.info(
+        f"Starting GSM SMS Service with device={device}, baud={baud_speed}, interval={scan_interval}"
+    )
+
     service = GSMSMSService(device, baud_speed, scan_interval)
     service.run()

--- a/addon-test-version/rootfs/usr/bin/send_sms.py
+++ b/addon-test-version/rootfs/usr/bin/send_sms.py
@@ -5,21 +5,18 @@ import argparse
 import json
 import sys
 
+
 def main():
-    parser = argparse.ArgumentParser(description='Send SMS via GSM modem')
-    parser.add_argument('--number', required=True, help='Phone number to send to')
-    parser.add_argument('--message', required=True, help='Message text to send')
+    parser = argparse.ArgumentParser(description="Send SMS via GSM modem")
+    parser.add_argument("--number", required=True, help="Phone number to send to")
+    parser.add_argument("--message", required=True, help="Message text to send")
     args = parser.parse_args()
-    
+
     # Write command to a queue file that the service monitors
-    command = {
-        'action': 'send_sms',
-        'number': args.number,
-        'message': args.message
-    }
-    
+    command = {"action": "send_sms", "number": args.number, "message": args.message}
+
     try:
-        with open('/tmp/gsm_sms_queue.json', 'w') as f:
+        with open("/tmp/gsm_sms_queue.json", "w") as f:
             json.dump(command, f)
         print(f"SMS queued for {args.number}")
         return 0
@@ -27,5 +24,6 @@ def main():
         print(f"Error: {e}", file=sys.stderr)
         return 1
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     sys.exit(main())

--- a/config_flow.py
+++ b/config_flow.py
@@ -6,8 +6,6 @@ import logging
 from typing import Any
 
 import gammu
-import voluptuous as vol
-
 from homeassistant.config_entries import (
     ConfigEntry,
     ConfigFlow,
@@ -18,6 +16,7 @@ from homeassistant.const import CONF_DEVICE
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import selector
+import voluptuous as vol
 
 from .const import (
     CONF_AUTO_DELETE_READ_SMS,

--- a/coordinator.py
+++ b/coordinator.py
@@ -5,7 +5,6 @@ from datetime import timedelta
 import logging
 
 import gammu
-
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import DEFAULT_SCAN_INTERVAL

--- a/custom_components/legacy_gsm_sms/__init__.py
+++ b/custom_components/legacy_gsm_sms/__init__.py
@@ -3,14 +3,13 @@
 import logging
 
 import gammu
-import voluptuous as vol
-
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_DEVICE, CONF_NAME, Platform
 from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import config_validation as cv, discovery
 from homeassistant.helpers.typing import ConfigType
+import voluptuous as vol
 
 from .const import (
     ATTR_FLASH,

--- a/custom_components/legacy_gsm_sms/button.py
+++ b/custom_components/legacy_gsm_sms/button.py
@@ -4,7 +4,6 @@ import logging
 from typing import Optional
 
 import gammu
-
 from homeassistant.components.button import ButtonEntity, ButtonEntityDescription
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
@@ -59,9 +58,7 @@ async def async_setup_entry(
 
     entities = []
     for description in BUTTON_DESCRIPTIONS:
-        entities.append(
-            SMSButton(hass, description, unique_id, gateway, sms_manager)
-        )
+        entities.append(SMSButton(hass, description, unique_id, gateway, sms_manager))
 
     async_add_entities(entities, True)
 
@@ -133,15 +130,19 @@ class SMSButton(ButtonEntity):
         message_state = self._hass.states.get(message_entity_id)
 
         # Check phone number is set and valid
-        if not phone_state or not phone_state.state or phone_state.state in (
-            "unknown", "unavailable", ""
+        if (
+            not phone_state
+            or not phone_state.state
+            or phone_state.state in ("unknown", "unavailable", "")
         ):
             _LOGGER.warning("Phone number not set, cannot send SMS")
             return
 
         # Check message is set and valid
-        if not message_state or not message_state.state or message_state.state in (
-            "unknown", "unavailable", ""
+        if (
+            not message_state
+            or not message_state.state
+            or message_state.state in ("unknown", "unavailable", "")
         ):
             _LOGGER.warning("Message text not set, cannot send SMS")
             return

--- a/custom_components/legacy_gsm_sms/config_flow.py
+++ b/custom_components/legacy_gsm_sms/config_flow.py
@@ -6,8 +6,6 @@ import logging
 from typing import Any
 
 import gammu
-import voluptuous as vol
-
 from homeassistant.config_entries import (
     ConfigEntry,
     ConfigFlow,
@@ -18,6 +16,7 @@ from homeassistant.const import CONF_DEVICE
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import selector
+import voluptuous as vol
 
 from .const import (
     CONF_AUTO_DELETE_READ_SMS,

--- a/custom_components/legacy_gsm_sms/coordinator.py
+++ b/custom_components/legacy_gsm_sms/coordinator.py
@@ -5,7 +5,6 @@ from datetime import timedelta
 import logging
 
 import gammu
-
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import DEFAULT_SCAN_INTERVAL

--- a/custom_components/legacy_gsm_sms/gateway.py
+++ b/custom_components/legacy_gsm_sms/gateway.py
@@ -4,7 +4,6 @@ import logging
 
 import gammu
 from gammu.asyncworker import GammuAsyncWorker
-
 from homeassistant.core import callback
 
 from .const import DOMAIN, SMS_STATE_UNREAD
@@ -179,16 +178,16 @@ class Gateway:
     async def get_signal_quality_async(self):
         """Get the current signal level of the modem."""
         signal_data = await self._worker.get_signal_quality_async()
-        
+
         # Gammu returns already processed values:
         # - SignalStrength: dBm value (already calculated, -1 = unknown)
         # - SignalPercent: percentage 0-100 (-1 = unknown)
         # - BitErrorRate: RXQUAL value 0-7 (99 = unknown)
-        
+
         signal_strength = signal_data.get("SignalStrength", -1)
         signal_percent = signal_data.get("SignalPercent", -1)
         ber = signal_data.get("BitErrorRate", 99)
-        
+
         # Convert -1 to None for unknown values
         if signal_strength == -1:
             signal_strength = None
@@ -197,7 +196,7 @@ class Gateway:
         # BitErrorRate: 99 or -1 means unknown, 0-7 is RXQUAL index
         if ber == 99 or ber == -1 or ber < 0:
             ber = None
-        
+
         return {
             "SignalStrength": signal_strength,
             "SignalPercent": signal_percent,
@@ -207,17 +206,17 @@ class Gateway:
     async def get_network_info_async(self):
         """Get the current network info of the modem."""
         network_info = await self._worker.get_network_info_async()
-        
+
         # Gammu returns: NetworkName, State, NetworkCode, CID, LAC
         raw_network_name = network_info.get("NetworkName")
         network_code = network_info.get("NetworkCode")
-        
+
         # Determine the best network name and code to display
         # Note: Some modems return the NITZ operator name in NetworkCode field
         # instead of the numeric MCC+MNC code
         network_name = raw_network_name
         resolved_code = None
-        
+
         # Check if NetworkCode is numeric (correct) or contains a name (modem quirk)
         if network_code:
             if network_code.isdigit():
@@ -233,21 +232,22 @@ class Gateway:
                 # This is a modem quirk - use it as the network name
                 if not network_name or not network_name.strip():
                     network_name = network_code
-                
+
                 # Try to find the numeric code by reverse lookup
                 # This works for MVNOs that have their own codes in the database
                 from .network_codes import NETWORK_OPERATORS
+
                 for code, name in NETWORK_OPERATORS.items():
                     if name.lower() == network_code.lower():
                         resolved_code = code
                         break
-                
+
                 # If reverse lookup failed, try to use cached code from gateway
                 # MVNOs often alternate between broadcasting their name and the
                 # host network code, so we cache the last known numeric code
-                if not resolved_code and hasattr(self, '_last_network_code'):
+                if not resolved_code and hasattr(self, "_last_network_code"):
                     resolved_code = self._last_network_code
-        
+
         # Map Gammu's state to match addon format
         state = network_info.get("State", "Unknown")
         # Gammu states: HomeNetwork, RoamingNetwork, RequestingNetwork,
@@ -263,12 +263,12 @@ class Gateway:
             "Unknown": "Unknown",
         }
         mapped_state = state_map.get(state, state)  # Use mapping or keep original
-        
+
         # Cache the resolved code for next time
         # This helps when modem alternates between numeric code and operator name
         if resolved_code:
             self._last_network_code = resolved_code
-        
+
         return {
             "NetworkName": network_name,
             "State": mapped_state,

--- a/custom_components/legacy_gsm_sms/network_codes.py
+++ b/custom_components/legacy_gsm_sms/network_codes.py
@@ -15,8 +15,6 @@ Auto-update: Monthly via GitHub Actions
 # Comprehensive database of mobile network operators by MCC+MNC
 # Format: "MCCMNC": "Operator Name"
 NETWORK_OPERATORS = {
-
-
     # United States (MCC 310-316)
     "310005": "Verizon",
     "310006": "Verizon",
@@ -352,7 +350,6 @@ NETWORK_OPERATORS = {
     "310970": "Globalstar",
     "310980": "Peoples Telephone",
     "310990": "Evolve Broadband",
-
     # US MVNOs with unique codes
     "310032": "IT&E Wireless",
     "310053": "Virgin Mobile",
@@ -483,7 +480,6 @@ NETWORK_OPERATORS = {
     "313970": "Tycrhron",
     "313980": "Next Generation Application LLC",
     "313990": "Ericsson US",
-
     # Canada (MCC 302)
     "302100": "dotmobile",
     "302130": "Xplore",
@@ -566,7 +562,6 @@ NETWORK_OPERATORS = {
     "302996": "Powertech Labs",
     "302997": "Powertech Labs",
     "302998": "Institut de Recherche d’Hydro-Québec",
-
     # United Kingdom (MCC 234, 235)
     "23400": "BT",
     "23401": "Vectone Mobile",
@@ -631,7 +626,6 @@ NETWORK_OPERATORS = {
     "23479": "UKTL",
     "23486": "EE",
     "23488": "telet",
-
     # Germany (MCC 262)
     "26201": "Telekom",
     "26202": "Vodafone",
@@ -675,7 +669,6 @@ NETWORK_OPERATORS = {
     "26279": "ng4T GmbH",
     "26292": "Nash Technologies",
     "26298": "private networks",
-
     # France (MCC 208)
     "20801": "Orange",
     "20802": "Orange",
@@ -753,7 +746,6 @@ NETWORK_OPERATORS = {
     "20896": "Région Bourgogne-Franche-Comté",
     "20897": "Thales Communications & Security SAS",
     "20898": "Société Air France",
-
     # Spain (MCC 214)
     "21401": "Vodafone",
     "21402": "Fibracat",
@@ -796,7 +788,6 @@ NETWORK_OPERATORS = {
     "21451": "ADIF",
     "214700": "Iberdrola",
     "214701": "Endesa",
-
     # Italy (MCC 222)
     "22201": "TIM",
     "22202": "Elsacom",
@@ -827,7 +818,6 @@ NETWORK_OPERATORS = {
     "22288": "WINDTRE",
     "22298": "BLU",
     "22299": "WINDTRE",
-
     # Netherlands (MCC 204)
     "20400": "Intovoice B.V.",
     "20401": "RadioAccess Network Services",
@@ -873,7 +863,6 @@ NETWORK_OPERATORS = {
     "20468": "Roamware (Netherlands) B.V.",
     "20469": "KPN Mobile The Netherlands B.V.",
     "20491": "Enexis Netbeheer B.V.",
-
     # Australia (MCC 505)
     "50501": "Telstra",
     "50502": "Optus",
@@ -936,7 +925,6 @@ NETWORK_OPERATORS = {
     "50588": "Pivotel Group Pty Ltd",
     "50590": "Optus",
     "50599": "One.Tel",
-
     # China (MCC 460, 461)
     "46000": "China Mobile",
     "46001": "China Unicom",
@@ -951,7 +939,6 @@ NETWORK_OPERATORS = {
     "46011": "China Telecom",
     "46015": "China Broadnet",
     "46020": "China Tietong",
-
     # Japan (MCC 440, 441)
     "44000": "Y!Mobile",
     "44001": "KDDI Corporation",
@@ -990,7 +977,6 @@ NETWORK_OPERATORS = {
     "44075": "au",
     "44076": "au",
     "44078": "au",
-
     # India (MCC 404, 405)
     "40401": "Vi India",
     "40402": "AirTel",
@@ -1080,7 +1066,6 @@ NETWORK_OPERATORS = {
     "40496": "AirTel",
     "40497": "AirTel",
     "40498": "AirTel",
-
     # Brazil (MCC 724)
     "72400": "Nextel",
     "72401": "SISTEER DO BRASIL TELECOMUNICAÇÔES",
@@ -1113,7 +1098,6 @@ NETWORK_OPERATORS = {
     "72439": "Nextel",
     "72454": "Conecta",
     "72499": "Local",
-
     # Mexico (MCC 334)
     "334001": "Comunicaciones Digitales Del Norte, S.A. de C.V.",
     "334010": "AT&T",
@@ -1143,7 +1127,6 @@ NETWORK_OPERATORS = {
     "334200": "Virgin Mobile",
     "334210": "YO Mobile",
     "334220": "Megamóvil",
-
     # Russia (MCC 250)
     "25001": "MTS",
     "25002": "MegaFon",
@@ -1194,7 +1177,6 @@ NETWORK_OPERATORS = {
     "25096": "+7Telecom",
     "25097": "Phoenix",
     "25099": "Beeline",
-
     # South Africa (MCC 655)
     "65501": "Vodacom",
     "65502": "Telkom",
@@ -1235,9 +1217,7 @@ NETWORK_OPERATORS = {
     "65575": "ACSA",
     "65576": "Comsol Networks (Pty) Ltd",
     "65577": "Umoja Connect",
-
     # Add more countries as needed...
-
     # Additional network codes
     "001001": "TEST",
     "00101": "TEST",
@@ -3114,10 +3094,10 @@ NETWORK_OPERATORS = {
 
 def get_network_name(network_code: str):
     """Get network operator name from MCC+MNC code.
-    
+
     Args:
         network_code: MCC+MNC code (e.g., "310260" for T-Mobile USA)
-        
+
     Returns:
         Network operator name or None if not found
     """

--- a/custom_components/legacy_gsm_sms/notify.py
+++ b/custom_components/legacy_gsm_sms/notify.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import logging
 
 import gammu
-
 from homeassistant.components.notify import ATTR_DATA, BaseNotificationService
 from homeassistant.const import CONF_TARGET
 from homeassistant.core import HomeAssistant

--- a/custom_components/legacy_gsm_sms/sensor.py
+++ b/custom_components/legacy_gsm_sms/sensor.py
@@ -125,9 +125,7 @@ async def async_setup_entry(
 
     # Add SMS counter sensors
     for description in SMS_SENSORS:
-        entities.append(
-            SMSCounterSensor(description, unique_id, gateway, sms_manager)
-        )
+        entities.append(SMSCounterSensor(description, unique_id, gateway, sms_manager))
 
     # Add Last SMS sensor
     entities.append(LastSMSSensor(unique_id, gateway, sms_manager))

--- a/debug_server.py
+++ b/debug_server.py
@@ -7,30 +7,32 @@ Run: python3 debug_server.py
 Then configure your app to send to: http://192.168.1.37:5555/sms
 """
 
-from flask import Flask, request
-import json
 from datetime import datetime
+import json
+
+from flask import Flask, request
 
 app = Flask(__name__)
 
+
 def log_request(endpoint):
     """Log all details of the incoming request"""
-    timestamp = datetime.now().strftime('%Y-%m-%d %H:%M:%S')
-    
+    timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+
     print("\n" + "=" * 80)
     print(f"📥 REQUEST RECEIVED at {timestamp}")
     print("=" * 80)
-    
+
     print(f"\n🎯 Endpoint: {request.method} {endpoint}")
     print(f"🌐 URL: {request.url}")
     print(f"🔗 Path: {request.path}")
-    
+
     print(f"\n📋 Headers:")
     for header, value in request.headers.items():
         print(f"  {header}: {value}")
-    
+
     print(f"\n📦 Content-Type: {request.content_type or 'NOT SET'}")
-    
+
     # Try to get raw body
     try:
         raw_body = request.get_data(as_text=True)
@@ -39,7 +41,7 @@ def log_request(endpoint):
         print(f"  Actual: {raw_body}")
     except Exception as e:
         print(f"\n❌ Could not read raw body: {e}")
-    
+
     # Try to parse as JSON
     print(f"\n🔍 Parsed Data:")
     try:
@@ -50,7 +52,7 @@ def log_request(endpoint):
             print(f"  ❌ Not valid JSON")
     except Exception as e:
         print(f"  ❌ JSON parse error: {e}")
-    
+
     # Try to parse as form data
     if request.form:
         print(f"  ✅ Form Data:")
@@ -58,7 +60,7 @@ def log_request(endpoint):
             print(f"    {key} = {repr(value)}")
     else:
         print(f"  ❌ No form data detected")
-    
+
     # Query parameters
     if request.args:
         print(f"\n🔗 Query Parameters:")
@@ -66,38 +68,42 @@ def log_request(endpoint):
             print(f"  {key} = {repr(value)}")
     else:
         print(f"\n  No query parameters")
-    
+
     print("\n" + "=" * 80)
     print("✅ Analysis complete - check above for issues")
     print("=" * 80 + "\n")
 
-@app.route('/sms', methods=['GET', 'POST', 'PUT', 'DELETE', 'PATCH'])
+
+@app.route("/sms", methods=["GET", "POST", "PUT", "DELETE", "PATCH"])
 def sms_endpoint():
     """Main SMS endpoint - logs everything and returns success"""
-    log_request('/sms')
-    
+    log_request("/sms")
+
     return {
         "status": 200,
         "message": "Debug server received your request - check console output",
         "received_at": datetime.now().isoformat(),
         "method": request.method,
         "content_type": request.content_type,
-        "body_length": len(request.get_data())
+        "body_length": len(request.get_data()),
     }, 200
 
-@app.route('/', methods=['GET', 'POST'])
+
+@app.route("/", methods=["GET", "POST"])
 def root():
     """Catch-all for root"""
-    log_request('/')
+    log_request("/")
     return {"message": "Debug server running - use /sms endpoint"}, 200
 
-@app.route('/<path:path>', methods=['GET', 'POST', 'PUT', 'DELETE', 'PATCH'])
+
+@app.route("/<path:path>", methods=["GET", "POST", "PUT", "DELETE", "PATCH"])
 def catch_all(path):
     """Catch any other endpoint"""
-    log_request(f'/{path}')
+    log_request(f"/{path}")
     return {"message": f"Debug server - wrong endpoint (use /sms)"}, 200
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     print("\n" + "=" * 80)
     print("🔍 DEBUG HTTP SERVER STARTED")
     print("=" * 80)
@@ -110,5 +116,5 @@ if __name__ == '__main__':
     print("   - Parsed JSON (if applicable)")
     print("   - Form data (if applicable)")
     print("\n⏸️  Press Ctrl+C to stop\n")
-    
-    app.run(host='0.0.0.0', port=5555, debug=False)
+
+    app.run(host="0.0.0.0", port=5555, debug=False)

--- a/gateway.py
+++ b/gateway.py
@@ -4,7 +4,6 @@ import logging
 
 import gammu
 from gammu.asyncworker import GammuAsyncWorker
-
 from homeassistant.core import callback
 
 from .const import DOMAIN, SMS_STATE_UNREAD
@@ -179,16 +178,16 @@ class Gateway:
     async def get_signal_quality_async(self):
         """Get the current signal level of the modem."""
         signal_data = await self._worker.get_signal_quality_async()
-        
+
         # Gammu returns already processed values:
         # - SignalStrength: dBm value (already calculated, -1 = unknown)
         # - SignalPercent: percentage 0-100 (-1 = unknown)
         # - BitErrorRate: RXQUAL value 0-7 (99 = unknown)
-        
+
         signal_strength = signal_data.get("SignalStrength", -1)
         signal_percent = signal_data.get("SignalPercent", -1)
         ber = signal_data.get("BitErrorRate", 99)
-        
+
         # Convert -1 to None for unknown values
         if signal_strength == -1:
             signal_strength = None
@@ -197,7 +196,7 @@ class Gateway:
         # BitErrorRate: 99 or -1 means unknown, 0-7 is RXQUAL index
         if ber == 99 or ber == -1 or ber < 0:
             ber = None
-        
+
         return {
             "SignalStrength": signal_strength,
             "SignalPercent": signal_percent,
@@ -207,17 +206,17 @@ class Gateway:
     async def get_network_info_async(self):
         """Get the current network info of the modem."""
         network_info = await self._worker.get_network_info_async()
-        
+
         # Gammu returns: NetworkName, State, NetworkCode, CID, LAC
         raw_network_name = network_info.get("NetworkName")
         network_code = network_info.get("NetworkCode")
-        
+
         # Determine the best network name and code to display
         # Note: Some modems return the NITZ operator name in NetworkCode field
         # instead of the numeric MCC+MNC code
         network_name = raw_network_name
         resolved_code = None
-        
+
         # Check if NetworkCode is numeric (correct) or contains a name (modem quirk)
         if network_code:
             if network_code.isdigit():
@@ -233,21 +232,22 @@ class Gateway:
                 # This is a modem quirk - use it as the network name
                 if not network_name or not network_name.strip():
                     network_name = network_code
-                
+
                 # Try to find the numeric code by reverse lookup
                 # This works for MVNOs that have their own codes in the database
                 from .network_codes import NETWORK_OPERATORS
+
                 for code, name in NETWORK_OPERATORS.items():
                     if name.lower() == network_code.lower():
                         resolved_code = code
                         break
-                
+
                 # If reverse lookup failed, try to use cached code from gateway
                 # MVNOs often alternate between broadcasting their name and the
                 # host network code, so we cache the last known numeric code
-                if not resolved_code and hasattr(self, '_last_network_code'):
+                if not resolved_code and hasattr(self, "_last_network_code"):
                     resolved_code = self._last_network_code
-        
+
         # Map Gammu's state to match addon format
         state = network_info.get("State", "Unknown")
         # Gammu states: HomeNetwork, RoamingNetwork, RequestingNetwork,
@@ -263,12 +263,12 @@ class Gateway:
             "Unknown": "Unknown",
         }
         mapped_state = state_map.get(state, state)  # Use mapping or keep original
-        
+
         # Cache the resolved code for next time
         # This helps when modem alternates between numeric code and operator name
         if resolved_code:
             self._last_network_code = resolved_code
-        
+
         return {
             "NetworkName": network_name,
             "State": mapped_state,

--- a/network_codes.py
+++ b/network_codes.py
@@ -15,8 +15,6 @@ Auto-update: Monthly via GitHub Actions
 # Comprehensive database of mobile network operators by MCC+MNC
 # Format: "MCCMNC": "Operator Name"
 NETWORK_OPERATORS = {
-
-
     # United States (MCC 310-316)
     "310005": "Verizon",
     "310006": "Verizon",
@@ -352,7 +350,6 @@ NETWORK_OPERATORS = {
     "310970": "Globalstar",
     "310980": "Peoples Telephone",
     "310990": "Evolve Broadband",
-
     # US MVNOs with unique codes
     "310032": "IT&E Wireless",
     "310053": "Virgin Mobile",
@@ -483,7 +480,6 @@ NETWORK_OPERATORS = {
     "313970": "Tycrhron",
     "313980": "Next Generation Application LLC",
     "313990": "Ericsson US",
-
     # Canada (MCC 302)
     "302100": "dotmobile",
     "302130": "Xplore",
@@ -566,7 +562,6 @@ NETWORK_OPERATORS = {
     "302996": "Powertech Labs",
     "302997": "Powertech Labs",
     "302998": "Institut de Recherche d’Hydro-Québec",
-
     # United Kingdom (MCC 234, 235)
     "23400": "BT",
     "23401": "Vectone Mobile",
@@ -631,7 +626,6 @@ NETWORK_OPERATORS = {
     "23479": "UKTL",
     "23486": "EE",
     "23488": "telet",
-
     # Germany (MCC 262)
     "26201": "Telekom",
     "26202": "Vodafone",
@@ -675,7 +669,6 @@ NETWORK_OPERATORS = {
     "26279": "ng4T GmbH",
     "26292": "Nash Technologies",
     "26298": "private networks",
-
     # France (MCC 208)
     "20801": "Orange",
     "20802": "Orange",
@@ -753,7 +746,6 @@ NETWORK_OPERATORS = {
     "20896": "Région Bourgogne-Franche-Comté",
     "20897": "Thales Communications & Security SAS",
     "20898": "Société Air France",
-
     # Spain (MCC 214)
     "21401": "Vodafone",
     "21402": "Fibracat",
@@ -796,7 +788,6 @@ NETWORK_OPERATORS = {
     "21451": "ADIF",
     "214700": "Iberdrola",
     "214701": "Endesa",
-
     # Italy (MCC 222)
     "22201": "TIM",
     "22202": "Elsacom",
@@ -827,7 +818,6 @@ NETWORK_OPERATORS = {
     "22288": "WINDTRE",
     "22298": "BLU",
     "22299": "WINDTRE",
-
     # Netherlands (MCC 204)
     "20400": "Intovoice B.V.",
     "20401": "RadioAccess Network Services",
@@ -873,7 +863,6 @@ NETWORK_OPERATORS = {
     "20468": "Roamware (Netherlands) B.V.",
     "20469": "KPN Mobile The Netherlands B.V.",
     "20491": "Enexis Netbeheer B.V.",
-
     # Australia (MCC 505)
     "50501": "Telstra",
     "50502": "Optus",
@@ -936,7 +925,6 @@ NETWORK_OPERATORS = {
     "50588": "Pivotel Group Pty Ltd",
     "50590": "Optus",
     "50599": "One.Tel",
-
     # China (MCC 460, 461)
     "46000": "China Mobile",
     "46001": "China Unicom",
@@ -951,7 +939,6 @@ NETWORK_OPERATORS = {
     "46011": "China Telecom",
     "46015": "China Broadnet",
     "46020": "China Tietong",
-
     # Japan (MCC 440, 441)
     "44000": "Y!Mobile",
     "44001": "KDDI Corporation",
@@ -990,7 +977,6 @@ NETWORK_OPERATORS = {
     "44075": "au",
     "44076": "au",
     "44078": "au",
-
     # India (MCC 404, 405)
     "40401": "Vi India",
     "40402": "AirTel",
@@ -1080,7 +1066,6 @@ NETWORK_OPERATORS = {
     "40496": "AirTel",
     "40497": "AirTel",
     "40498": "AirTel",
-
     # Brazil (MCC 724)
     "72400": "Nextel",
     "72401": "SISTEER DO BRASIL TELECOMUNICAÇÔES",
@@ -1113,7 +1098,6 @@ NETWORK_OPERATORS = {
     "72439": "Nextel",
     "72454": "Conecta",
     "72499": "Local",
-
     # Mexico (MCC 334)
     "334001": "Comunicaciones Digitales Del Norte, S.A. de C.V.",
     "334010": "AT&T",
@@ -1143,7 +1127,6 @@ NETWORK_OPERATORS = {
     "334200": "Virgin Mobile",
     "334210": "YO Mobile",
     "334220": "Megamóvil",
-
     # Russia (MCC 250)
     "25001": "MTS",
     "25002": "MegaFon",
@@ -1194,7 +1177,6 @@ NETWORK_OPERATORS = {
     "25096": "+7Telecom",
     "25097": "Phoenix",
     "25099": "Beeline",
-
     # South Africa (MCC 655)
     "65501": "Vodacom",
     "65502": "Telkom",
@@ -1235,9 +1217,7 @@ NETWORK_OPERATORS = {
     "65575": "ACSA",
     "65576": "Comsol Networks (Pty) Ltd",
     "65577": "Umoja Connect",
-
     # Add more countries as needed...
-
     # Additional network codes
     "001001": "TEST",
     "00101": "TEST",
@@ -3114,10 +3094,10 @@ NETWORK_OPERATORS = {
 
 def get_network_name(network_code: str):
     """Get network operator name from MCC+MNC code.
-    
+
     Args:
         network_code: MCC+MNC code (e.g., "310260" for T-Mobile USA)
-        
+
     Returns:
         Network operator name or None if not found
     """

--- a/notify.py
+++ b/notify.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import logging
 
 import gammu
-
 from homeassistant.components.notify import ATTR_DATA, BaseNotificationService
 from homeassistant.const import CONF_TARGET
 from homeassistant.core import HomeAssistant

--- a/sensor.py
+++ b/sensor.py
@@ -125,9 +125,7 @@ async def async_setup_entry(
 
     # Add SMS counter sensors
     for description in SMS_SENSORS:
-        entities.append(
-            SMSCounterSensor(description, unique_id, gateway, sms_manager)
-        )
+        entities.append(SMSCounterSensor(description, unique_id, gateway, sms_manager))
 
     # Add Last SMS sensor
     entities.append(LastSMSSensor(unique_id, gateway, sms_manager))

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,9 @@
 [flake8]
-exclude = .venv,.git,.tox,docs,venv,bin,lib,deps,build
-max-line-length = 88
-extend-ignore = E203
+exclude = .venv*,.git,.tox,docs,venv,bin,lib,deps,build,temp-pavelve,z-addon-old-test
+max-line-length = 120
+# E203: whitespace before ':' (conflicts with black)
+# W291, W292, W293: trailing/blank-line whitespace (handled by black)
+extend-ignore = E203, W291, W292, W293
 
 [isort]
 profile = black

--- a/tests/common.py
+++ b/tests/common.py
@@ -1,4 +1,5 @@
 """Common test helpers."""
+
 from unittest.mock import Mock
 
 
@@ -6,7 +7,9 @@ def mock_gateway():
     """Create a mock gateway."""
     gateway = Mock()
     gateway.init_async = Mock(return_value=None)
-    gateway.get_signal_quality_async = Mock(return_value={"SignalStrength": 42, "SignalPercent": 50})
+    gateway.get_signal_quality_async = Mock(
+        return_value={"SignalStrength": 42, "SignalPercent": 50}
+    )
     gateway.get_network_info_async = Mock(
         return_value={"NetworkName": "TestOperator", "NetworkCode": "123456"}
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,11 @@
 """Conftest for legacy_gsm_sms tests."""
+
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
 pytest.register_assert_rewrite("tests.common")
+
 
 # This fixture is used to prevent HomeAssistant from attempting to create and dismiss persistent
 # notifications. These calls would fail without this fixture since the persistent_notification

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,4 +1,5 @@
 """Tests for the legacy_gsm_sms integration config flow."""
+
 from unittest.mock import patch
 
 from homeassistant import config_entries, setup

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1,12 +1,12 @@
 """Tests for the legacy_gsm_sms sensors."""
-from unittest.mock import patch
 
-import pytest
+from unittest.mock import patch
 
 from homeassistant.components.legacy_gsm_sms.const import DOMAIN
 from homeassistant.components.sensor import SensorDeviceClass, SensorStateClass
 from homeassistant.const import PERCENTAGE, SIGNAL_STRENGTH_DECIBELS
 from homeassistant.setup import async_setup_component
+import pytest
 
 from tests.common import mock_gateway
 

--- a/z-addon-old-test/gsm_sms_service.py
+++ b/z-addon-old-test/gsm_sms_service.py
@@ -1,28 +1,28 @@
 #!/usr/bin/env python3
 """Standalone GSM SMS service for Home Assistant addon."""
 
+from datetime import datetime
 import json
 import logging
 import os
 import sys
 import time
-from datetime import datetime
-import requests
+
 import gammu
+import requests
 
 # Default to INFO level until we load the config
 logging.basicConfig(
     level=logging.INFO,
-    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
-    handlers=[
-        logging.StreamHandler(sys.stdout)
-    ]
+    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    handlers=[logging.StreamHandler(sys.stdout)],
 )
 
 # For s6-overlay compatibility
-os.environ['PYTHONUNBUFFERED'] = '1'
+os.environ["PYTHONUNBUFFERED"] = "1"
 
 _LOGGER = logging.getLogger("gsm_sms_service")
+
 
 # Function to set log level from string
 def set_log_level(level_str):
@@ -30,23 +30,23 @@ def set_log_level(level_str):
     log_levels = {
         "trace": logging.DEBUG,  # Treat trace as debug for Python
         "debug": logging.DEBUG,
-        "info": logging.INFO, 
+        "info": logging.INFO,
         "notice": logging.INFO,  # Treat notice as info for Python
         "warning": logging.WARNING,
         "error": logging.ERROR,
-        "fatal": logging.CRITICAL
+        "fatal": logging.CRITICAL,
     }
-    
+
     # Default to INFO if the level is not recognized
     level = log_levels.get(level_str.lower(), logging.INFO)
     _LOGGER.setLevel(level)
-    
+
     # Also set the root logger
     logging.getLogger().setLevel(level)
-    
+
     # Log the change
     _LOGGER.info(f"Log level set to: {level_str} ({logging.getLevelName(level)})")
-    
+
     # Special case for debug level - print extra information
     if level == logging.DEBUG:
         _LOGGER.debug("====== GSM SMS Service Debug Information ======")
@@ -56,6 +56,7 @@ def set_log_level(level_str):
         _LOGGER.debug(f"Environment variables: {os.environ}")
         _LOGGER.debug("=============================================")
 
+
 # Print startup diagnostic information
 _LOGGER.debug("====== GSM SMS Service Debug Information ======")
 _LOGGER.debug(f"Python version: {sys.version}")
@@ -63,6 +64,7 @@ _LOGGER.debug(f"Current working directory: {os.getcwd()}")
 _LOGGER.debug(f"Current user: {os.getuid()}")
 _LOGGER.debug(f"Environment variables: {os.environ}")
 _LOGGER.debug("============================================")
+
 
 class GSMSMSService:
     """Service to handle SMS via GSM modem."""
@@ -75,20 +77,20 @@ class GSMSMSService:
         self.scan_interval = config.get("scan_interval", 30)
         self.service_name = config.get("service_name", "legacy_gsm_sms")
         self.sm = None
-        
+
         # Device information - will be populated when modem connects
         self.device_manufacturer = None
         self.device_model = None
         self.device_imei = None
-        
+
         # Get Home Assistant connection details from environment
         self.ha_url = os.environ.get("SUPERVISOR_API") or "http://supervisor/core"
         self.ha_token = os.environ.get("SUPERVISOR_TOKEN", "")
-        
+
         # Log connection details (redact token for security)
         _LOGGER.info(f"Home Assistant URL: {self.ha_url}")
         _LOGGER.debug(f"Home Assistant token available: {bool(self.ha_token)}")
-        
+
         self.headers = {
             "Authorization": f"Bearer {self.ha_token}",
             "Content-Type": "application/json",
@@ -101,87 +103,89 @@ class GSMSMSService:
     def setup_modem(self):
         """Set up the GSM modem."""
         _LOGGER.info("Setting up GSM modem: %s", self.device)
-        
+
         try:
             # Wait for the device to be available
             if not os.path.exists(self.device):
-                _LOGGER.warning("Device %s does not exist, checking available devices", self.device)
-                
+                _LOGGER.warning(
+                    "Device %s does not exist, checking available devices", self.device
+                )
+
                 # List available devices
                 tty_devices = [d for d in os.listdir("/dev") if d.startswith("tty")]
                 _LOGGER.info("Available tty devices: %s", ", ".join(tty_devices))
-                
+
                 # Wait and retry
                 _LOGGER.info("Waiting for device to become available...")
                 return False
-            
+
             # Gammu configuration - Get verbose about what we're doing
             _LOGGER.info(f"Setting up Gammu configuration for device: {self.device}")
-            
+
             # We'll try multiple configurations in sequence until one works
             configurations = [
                 # Config 1: Basic AT connection (most common)
-                {
-                    "Device": self.device,
-                    "Connection": "at"
-                },
+                {"Device": self.device, "Connection": "at"},
                 # Config 2: AT with specific baud rate in connection string
                 {
                     "Device": self.device,
-                    "Connection": f"at{self.baud_speed}" if self.baud_speed != "0" else "at19200"
+                    "Connection": (
+                        f"at{self.baud_speed}" if self.baud_speed != "0" else "at19200"
+                    ),
                 },
                 # Config 3: Auto detection
-                {
-                    "Device": self.device,
-                    "Connection": "auto"
-                }
+                {"Device": self.device, "Connection": "auto"},
             ]
-            
+
             # Try configurations in sequence
             connection_error = None
             gammu_config = configurations[0]  # Default to first config if all fail
-            
+
             for i, config in enumerate(configurations):
                 try:
-                    _LOGGER.info(f"Trying configuration {i+1}/{len(configurations)}: {config}")
+                    _LOGGER.info(
+                        f"Trying configuration {i+1}/{len(configurations)}: {config}"
+                    )
                     # Use this configuration
                     gammu_config = config
-                    
+
                     # Initialize Gammu state machine with this config
                     self.sm = gammu.StateMachine()
                     self.sm.SetConfig(0, gammu_config)
                     self.sm.Init()
-                    
+
                     # If we get here, the configuration worked!
-                    _LOGGER.info(f"Successfully connected to modem with config: {gammu_config}")
+                    _LOGGER.info(
+                        f"Successfully connected to modem with config: {gammu_config}"
+                    )
                     self.connected = True
-                    
+
                     # Get device information
                     self.get_device_info()
-                    
+
                     return True
-                    
+
                 except Exception as e:
                     _LOGGER.warning(f"Configuration {i+1} failed: {str(e)}")
                     connection_error = e
                     self.connected = False
                     # Continue to next configuration
-            
+
             # If we get here, all configurations failed
             if connection_error:
                 raise connection_error  # Re-raise the last error
-            
+
             # Initialize Gammu state machine
             self.sm = gammu.StateMachine()
             self.sm.SetConfig(0, gammu_config)
             self.sm.Init()
-            
+
             _LOGGER.info("Modem initialized successfully")
             self.connected = True
-            
+
             # Get device information from the modem
             self.get_device_info()
-            
+
             return True
         except gammu.ERR_DEVICENOTEXIST:
             _LOGGER.error("Device %s does not exist", self.device)
@@ -201,25 +205,29 @@ class GSMSMSService:
         try:
             if not self.sm or not self.connected:
                 return
-                
+
             signal_quality = self.sm.GetSignalQuality()
             self.signal_strength = signal_quality["SignalPercent"]
-            
+
             net_info = self.sm.GetNetworkInfo()
             self.network_name = net_info.get("NetworkName", "Unknown")
-            
+
             _LOGGER.debug(
-                "Signal: %s%%, Network: %s",
-                self.signal_strength,
-                self.network_name
+                "Signal: %s%%, Network: %s", self.signal_strength, self.network_name
             )
-            
+
             # Update the Home Assistant sensor states
-            self._update_ha_sensor(f"sensor.{self.service_name}_signal_strength", self.signal_strength, "%")
-            self._update_ha_sensor(f"sensor.{self.service_name}_network_name", self.network_name)
-            
+            self._update_ha_sensor(
+                f"sensor.{self.service_name}_signal_strength", self.signal_strength, "%"
+            )
+            self._update_ha_sensor(
+                f"sensor.{self.service_name}_network_name", self.network_name
+            )
+
             # Add a last_update sensor to track when data was last refreshed
-            self._update_ha_sensor(f"sensor.{self.service_name}_last_update", datetime.now().isoformat())
+            self._update_ha_sensor(
+                f"sensor.{self.service_name}_last_update", datetime.now().isoformat()
+            )
         except gammu.GSMError as ex:
             _LOGGER.error("Failed to update signal info: %s", str(ex))
             self.connected = False
@@ -229,39 +237,39 @@ class GSMSMSService:
         try:
             if not self.sm or not self.connected:
                 return
-                
+
             # Get status of messages in all folders
             status = self.sm.GetSMSStatus()
             remain = status["SIMUsed"] + status["PhoneUsed"] + status["TemplatesUsed"]
-            
+
             _LOGGER.debug("Messages in phone: %s", remain)
-            
+
             if remain > 0:
                 # Get all sms
                 sms = []
                 entry = None
-                
+
                 # Get first message
                 try:
                     entry = self.sm.GetNextSMS(Start=True, Folder=0)
                     if entry:
                         sms.append(entry)
-                        
+
                     # Get remaining messages
                     while entry and len(entry) > 0:
                         last_location = entry[0].get("Location", 0)
                         entry = self.sm.GetNextSMS(Location=last_location, Folder=0)
                         if entry:
                             sms.append(entry)
-                        
+
                 except gammu.ERR_EMPTY:
                     # This is expected, means we've read all messages
                     pass
-                
+
                 # Process the messages
                 for message in sms:
                     self._process_sms_message(message)
-                
+
         except gammu.GSMError as ex:
             _LOGGER.error("Failed to check for new SMS: %s", str(ex))
             self.connected = False
@@ -271,7 +279,7 @@ class GSMSMSService:
         if not self.sm or not self.connected:
             _LOGGER.warning("Cannot process SMS: modem not connected")
             return
-            
+
         for single in message:
             # Only process unread messages
             if single["State"] == "UnRead":
@@ -282,22 +290,24 @@ class GSMSMSService:
                     _LOGGER.error("Failed to mark SMS as read: %s", str(ex))
                 except Exception as ex:
                     _LOGGER.error("Unexpected error marking SMS as read: %s", str(ex))
-                
+
                 try:
                     decoded_message = {
                         "phone": single["Number"],
                         "date": single["DateTime"].strftime("%Y-%m-%d %H:%M:%S"),
                         "text": single["Text"],
                     }
-                    
+
                     _LOGGER.info(
                         "Received SMS from %s: %s",
                         decoded_message["phone"],
-                        decoded_message["text"]
+                        decoded_message["text"],
                     )
-                    
+
                     # Fire event in Home Assistant
-                    self._fire_ha_event(f"{self.service_name}.incoming_sms", decoded_message)
+                    self._fire_ha_event(
+                        f"{self.service_name}.incoming_sms", decoded_message
+                    )
                 except Exception as ex:
                     _LOGGER.error("Error processing SMS content: %s", str(ex))
 
@@ -306,7 +316,7 @@ class GSMSMSService:
         if not self.sm or not self.connected:
             _LOGGER.error("Cannot send SMS: Modem not connected")
             return False
-            
+
         try:
             # Prepare message data
             sms_info = {
@@ -319,16 +329,16 @@ class GSMSMSService:
                     }
                 ],
             }
-            
+
             # Encode message
             encoded_sms = gammu.EncodeSMS(sms_info)
-            
+
             # Send the message parts
             for sms in encoded_sms:
                 sms["SMSC"] = {"Location": 1}
                 sms["Number"] = to
                 self.sm.SendSMS(sms)
-            
+
             _LOGGER.info("SMS sent to %s", to)
             return True
         except gammu.GSMError as ex:
@@ -339,16 +349,16 @@ class GSMSMSService:
         """Update a sensor state in Home Assistant."""
         try:
             # Extract the sensor name from entity_id (removing the sensor. prefix)
-            sensor_name = entity_id.replace('sensor.', '')
-            
+            sensor_name = entity_id.replace("sensor.", "")
+
             # Create a unique_id based on the entity_id but without the domain prefix
             unique_id = f"gsm_sms_{sensor_name}"
-            
+
             # Prepare attributes and metadata based on sensor type
             attributes = {
-                "friendly_name": sensor_name.replace('_', ' ').title(),
+                "friendly_name": sensor_name.replace("_", " ").title(),
             }
-            
+
             # Set specific metadata based on sensor type
             if "signal_strength" in entity_id:
                 attributes["device_class"] = "signal_strength"
@@ -363,53 +373,56 @@ class GSMSMSService:
             elif "last_update" in entity_id:
                 attributes["device_class"] = "timestamp"
                 attributes["icon"] = "mdi:clock-outline"
-            
-            data = {
-                "state": state,
-                "attributes": attributes
-            }
-            
+
+            data = {"state": state, "attributes": attributes}
+
             # Add unique_id to make the entity persistent
             data["unique_id"] = unique_id
-            
+
             # Add device info to group all entities under one device in the UI
             device_info = {
                 "identifiers": [f"gsm_sms_{self.service_name}"],
                 "name": f"GSM SMS {self.service_name}",
-                "sw_version": "0.0.1g"  # Match the addon version
+                "sw_version": "0.0.1g",  # Match the addon version
             }
-            
+
             # Use real device info if available
             if self.device_manufacturer:
                 device_info["manufacturer"] = self.device_manufacturer
             else:
                 device_info["manufacturer"] = "Home Assistant Add-on"
-                
+
             if self.device_model:
                 device_info["model"] = self.device_model
             else:
                 device_info["model"] = "GSM Modem"
-                
+
             if self.device_imei:
                 # Add IMEI as a secondary identifier
                 device_info["identifiers"].append(f"imei_{self.device_imei}")
-                
+
             data["device"] = device_info
-            
+
             if unit:
                 data["attributes"]["unit_of_measurement"] = unit
-                
+
             # Skip if no token
             if not self.ha_token:
-                _LOGGER.debug(f"No Home Assistant token, skipping sensor update for {entity_id}")
+                _LOGGER.debug(
+                    f"No Home Assistant token, skipping sensor update for {entity_id}"
+                )
                 return
-                
+
             url = f"{self.ha_url}/api/states/{entity_id}"
             try:
-                response = requests.post(url, headers=self.headers, json=data, timeout=10)
-                
+                response = requests.post(
+                    url, headers=self.headers, json=data, timeout=10
+                )
+
                 if response.status_code not in (200, 201):
-                    _LOGGER.error(f"Failed to update sensor {entity_id}: HTTP {response.status_code} - {response.text}")
+                    _LOGGER.error(
+                        f"Failed to update sensor {entity_id}: HTTP {response.status_code} - {response.text}"
+                    )
                 else:
                     _LOGGER.debug(f"Successfully updated sensor {entity_id}")
             except requests.exceptions.RequestException as e:
@@ -424,52 +437,59 @@ class GSMSMSService:
             if not self.ha_token:
                 _LOGGER.debug(f"No Home Assistant token, skipping event {event_type}")
                 return
-                
+
             url = f"{self.ha_url}/api/events/{event_type}"
-            
+
             try:
-                response = requests.post(url, headers=self.headers, json=event_data, timeout=10)
-                
+                response = requests.post(
+                    url, headers=self.headers, json=event_data, timeout=10
+                )
+
                 if response.status_code != 200:
-                    _LOGGER.error(f"Failed to fire event {event_type}: HTTP {response.status_code} - {response.text}")
+                    _LOGGER.error(
+                        f"Failed to fire event {event_type}: HTTP {response.status_code} - {response.text}"
+                    )
                 else:
                     _LOGGER.debug(f"Successfully fired event {event_type}")
             except requests.exceptions.RequestException as e:
                 _LOGGER.error(f"Error connecting to Home Assistant: {str(e)}")
         except Exception as ex:
             _LOGGER.error("Error firing event: %s", str(ex))
-            
+
     def register_service(self):
         """Register the notify service in Home Assistant."""
-        
+
         # Skip registration if token is empty
         if not self.ha_token:
-            _LOGGER.warning("No Home Assistant token provided, skipping service registration")
+            _LOGGER.warning(
+                "No Home Assistant token provided, skipping service registration"
+            )
             return
-            
+
         try:
             # Create a service for sending SMS
             service_data = {
                 "domain": "notify",
                 "service": self.service_name,
-                "service_data": {
-                    "message": "{{ message }}",
-                    "target": "{{ target }}"
-                },
-                "target": {
-                    "entity_id": f"notify.{self.service_name}"
-                }
+                "service_data": {"message": "{{ message }}", "target": "{{ target }}"},
+                "target": {"entity_id": f"notify.{self.service_name}"},
             }
-            
-            _LOGGER.info(f"Registering notify service with Home Assistant at {self.ha_url}")
-            
+
+            _LOGGER.info(
+                f"Registering notify service with Home Assistant at {self.ha_url}"
+            )
+
             url = f"{self.ha_url}/api/services/notify/{self.service_name}"
-            
+
             try:
-                response = requests.post(url, headers=self.headers, json=service_data, timeout=10)
-                
+                response = requests.post(
+                    url, headers=self.headers, json=service_data, timeout=10
+                )
+
                 if response.status_code not in (200, 201):
-                    _LOGGER.error(f"Failed to register notify service: HTTP {response.status_code} - {response.text}")
+                    _LOGGER.error(
+                        f"Failed to register notify service: HTTP {response.status_code} - {response.text}"
+                    )
                 else:
                     _LOGGER.info("Successfully registered notify service")
             except requests.exceptions.RequestException as e:
@@ -481,62 +501,70 @@ class GSMSMSService:
 
     def listen_for_service_calls(self):
         """Start a thread to listen for service calls."""
+        import json
         import threading
         import time
-        import json
-        
+
         # Don't start listener if no HA token
         if not self.ha_token:
-            _LOGGER.warning("No Home Assistant token, service call listener not started")
+            _LOGGER.warning(
+                "No Home Assistant token, service call listener not started"
+            )
             return
 
         def listener():
             """Monitor for SMS requests through files."""
-            _LOGGER.info(f"Starting service call listener for notify.{self.service_name}")
-            
+            _LOGGER.info(
+                f"Starting service call listener for notify.{self.service_name}"
+            )
+
             # Instead of polling Home Assistant API, we'll use a file-based approach
             # This avoids issues with non-existent API endpoints like /core/api/services/notify/{service_name}/history
             sms_dir = "/data/gsm_sms/pending"
             os.makedirs(sms_dir, exist_ok=True)
-            
+
             _LOGGER.info(f"Monitoring directory for SMS requests: {sms_dir}")
-            
+
             while True:
                 try:
                     # Look for pending SMS files
-                    sms_files = [f for f in os.listdir(sms_dir) if f.endswith('.sms')]
-                    
+                    sms_files = [f for f in os.listdir(sms_dir) if f.endswith(".sms")]
+
                     for sms_file in sms_files:
                         file_path = os.path.join(sms_dir, sms_file)
                         _LOGGER.debug(f"Found SMS request file: {sms_file}")
-                        
+
                         try:
                             # Read the SMS data from file
-                            with open(file_path, 'r') as f:
+                            with open(file_path, "r") as f:
                                 sms_data = json.load(f)
-                            
+
                             # Process the SMS data
                             message = sms_data.get("message", "")
                             targets = sms_data.get("target", [])
-                            
+
                             if not message:
-                                _LOGGER.warning(f"Empty message in SMS request file: {sms_file}")
-                            
+                                _LOGGER.warning(
+                                    f"Empty message in SMS request file: {sms_file}"
+                                )
+
                             if not targets:
-                                _LOGGER.warning(f"No targets in SMS request file: {sms_file}")
-                            
+                                _LOGGER.warning(
+                                    f"No targets in SMS request file: {sms_file}"
+                                )
+
                             if isinstance(targets, str):
                                 targets = [targets]
-                            
+
                             # Send SMS to each target
                             for target in targets:
                                 _LOGGER.info(f"Sending SMS to {target}: {message}")
                                 self.send_sms(target, message)
-                            
+
                             # Delete the file after processing
                             os.remove(file_path)
                             _LOGGER.debug(f"Processed and removed SMS file: {sms_file}")
-                            
+
                         except Exception as ex:
                             _LOGGER.error(f"Error processing SMS file {sms_file}: {ex}")
                             # Move the file to an error directory
@@ -550,47 +578,47 @@ class GSMSMSService:
                                     os.remove(file_path)
                                 except:
                                     pass
-                
+
                 except Exception as ex:
                     _LOGGER.error(f"Error in service call listener: {ex}")
-                
+
                 # Sleep for a short period before checking again
                 time.sleep(5)
-                
+
         # Start the listener thread
         thread = threading.Thread(target=listener)
         thread.daemon = True
         thread.start()
-    
+
     def run(self):
         """Run the service."""
         _LOGGER.info("Starting GSM SMS Service")
-        
+
         # Register the service with Home Assistant
         self.register_service()
-        
+
         # Start service call listener
         self.listen_for_service_calls()
-        
+
         last_signal_update = 0
-        
+
         while True:
             # Try to setup/reconnect the modem if not connected
             if not self.connected:
                 self.setup_modem()
                 time.sleep(5)
                 continue
-                
+
             current_time = time.time()
-            
+
             # Update signal info every minute
             if current_time - last_signal_update > 60:
                 self.update_signal_info()
                 last_signal_update = current_time
-            
+
             # Check for new messages according to scan interval
             self.check_for_new_sms()
-            
+
             # Sleep for the configured scan interval
             time.sleep(self.scan_interval)
 
@@ -598,40 +626,45 @@ class GSMSMSService:
         """Get device information from the modem."""
         if not self.sm or not self.connected:
             return
-            
+
         try:
             # Get device information
             self.device_manufacturer = self.sm.GetManufacturer()
             _LOGGER.debug(f"Manufacturer: {self.device_manufacturer}")
-            
+
             self.device_model = self.sm.GetModel()[0]
             _LOGGER.debug(f"Model: {self.device_model}")
-            
+
             self.device_imei = self.sm.GetIMEI()
             _LOGGER.debug(f"IMEI: {self.device_imei}")
-            
+
             # Report device information to Home Assistant
-            self._update_ha_sensor(f"sensor.{self.service_name}_manufacturer", self.device_manufacturer)
-            self._update_ha_sensor(f"sensor.{self.service_name}_model", self.device_model)
-            
+            self._update_ha_sensor(
+                f"sensor.{self.service_name}_manufacturer", self.device_manufacturer
+            )
+            self._update_ha_sensor(
+                f"sensor.{self.service_name}_model", self.device_model
+            )
+
         except Exception as e:
             _LOGGER.error(f"Error getting device information: {e}")
+
 
 if __name__ == "__main__":
     retry_count = 0
     max_retries = 5
-    
+
     while retry_count < max_retries:
         try:
             # Load configuration
             try:
-                with open('/data/gsm_sms/config.json', 'r') as f:
+                with open("/data/gsm_sms/config.json", "r") as f:
                     config = json.load(f)
-                
+
                 # Set log level from configuration
                 log_level = config.get("log_level", "info")
                 set_log_level(log_level)
-                
+
             except FileNotFoundError:
                 _LOGGER.error("Config file not found. Waiting for 10 seconds...")
                 time.sleep(10)
@@ -642,25 +675,29 @@ if __name__ == "__main__":
                 time.sleep(10)
                 retry_count += 1
                 continue
-                
+
             # Create and run service
             service = GSMSMSService(config)
-            
+
             # Give Home Assistant time to start up if needed
             _LOGGER.info("Waiting for Home Assistant to be ready...")
             time.sleep(10)
-            
+
             # Run the service
             _LOGGER.info("Starting GSM SMS service main loop...")
             service.run()
             break
-            
+
         except Exception as e:
             _LOGGER.error("Service error: %s", str(e))
-            _LOGGER.info("Retrying in 30 seconds... (Attempt %d of %d)", retry_count + 1, max_retries)
+            _LOGGER.info(
+                "Retrying in 30 seconds... (Attempt %d of %d)",
+                retry_count + 1,
+                max_retries,
+            )
             time.sleep(30)
             retry_count += 1
-    
+
     if retry_count >= max_retries:
         _LOGGER.error("Maximum retry attempts reached. Exiting...")
         sys.exit(1)

--- a/z-addon-old-test/rootfs/usr/bin/test_gammu.py
+++ b/z-addon-old-test/rootfs/usr/bin/test_gammu.py
@@ -1,33 +1,32 @@
 #!/usr/bin/env python3
 """Test script for Gammu configuration."""
 
-import sys
-import os
 import json
 import logging
+import os
+import sys
+
 import gammu
 
 # Set up logging
 logging.basicConfig(
     level=logging.DEBUG,
-    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
-    handlers=[
-        logging.StreamHandler(sys.stdout)
-    ]
+    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    handlers=[logging.StreamHandler(sys.stdout)],
 )
 
 _LOGGER = logging.getLogger("test_gammu")
 
 # Load config if available
-config_file = '/data/gsm_sms/config.json'
-device = '/dev/ttyUSB0'  # Default
+config_file = "/data/gsm_sms/config.json"
+device = "/dev/ttyUSB0"  # Default
 
 try:
     if os.path.exists(config_file):
-        with open(config_file, 'r') as f:
+        with open(config_file, "r") as f:
             config_data = json.load(f)
-            device = config_data.get('device', device)
-            baud_speed = config_data.get('baud_speed', '0')
+            device = config_data.get("device", device)
+            baud_speed = config_data.get("baud_speed", "0")
             _LOGGER.info(f"Loaded config: device={device}, baud_speed={baud_speed}")
     else:
         _LOGGER.info(f"No config file found at {config_file}, using defaults")
@@ -46,7 +45,7 @@ test_configs = [
         "config": {
             "Device": device,
             "Connection": "at",
-        }
+        },
     },
     # Config 2: AT serial connection
     {
@@ -54,7 +53,7 @@ test_configs = [
         "config": {
             "Device": device,
             "Connection": "at19200",
-        }
+        },
     },
     # Config 3: USB connection
     {
@@ -62,7 +61,7 @@ test_configs = [
         "config": {
             "Device": device,
             "Connection": "usb",
-        }
+        },
     },
     # Config 4: Auto connection
     {
@@ -70,8 +69,8 @@ test_configs = [
         "config": {
             "Device": device,
             "Connection": "auto",
-        }
-    }
+        },
+    },
 ]
 
 # Try each configuration
@@ -80,38 +79,38 @@ for test in test_configs:
     try:
         _LOGGER.info(f"Trying configuration: {test['name']}")
         _LOGGER.info(f"Config: {test['config']}")
-        
+
         # Initialize the state machine
         sm = gammu.StateMachine()
-        sm.SetConfig(0, test['config'])
-        
+        sm.SetConfig(0, test["config"])
+
         # Try to initialize
         _LOGGER.info("Initializing connection...")
         sm.Init()
-        
+
         # Try to get manufacturer
         _LOGGER.info("Getting manufacturer...")
         manufacturer = sm.GetManufacturer()
         _LOGGER.info(f"Manufacturer: {manufacturer}")
-        
+
         # Try to get model
         _LOGGER.info("Getting model...")
         model = sm.GetModel()
         _LOGGER.info(f"Model: {model}")
-        
+
         # Try to get IMEI
         _LOGGER.info("Getting IMEI...")
         imei = sm.GetIMEI()
         _LOGGER.info(f"IMEI: {imei}")
-        
+
         # If we got here, we have a working configuration
         _LOGGER.info(f"SUCCESSFUL CONFIGURATION: {test['name']}")
         _LOGGER.info(f"Working config: {test['config']}")
         success = True
-        
+
         # No need to try other configurations
         break
-        
+
     except Exception as e:
         _LOGGER.error(f"Configuration {test['name']} failed: {e}")
         continue


### PR DESCRIPTION
## Summary

Adds automated code style checking and applies initial formatting to the codebase.

## Changes

### Formatting (no logic changes)
- Applied **black 26.3.1** and **isort 8.0.1** to all Python files
- Fixed test_route_order.py assertions to match black's double-quote preference
- Excluded temp-pavelve/ and z-addon-old-test/ (legacy/experimental code)

### New CI workflow: code-style.yml
- **Black + isort** — blocking check (code must be formatted)
- **Flake8** — informational only (continue-on-error: true) with 168 existing issues to fix gradually

### Config update: setup.cfg
- max-line-length raised from 88 to 120
- Added whitespace ignores (W291, W292, W293) since black handles these
- Added temp-pavelve and z-addon-old-test to exclude list

## Testing
- All 136 tests pass (68 addon-gsm-gateway + 68 addon-test-current)
- black --check passes
- isort --check passes
- Verified locally on Python 3.12