### PR TITLE
fix: handle incomplete multipart SMS in monitor loop

### DIFF
--- a/addon-gsm-gateway/mqtt_publisher.py
+++ b/addon-gsm-gateway/mqtt_publisher.py
@@ -4211,6 +4211,7 @@ class MQTTPublisher:
                     # Re-check previously incomplete multipart SMS for completeness.
                     # Parts may arrive between polls without changing len(all_sms).
                     just_completed_keys = set()
+                    recheck_deleted = 0
                     if pending_incomplete and all_sms:
                         for sms in all_sms:
                             key = (sms.get("Number"), sms.get("Date"))
@@ -4234,6 +4235,7 @@ class MQTTPublisher:
                                             self.gammu_machine,
                                             sms,
                                         )
+                                        recheck_deleted += 1
                                         logger.info(
                                             f"🗑️ Auto-deleted completed multipart SMS from {sms.get('Number', 'Unknown')}"
                                         )
@@ -4242,18 +4244,47 @@ class MQTTPublisher:
                                             f"Error auto-deleting completed multipart SMS: {e}"
                                         )
 
+                    # After re-check deletes, current_count is stale (based on
+                    # pre-delete all_sms snapshot). Refresh from modem so
+                    # last_sms_count is set correctly at end of this cycle.
+                    if recheck_deleted > 0:
+                        try:
+                            capacity = self.track_gammu_operation(
+                                "GetSMSStatus",
+                                self.gammu_machine.GetSMSStatus,
+                            )
+                            current_count = capacity.get("SIMUsed", 0) + capacity.get(
+                                "PhoneUsed", 0
+                            )
+                            self.publish_sms_capacity(capacity)
+                            logger.info(
+                                f"📡 Refreshed SMS count after re-check delete: {current_count}"
+                            )
+                        except Exception as e:
+                            logger.warning(
+                                f"Could not refresh SMS count after re-check delete: {e}"
+                            )
+
                     # Clean up stale entries for SMS no longer on the modem
                     # (e.g., externally deleted, SIM cleared, modem reset)
-                    if pending_incomplete and all_sms:
-                        current_keys = {
-                            (s.get("Number"), s.get("Date")) for s in all_sms
-                        }
-                        stale = [k for k in pending_incomplete if k not in current_keys]
-                        for k in stale:
-                            pending_incomplete.pop(k)
+                    if pending_incomplete:
+                        if not all_sms:
+                            pending_incomplete.clear()
                             logger.debug(
-                                f"🧹 Cleared stale pending multipart entry: {k[0]}"
+                                "🧹 Modem empty; cleared all pending multipart entries"
                             )
+                        else:
+                            current_keys = {
+                                (s.get("Number"), s.get("Date")) for s in all_sms
+                            }
+                            stale = [
+                                k for k in pending_incomplete if k not in current_keys
+                            ]
+                            for k in stale:
+                                pending_incomplete.pop(k)
+                                logger.debug(
+                                    f"🧹 Cleared stale pending multipart entry: {k[0]}"
+                                )
 
                     if first_run:
                         # On first run, publish only unread SMS and process delivery reports

--- a/addon-gsm-gateway/mqtt_publisher.py
+++ b/addon-gsm-gateway/mqtt_publisher.py
@@ -4294,6 +4294,20 @@ class MQTTPublisher:
 
                             # Publish unread regular SMS
                             if sms.get("State") == "UnRead":
+                                # Skip incomplete multipart SMS — track and wait
+                                if not sms.get("Complete", True):
+                                    key = (sms.get("Number"), sms.get("Date"))
+                                    pending_incomplete[key] = sms.get(
+                                        "PartsReceived", 1
+                                    )
+                                    logger.info(
+                                        f"⏳ Incomplete multipart SMS from "
+                                        f"{sms.get('Number', 'Unknown')} "
+                                        f"({sms.get('PartsReceived')}/{sms.get('PartsExpected')} parts) "
+                                        f"- waiting for the rest"
+                                    )
+                                    continue
+
                                 sms_copy = sms.copy()
                                 sms_copy.pop("Locations", None)
                                 self.publish_sms_received(sms_copy)

--- a/addon-gsm-gateway/mqtt_publisher.py
+++ b/addon-gsm-gateway/mqtt_publisher.py
@@ -4211,7 +4211,6 @@ class MQTTPublisher:
                     # Re-check previously incomplete multipart SMS for completeness.
                     # Parts may arrive between polls without changing len(all_sms).
                     just_completed_keys = set()
-                    recheck_deleted = 0
                     if pending_incomplete and all_sms:
                         for sms in all_sms:
                             key = (sms.get("Number"), sms.get("Date"))
@@ -4235,7 +4234,6 @@ class MQTTPublisher:
                                             self.gammu_machine,
                                             sms,
                                         )
-                                        recheck_deleted += 1
                                         logger.info(
                                             f"🗑️ Auto-deleted completed multipart SMS from {sms.get('Number', 'Unknown')}"
                                         )
@@ -4243,9 +4241,6 @@ class MQTTPublisher:
                                         logger.error(
                                             f"Error auto-deleting completed multipart SMS: {e}"
                                         )
-                    # Adjust count so last_sms_count stays in sync after
-                    # deleting completed multipart SMS from the modem.
-                    current_count -= recheck_deleted
 
                     # Clean up stale entries for SMS no longer on the modem
                     # (e.g., externally deleted, SIM cleared, modem reset)

--- a/addon-gsm-gateway/mqtt_publisher.py
+++ b/addon-gsm-gateway/mqtt_publisher.py
@@ -4211,6 +4211,7 @@ class MQTTPublisher:
                     # Re-check previously incomplete multipart SMS for completeness.
                     # Parts may arrive between polls without changing len(all_sms).
                     just_completed_keys = set()
+                    recheck_deleted = 0
                     if pending_incomplete and all_sms:
                         for sms in all_sms:
                             key = (sms.get("Number"), sms.get("Date"))
@@ -4234,6 +4235,7 @@ class MQTTPublisher:
                                             self.gammu_machine,
                                             sms,
                                         )
+                                        recheck_deleted += 1
                                         logger.info(
                                             f"🗑️ Auto-deleted completed multipart SMS from {sms.get('Number', 'Unknown')}"
                                         )
@@ -4241,6 +4243,9 @@ class MQTTPublisher:
                                         logger.error(
                                             f"Error auto-deleting completed multipart SMS: {e}"
                                         )
+                    # Adjust count so last_sms_count stays in sync after
+                    # deleting completed multipart SMS from the modem.
+                    current_count -= recheck_deleted
 
                     if first_run:
                         # On first run, publish only unread SMS and process delivery reports

--- a/addon-gsm-gateway/mqtt_publisher.py
+++ b/addon-gsm-gateway/mqtt_publisher.py
@@ -4214,10 +4214,7 @@ class MQTTPublisher:
                     if pending_incomplete and all_sms:
                         for sms in all_sms:
                             key = (sms.get("Number"), sms.get("Date"))
-                            if (
-                                key in pending_incomplete
-                                and sms.get("Complete", True)
-                            ):
+                            if key in pending_incomplete and sms.get("Complete", True):
                                 # Previously incomplete, now all parts arrived
                                 pending_incomplete.pop(key, None)
                                 just_completed_keys.add(key)

--- a/addon-gsm-gateway/mqtt_publisher.py
+++ b/addon-gsm-gateway/mqtt_publisher.py
@@ -4089,6 +4089,9 @@ class MQTTPublisher:
             # Initial setup: Get all SMS and publish only unread ones
             last_sms_count = 0
             first_run = True
+            # Track incomplete multipart SMS waiting for remaining parts.
+            # Key: (Number, Date) tuple, Value: parts seen so far.
+            pending_incomplete = {}
 
             while self.connected and not self.disconnecting:
                 from support import deleteSms, retrieveAllSms
@@ -4205,6 +4208,43 @@ class MQTTPublisher:
                     continue
 
                 try:
+                    # Re-check previously incomplete multipart SMS for completeness.
+                    # Parts may arrive between polls without changing len(all_sms).
+                    just_completed_keys = set()
+                    if pending_incomplete and all_sms:
+                        for sms in all_sms:
+                            key = (sms.get("Number"), sms.get("Date"))
+                            if (
+                                key in pending_incomplete
+                                and sms.get("Complete", True)
+                            ):
+                                # Previously incomplete, now all parts arrived
+                                pending_incomplete.pop(key, None)
+                                just_completed_keys.add(key)
+                                sms_copy = sms.copy()
+                                sms_copy.pop("Locations", None)
+                                self.publish_sms_received(sms_copy)
+                                logger.info(
+                                    f"✅ Multipart SMS from {sms.get('Number', 'Unknown')} "
+                                    f"now complete ({sms.get('PartsExpected', '?')} parts), published"
+                                )
+                                # Auto-delete if enabled
+                                if self.config.get("auto_delete_read_sms", False):
+                                    try:
+                                        self.track_gammu_operation(
+                                            "deleteSms",
+                                            deleteSms,
+                                            self.gammu_machine,
+                                            sms,
+                                        )
+                                        logger.info(
+                                            f"🗑️ Auto-deleted completed multipart SMS from {sms.get('Number', 'Unknown')}"
+                                        )
+                                    except Exception as e:
+                                        logger.error(
+                                            f"Error auto-deleting completed multipart SMS: {e}"
+                                        )
+
                     if first_run:
                         # On first run, publish only unread SMS and process delivery reports
                         logger.info(
@@ -4349,6 +4389,29 @@ class MQTTPublisher:
                                                 f"Error deleting delivery report: {e}"
                                             )
                                         continue  # Skip regular SMS processing
+
+                                # Skip incomplete multipart SMS — track and wait
+                                if not all_sms[i].get("Complete", True):
+                                    key = (
+                                        all_sms[i].get("Number"),
+                                        all_sms[i].get("Date"),
+                                    )
+                                    if key not in just_completed_keys:
+                                        pending_incomplete[key] = all_sms[i].get(
+                                            "PartsReceived", 1
+                                        )
+                                        logger.info(
+                                            f"⏳ Incomplete multipart SMS from "
+                                            f"{all_sms[i].get('Number', 'Unknown')} "
+                                            f"({all_sms[i].get('PartsReceived')}/{all_sms[i].get('PartsExpected')} parts) "
+                                            f"- waiting for the rest"
+                                        )
+                                    continue
+
+                                # Skip if already published via re-check above
+                                key = (sms.get("Number"), sms.get("Date"))
+                                if key in just_completed_keys:
+                                    continue
 
                                 # Publish regular SMS to MQTT
                                 self.publish_sms_received(sms)

--- a/addon-gsm-gateway/mqtt_publisher.py
+++ b/addon-gsm-gateway/mqtt_publisher.py
@@ -4157,6 +4157,9 @@ class MQTTPublisher:
                         "retrieveAllSms", retrieveAllSms, self.gammu_machine
                     )
                     current_count = len(all_sms)
+                    # snapshot_count: index bound for iterating all_sms (never
+                    # changes even if current_count is refreshed after deletes).
+                    snapshot_count = current_count
                     # Only log routine polling in debug mode to reduce log spam
                     if self.log_level == "debug":
                         logger.info(
@@ -4261,6 +4264,8 @@ class MQTTPublisher:
                                 f"📡 Refreshed SMS count after re-check delete: {current_count}"
                             )
                         except Exception as e:
+                            # Best-effort fallback: subtract deleted count
+                            current_count = max(0, current_count - recheck_deleted)
                             logger.warning(
                                 f"Could not refresh SMS count after re-check delete: {e}"
                             )
@@ -4388,17 +4393,17 @@ class MQTTPublisher:
 
                         last_sms_count = current_count
                         first_run = False
-                    elif current_count > last_sms_count:
+                    elif snapshot_count > last_sms_count:
                         # On subsequent runs, publish all new SMS
                         logger.info(
-                            f"📱 Detected {current_count - last_sms_count} new SMS messages"
+                            f"📱 Detected {snapshot_count - last_sms_count} new SMS messages"
                         )
 
                         deleted_count = 0
                         auto_delete = self.config.get("auto_delete_read_sms", False)
 
                         # Process new SMS (from the end, newest first)
-                        for i in range(last_sms_count, current_count):
+                        for i in range(last_sms_count, snapshot_count):
                             if i < len(all_sms):
                                 sms = all_sms[i].copy()
                                 sms.pop("Locations", None)

--- a/addon-gsm-gateway/mqtt_publisher.py
+++ b/addon-gsm-gateway/mqtt_publisher.py
@@ -4247,6 +4247,19 @@ class MQTTPublisher:
                     # deleting completed multipart SMS from the modem.
                     current_count -= recheck_deleted
 
+                    # Clean up stale entries for SMS no longer on the modem
+                    # (e.g., externally deleted, SIM cleared, modem reset)
+                    if pending_incomplete and all_sms:
+                        current_keys = {
+                            (s.get("Number"), s.get("Date")) for s in all_sms
+                        }
+                        stale = [k for k in pending_incomplete if k not in current_keys]
+                        for k in stale:
+                            pending_incomplete.pop(k)
+                            logger.debug(
+                                f"🧹 Cleared stale pending multipart entry: {k[0]}"
+                            )
+
                     if first_run:
                         # On first run, publish only unread SMS and process delivery reports
                         logger.info(

--- a/addon-test-current/mqtt_publisher.py
+++ b/addon-test-current/mqtt_publisher.py
@@ -3789,6 +3789,9 @@ class MQTTPublisher:
                         "retrieveAllSms", retrieveAllSms, self.gammu_machine
                     )
                     current_count = len(all_sms)
+                    # snapshot_count: index bound for iterating all_sms (never
+                    # changes even if current_count is refreshed after deletes).
+                    snapshot_count = current_count
                     # Only log routine polling in debug mode to reduce log spam
                     if self.log_level == "debug":
                         logger.info(
@@ -3893,6 +3896,8 @@ class MQTTPublisher:
                                 f"📡 Refreshed SMS count after re-check delete: {current_count}"
                             )
                         except Exception as e:
+                            # Best-effort fallback: subtract deleted count
+                            current_count = max(0, current_count - recheck_deleted)
                             logger.warning(
                                 f"Could not refresh SMS count after re-check delete: {e}"
                             )
@@ -4020,17 +4025,17 @@ class MQTTPublisher:
 
                         last_sms_count = current_count
                         first_run = False
-                    elif current_count > last_sms_count:
+                    elif snapshot_count > last_sms_count:
                         # On subsequent runs, publish all new SMS
                         logger.info(
-                            f"📱 Detected {current_count - last_sms_count} new SMS messages"
+                            f"📱 Detected {snapshot_count - last_sms_count} new SMS messages"
                         )
 
                         deleted_count = 0
                         auto_delete = self.config.get("auto_delete_read_sms", False)
 
                         # Process new SMS (from the end, newest first)
-                        for i in range(last_sms_count, current_count):
+                        for i in range(last_sms_count, snapshot_count):
                             if i < len(all_sms):
                                 sms = all_sms[i].copy()
                                 sms.pop("Locations", None)

--- a/addon-test-current/mqtt_publisher.py
+++ b/addon-test-current/mqtt_publisher.py
@@ -3843,7 +3843,6 @@ class MQTTPublisher:
                     # Re-check previously incomplete multipart SMS for completeness.
                     # Parts may arrive between polls without changing len(all_sms).
                     just_completed_keys = set()
-                    recheck_deleted = 0
                     if pending_incomplete and all_sms:
                         for sms in all_sms:
                             key = (sms.get("Number"), sms.get("Date"))
@@ -3867,7 +3866,6 @@ class MQTTPublisher:
                                             self.gammu_machine,
                                             sms,
                                         )
-                                        recheck_deleted += 1
                                         logger.info(
                                             f"🗑️ Auto-deleted completed multipart SMS from {sms.get('Number', 'Unknown')}"
                                         )
@@ -3875,9 +3873,6 @@ class MQTTPublisher:
                                         logger.error(
                                             f"Error auto-deleting completed multipart SMS: {e}"
                                         )
-                    # Adjust count so last_sms_count stays in sync after
-                    # deleting completed multipart SMS from the modem.
-                    current_count -= recheck_deleted
 
                     # Clean up stale entries for SMS no longer on the modem
                     # (e.g., externally deleted, SIM cleared, modem reset)

--- a/addon-test-current/mqtt_publisher.py
+++ b/addon-test-current/mqtt_publisher.py
@@ -3846,10 +3846,7 @@ class MQTTPublisher:
                     if pending_incomplete and all_sms:
                         for sms in all_sms:
                             key = (sms.get("Number"), sms.get("Date"))
-                            if (
-                                key in pending_incomplete
-                                and sms.get("Complete", True)
-                            ):
+                            if key in pending_incomplete and sms.get("Complete", True):
                                 # Previously incomplete, now all parts arrived
                                 pending_incomplete.pop(key, None)
                                 just_completed_keys.add(key)

--- a/addon-test-current/mqtt_publisher.py
+++ b/addon-test-current/mqtt_publisher.py
@@ -3843,6 +3843,7 @@ class MQTTPublisher:
                     # Re-check previously incomplete multipart SMS for completeness.
                     # Parts may arrive between polls without changing len(all_sms).
                     just_completed_keys = set()
+                    recheck_deleted = 0
                     if pending_incomplete and all_sms:
                         for sms in all_sms:
                             key = (sms.get("Number"), sms.get("Date"))
@@ -3866,6 +3867,7 @@ class MQTTPublisher:
                                             self.gammu_machine,
                                             sms,
                                         )
+                                        recheck_deleted += 1
                                         logger.info(
                                             f"🗑️ Auto-deleted completed multipart SMS from {sms.get('Number', 'Unknown')}"
                                         )
@@ -3874,18 +3876,47 @@ class MQTTPublisher:
                                             f"Error auto-deleting completed multipart SMS: {e}"
                                         )
 
+                    # After re-check deletes, current_count is stale (based on
+                    # pre-delete all_sms snapshot). Refresh from modem so
+                    # last_sms_count is set correctly at end of this cycle.
+                    if recheck_deleted > 0:
+                        try:
+                            capacity = self.track_gammu_operation(
+                                "GetSMSStatus",
+                                self.gammu_machine.GetSMSStatus,
+                            )
+                            current_count = capacity.get("SIMUsed", 0) + capacity.get(
+                                "PhoneUsed", 0
+                            )
+                            self.publish_sms_capacity(capacity)
+                            logger.info(
+                                f"📡 Refreshed SMS count after re-check delete: {current_count}"
+                            )
+                        except Exception as e:
+                            logger.warning(
+                                f"Could not refresh SMS count after re-check delete: {e}"
+                            )
+
                     # Clean up stale entries for SMS no longer on the modem
                     # (e.g., externally deleted, SIM cleared, modem reset)
-                    if pending_incomplete and all_sms:
-                        current_keys = {
-                            (s.get("Number"), s.get("Date")) for s in all_sms
-                        }
-                        stale = [k for k in pending_incomplete if k not in current_keys]
-                        for k in stale:
-                            pending_incomplete.pop(k)
+                    if pending_incomplete:
+                        if not all_sms:
+                            pending_incomplete.clear()
                             logger.debug(
-                                f"🧹 Cleared stale pending multipart entry: {k[0]}"
+                                "🧹 Modem empty; cleared all pending multipart entries"
                             )
+                        else:
+                            current_keys = {
+                                (s.get("Number"), s.get("Date")) for s in all_sms
+                            }
+                            stale = [
+                                k for k in pending_incomplete if k not in current_keys
+                            ]
+                            for k in stale:
+                                pending_incomplete.pop(k)
+                                logger.debug(
+                                    f"🧹 Cleared stale pending multipart entry: {k[0]}"
+                                )
 
                     if first_run:
                         # On first run, publish only unread SMS and process delivery reports

--- a/addon-test-current/mqtt_publisher.py
+++ b/addon-test-current/mqtt_publisher.py
@@ -3721,6 +3721,9 @@ class MQTTPublisher:
             # Initial setup: Get all SMS and publish only unread ones
             last_sms_count = 0
             first_run = True
+            # Track incomplete multipart SMS waiting for remaining parts.
+            # Key: (Number, Date) tuple, Value: parts seen so far.
+            pending_incomplete = {}
 
             while self.connected and not self.disconnecting:
                 from support import deleteSms, retrieveAllSms
@@ -3837,6 +3840,43 @@ class MQTTPublisher:
                     continue
 
                 try:
+                    # Re-check previously incomplete multipart SMS for completeness.
+                    # Parts may arrive between polls without changing len(all_sms).
+                    just_completed_keys = set()
+                    if pending_incomplete and all_sms:
+                        for sms in all_sms:
+                            key = (sms.get("Number"), sms.get("Date"))
+                            if (
+                                key in pending_incomplete
+                                and sms.get("Complete", True)
+                            ):
+                                # Previously incomplete, now all parts arrived
+                                pending_incomplete.pop(key, None)
+                                just_completed_keys.add(key)
+                                sms_copy = sms.copy()
+                                sms_copy.pop("Locations", None)
+                                self.publish_sms_received(sms_copy)
+                                logger.info(
+                                    f"✅ Multipart SMS from {sms.get('Number', 'Unknown')} "
+                                    f"now complete ({sms.get('PartsExpected', '?')} parts), published"
+                                )
+                                # Auto-delete if enabled
+                                if self.config.get("auto_delete_read_sms", False):
+                                    try:
+                                        self.track_gammu_operation(
+                                            "deleteSms",
+                                            deleteSms,
+                                            self.gammu_machine,
+                                            sms,
+                                        )
+                                        logger.info(
+                                            f"🗑️ Auto-deleted completed multipart SMS from {sms.get('Number', 'Unknown')}"
+                                        )
+                                    except Exception as e:
+                                        logger.error(
+                                            f"Error auto-deleting completed multipart SMS: {e}"
+                                        )
+
                     if first_run:
                         # On first run, publish only unread SMS and process delivery reports
                         logger.info(
@@ -3981,6 +4021,29 @@ class MQTTPublisher:
                                                 f"Error deleting delivery report: {e}"
                                             )
                                         continue  # Skip regular SMS processing
+
+                                # Skip incomplete multipart SMS — track and wait
+                                if not all_sms[i].get("Complete", True):
+                                    key = (
+                                        all_sms[i].get("Number"),
+                                        all_sms[i].get("Date"),
+                                    )
+                                    if key not in just_completed_keys:
+                                        pending_incomplete[key] = all_sms[i].get(
+                                            "PartsReceived", 1
+                                        )
+                                        logger.info(
+                                            f"⏳ Incomplete multipart SMS from "
+                                            f"{all_sms[i].get('Number', 'Unknown')} "
+                                            f"({all_sms[i].get('PartsReceived')}/{all_sms[i].get('PartsExpected')} parts) "
+                                            f"- waiting for the rest"
+                                        )
+                                    continue
+
+                                # Skip if already published via re-check above
+                                key = (sms.get("Number"), sms.get("Date"))
+                                if key in just_completed_keys:
+                                    continue
 
                                 # Publish regular SMS to MQTT
                                 self.publish_sms_received(sms)

--- a/addon-test-current/mqtt_publisher.py
+++ b/addon-test-current/mqtt_publisher.py
@@ -3843,6 +3843,7 @@ class MQTTPublisher:
                     # Re-check previously incomplete multipart SMS for completeness.
                     # Parts may arrive between polls without changing len(all_sms).
                     just_completed_keys = set()
+                    recheck_deleted = 0
                     if pending_incomplete and all_sms:
                         for sms in all_sms:
                             key = (sms.get("Number"), sms.get("Date"))
@@ -3866,6 +3867,7 @@ class MQTTPublisher:
                                             self.gammu_machine,
                                             sms,
                                         )
+                                        recheck_deleted += 1
                                         logger.info(
                                             f"🗑️ Auto-deleted completed multipart SMS from {sms.get('Number', 'Unknown')}"
                                         )
@@ -3873,6 +3875,9 @@ class MQTTPublisher:
                                         logger.error(
                                             f"Error auto-deleting completed multipart SMS: {e}"
                                         )
+                    # Adjust count so last_sms_count stays in sync after
+                    # deleting completed multipart SMS from the modem.
+                    current_count -= recheck_deleted
 
                     if first_run:
                         # On first run, publish only unread SMS and process delivery reports

--- a/addon-test-current/mqtt_publisher.py
+++ b/addon-test-current/mqtt_publisher.py
@@ -3926,6 +3926,20 @@ class MQTTPublisher:
 
                             # Publish unread regular SMS
                             if sms.get("State") == "UnRead":
+                                # Skip incomplete multipart SMS — track and wait
+                                if not sms.get("Complete", True):
+                                    key = (sms.get("Number"), sms.get("Date"))
+                                    pending_incomplete[key] = sms.get(
+                                        "PartsReceived", 1
+                                    )
+                                    logger.info(
+                                        f"⏳ Incomplete multipart SMS from "
+                                        f"{sms.get('Number', 'Unknown')} "
+                                        f"({sms.get('PartsReceived')}/{sms.get('PartsExpected')} parts) "
+                                        f"- waiting for the rest"
+                                    )
+                                    continue
+
                                 sms_copy = sms.copy()
                                 sms_copy.pop("Locations", None)
                                 self.publish_sms_received(sms_copy)

--- a/addon-test-current/mqtt_publisher.py
+++ b/addon-test-current/mqtt_publisher.py
@@ -3879,6 +3879,19 @@ class MQTTPublisher:
                     # deleting completed multipart SMS from the modem.
                     current_count -= recheck_deleted
 
+                    # Clean up stale entries for SMS no longer on the modem
+                    # (e.g., externally deleted, SIM cleared, modem reset)
+                    if pending_incomplete and all_sms:
+                        current_keys = {
+                            (s.get("Number"), s.get("Date")) for s in all_sms
+                        }
+                        stale = [k for k in pending_incomplete if k not in current_keys]
+                        for k in stale:
+                            pending_incomplete.pop(k)
+                            logger.debug(
+                                f"🧹 Cleared stale pending multipart entry: {k[0]}"
+                            )
+
                     if first_run:
                         # On first run, publish only unread SMS and process delivery reports
                         logger.info(


### PR DESCRIPTION
## Summary

Related to #111 — adds multipart SMS assembly logic to prevent publishing truncated fragments.

### Problem

When a long SMS arrives as multiple parts (e.g., 4 parts), each part may arrive between poll cycles. The monitor loop's counter-based detection (`current_count > last_sms_count`) cannot detect when parts complete because `gammu.LinkSMS()` links them into the same group — `len(all_sms)` stays constant as new parts arrive.

Result: each part was published as a separate truncated message, then auto-deleted, making reassembly impossible.

### Solution

- **Track incomplete SMS** in a `pending_incomplete` dict keyed by `(Number, Date)`
- **Skip** incomplete multipart SMS instead of publishing truncated text
- **Re-check** pending incomplete SMS each poll cycle for newly arrived parts
- **Publish** once all parts have arrived, then optionally auto-delete
- **Clean up** stale entries when SMS disappears from the modem

### How it works

```
Poll 1: Part 1/3 arrives → incomplete → tracked in pending_incomplete, skipped
Poll 2: Part 2/3 arrives → re-check finds 2/3 → still incomplete → skip
Poll 3: Part 3/3 arrives → re-check finds 3/3 → complete! → publish full message
```

### Risk

**Medium** — this modifies the SMS monitoring loop which is the primary SMS processing path. However:
- Single-part SMS (the common case) are unaffected — `Complete` defaults to `True`
- The counter-based detection logic is unchanged — we only add checks around it
- Auto-delete behavior is preserved for complete messages
- Builds on the `Complete`/`PartsReceived`/`PartsExpected` fields added in PR #116

### Files changed

- `addon-gsm-gateway/mqtt_publisher.py` — monitor loop multipart handling
- `addon-test-current/mqtt_publisher.py` — same changes