### PR TITLE
fix: multipart SMS completeness check and bytes sanitization

### DIFF
--- a/addon-gsm-gateway/mqtt_publisher.py
+++ b/addon-gsm-gateway/mqtt_publisher.py
@@ -2749,7 +2749,7 @@ class MQTTPublisher:
         self.client.publish(topic, json.dumps(safe_data), qos=1, retain=True)
 
         # Fire Home Assistant event for reliable automation triggering
-        self.fire_ha_event(sms_data)
+        self.fire_ha_event(safe_data)
 
         logger.info(
             f"📡 Published SMS to MQTT: {safe_data.get('Number', 'Unknown')} -> {safe_data.get('Text', '')}"

--- a/addon-gsm-gateway/mqtt_publisher.py
+++ b/addon-gsm-gateway/mqtt_publisher.py
@@ -2701,6 +2701,12 @@ class MQTTPublisher:
         if not self.connected:
             return
 
+        # Sanitize early: bytes values (undecoded text/number) would crash
+        # json.dumps and break string operations like keyword matching.
+        for k, v in sms_data.items():
+            if isinstance(v, bytes):
+                sms_data[k] = v.decode("utf-8", errors="replace")
+
         # Add timestamp
         timestamp = time.strftime("%Y-%m-%d %H:%M:%S")
         sms_data["timestamp"] = timestamp
@@ -2738,21 +2744,14 @@ class MQTTPublisher:
         # Include history in published data
         sms_data["history"] = self.sms_history.get_history()
 
-        # Sanitize: bytes values (undecoded text/number) would crash
-        # json.dumps with "Object of type bytes is not JSON serializable"
-        safe_data = {
-            k: (v.decode("utf-8", errors="replace") if isinstance(v, bytes) else v)
-            for k, v in sms_data.items()
-        }
-
         topic = f"{self.topic_prefix}/sms/state"
-        self.client.publish(topic, json.dumps(safe_data), qos=1, retain=True)
+        self.client.publish(topic, json.dumps(sms_data), qos=1, retain=True)
 
         # Fire Home Assistant event for reliable automation triggering
-        self.fire_ha_event(safe_data)
+        self.fire_ha_event(sms_data)
 
         logger.info(
-            f"📡 Published SMS to MQTT: {safe_data.get('Number', 'Unknown')} -> {safe_data.get('Text', '')}"
+            f"📡 Published SMS to MQTT: {sms_data.get('Number', 'Unknown')} -> {sms_data.get('Text', '')}"
         )
 
     def fire_ha_event(self, sms_data: Dict[str, Any]):

--- a/addon-gsm-gateway/mqtt_publisher.py
+++ b/addon-gsm-gateway/mqtt_publisher.py
@@ -2738,14 +2738,21 @@ class MQTTPublisher:
         # Include history in published data
         sms_data["history"] = self.sms_history.get_history()
 
+        # Sanitize: bytes values (undecoded text/number) would crash
+        # json.dumps with "Object of type bytes is not JSON serializable"
+        safe_data = {
+            k: (v.decode("utf-8", errors="replace") if isinstance(v, bytes) else v)
+            for k, v in sms_data.items()
+        }
+
         topic = f"{self.topic_prefix}/sms/state"
-        self.client.publish(topic, json.dumps(sms_data), qos=1, retain=True)
+        self.client.publish(topic, json.dumps(safe_data), qos=1, retain=True)
 
         # Fire Home Assistant event for reliable automation triggering
         self.fire_ha_event(sms_data)
 
         logger.info(
-            f"📡 Published SMS to MQTT: {sms_data.get('Number', 'Unknown')} -> {sms_data.get('Text', '')}"
+            f"📡 Published SMS to MQTT: {safe_data.get('Number', 'Unknown')} -> {safe_data.get('Text', '')}"
         )
 
     def fire_ha_event(self, sms_data: Dict[str, Any]):
@@ -3555,6 +3562,15 @@ class MQTTPublisher:
 
             # Process each SMS
             for sms in all_sms:
+                # Skip incomplete multipart SMS — wait for all parts to arrive
+                if not sms.get("Complete", True):
+                    logger.info(
+                        f"⏳ Incomplete multipart SMS from {sms.get('Number', 'Unknown')} "
+                        f"({sms.get('PartsReceived')}/{sms.get('PartsExpected')} parts) "
+                        f"- waiting for the rest"
+                    )
+                    continue
+
                 self.publish_sms_received(sms)
 
                 # Auto-delete if enabled

--- a/addon-gsm-gateway/support.py
+++ b/addon-gsm-gateway/support.py
@@ -113,11 +113,26 @@ def retrieveAllSms(machine):
         for sms in allSms:
             smsPart = sms[0]
 
+            # Multipart completeness check: each part carries UDH info with
+            # AllParts = total expected parts.  If not all parts have arrived
+            # yet, mark the message as incomplete so callers can decide to
+            # wait rather than publishing/deleting a truncated message.
+            all_parts = 0
+            for part in sms:
+                udh = part.get("UDH") or {}
+                part_total = udh.get("AllParts", 0) or 0
+                if part_total > all_parts:
+                    all_parts = part_total
+            complete = (all_parts <= 1) or (len(sms) >= all_parts)
+
             result = {
                 "Date": str(smsPart["DateTime"]),
                 "Number": smsPart["Number"],
                 "State": smsPart["State"],
                 "Locations": [smsPart["Location"] for smsPart in sms],
+                "Complete": complete,
+                "PartsReceived": len(sms),
+                "PartsExpected": all_parts if all_parts > 1 else 1,
             }
 
             # Try to decode SMS - this may fail for MMS notifications or corrupted messages

--- a/addon-test-current/mqtt_publisher.py
+++ b/addon-test-current/mqtt_publisher.py
@@ -2748,7 +2748,7 @@ class MQTTPublisher:
         self.client.publish(topic, json.dumps(safe_data), qos=1, retain=True)
 
         # Fire Home Assistant event for reliable automation triggering
-        self.fire_ha_event(sms_data)
+        self.fire_ha_event(safe_data)
 
         logger.info(
             f"📡 Published SMS to MQTT: {safe_data.get('Number', 'Unknown')} -> {safe_data.get('Text', '')}"

--- a/addon-test-current/mqtt_publisher.py
+++ b/addon-test-current/mqtt_publisher.py
@@ -2737,14 +2737,21 @@ class MQTTPublisher:
         # Include history in published data
         sms_data["history"] = self.sms_history.get_history()
 
+        # Sanitize: bytes values (undecoded text/number) would crash
+        # json.dumps with "Object of type bytes is not JSON serializable"
+        safe_data = {
+            k: (v.decode("utf-8", errors="replace") if isinstance(v, bytes) else v)
+            for k, v in sms_data.items()
+        }
+
         topic = f"{self.topic_prefix}/sms/state"
-        self.client.publish(topic, json.dumps(sms_data), qos=1, retain=True)
+        self.client.publish(topic, json.dumps(safe_data), qos=1, retain=True)
 
         # Fire Home Assistant event for reliable automation triggering
         self.fire_ha_event(sms_data)
 
         logger.info(
-            f"📡 Published SMS to MQTT: {sms_data.get('Number', 'Unknown')} -> {sms_data.get('Text', '')}"
+            f"📡 Published SMS to MQTT: {safe_data.get('Number', 'Unknown')} -> {safe_data.get('Text', '')}"
         )
 
     def fire_ha_event(self, sms_data: Dict[str, Any]):
@@ -4475,6 +4482,15 @@ class MQTTPublisher:
             # Process all unread SMS
             for sms in all_sms:
                 if sms.get("State") == "UnRead":
+                    # Skip incomplete multipart SMS — wait for all parts to arrive
+                    if not sms.get("Complete", True):
+                        logger.info(
+                            f"⏳ Incomplete multipart SMS from {sms.get('Number', 'Unknown')} "
+                            f"({sms.get('PartsReceived')}/{sms.get('PartsExpected')} parts) "
+                            f"- waiting for the rest"
+                        )
+                        continue
+
                     sms_copy = sms.copy()
                     sms_copy.pop("Locations", None)
 

--- a/addon-test-current/mqtt_publisher.py
+++ b/addon-test-current/mqtt_publisher.py
@@ -2700,6 +2700,12 @@ class MQTTPublisher:
         if not self.connected:
             return
 
+        # Sanitize early: bytes values (undecoded text/number) would crash
+        # json.dumps and break string operations like keyword matching.
+        for k, v in sms_data.items():
+            if isinstance(v, bytes):
+                sms_data[k] = v.decode("utf-8", errors="replace")
+
         # Add timestamp
         timestamp = time.strftime("%Y-%m-%d %H:%M:%S")
         sms_data["timestamp"] = timestamp
@@ -2737,21 +2743,14 @@ class MQTTPublisher:
         # Include history in published data
         sms_data["history"] = self.sms_history.get_history()
 
-        # Sanitize: bytes values (undecoded text/number) would crash
-        # json.dumps with "Object of type bytes is not JSON serializable"
-        safe_data = {
-            k: (v.decode("utf-8", errors="replace") if isinstance(v, bytes) else v)
-            for k, v in sms_data.items()
-        }
-
         topic = f"{self.topic_prefix}/sms/state"
-        self.client.publish(topic, json.dumps(safe_data), qos=1, retain=True)
+        self.client.publish(topic, json.dumps(sms_data), qos=1, retain=True)
 
         # Fire Home Assistant event for reliable automation triggering
-        self.fire_ha_event(safe_data)
+        self.fire_ha_event(sms_data)
 
         logger.info(
-            f"📡 Published SMS to MQTT: {safe_data.get('Number', 'Unknown')} -> {safe_data.get('Text', '')}"
+            f"📡 Published SMS to MQTT: {sms_data.get('Number', 'Unknown')} -> {sms_data.get('Text', '')}"
         )
 
     def fire_ha_event(self, sms_data: Dict[str, Any]):

--- a/addon-test-current/support.py
+++ b/addon-test-current/support.py
@@ -113,11 +113,26 @@ def retrieveAllSms(machine):
         for sms in allSms:
             smsPart = sms[0]
 
+            # Multipart completeness check: each part carries UDH info with
+            # AllParts = total expected parts.  If not all parts have arrived
+            # yet, mark the message as incomplete so callers can decide to
+            # wait rather than publishing/deleting a truncated message.
+            all_parts = 0
+            for part in sms:
+                udh = part.get("UDH") or {}
+                part_total = udh.get("AllParts", 0) or 0
+                if part_total > all_parts:
+                    all_parts = part_total
+            complete = (all_parts <= 1) or (len(sms) >= all_parts)
+
             result = {
                 "Date": str(smsPart["DateTime"]),
                 "Number": smsPart["Number"],
                 "State": smsPart["State"],
                 "Locations": [smsPart["Location"] for smsPart in sms],
+                "Complete": complete,
+                "PartsReceived": len(sms),
+                "PartsExpected": all_parts if all_parts > 1 else 1,
             }
 
             # Try to decode SMS - this may fail for MMS notifications or corrupted messages


### PR DESCRIPTION
## Summary

Partial fix for #111 — multipart SMS safety checks for the callback processing path.

### Changes

**`support.py`** (both addons):
- Added `Complete`, `PartsReceived`, `PartsExpected` fields to the dict returned by `retrieveAllSms()`
- Uses UDH `AllParts` info from `gammu.LinkSMS()` to determine if all parts have arrived

**`mqtt_publisher.py`** (both addons):
- `_process_sms_from_callback()`: Skip incomplete multipart SMS instead of publishing truncated text and deleting parts
- `publish_sms_received()`: Sanitize `bytes` values before `json.dumps()` to prevent `TypeError: Object of type bytes is not JSON serializable` crashes

### What this does NOT fix (yet)

The `_sms_monitor_loop()` polling path has a counter-based SMS detection mechanism that needs a different approach. That will be addressed in a follow-up PR.

### Risk

**Low** — all changes are additive/defensive:
- `Complete` defaults to `True` if missing, so single-part SMS behavior is unchanged
- Bytes sanitization only triggers on actual `bytes` objects (no-op for normal strings)
- No config changes, no new options, no schema changes