### PR TITLE
feat: add multipart SMS timeout to unblock modem

### DIFF
--- a/addon-gsm-gateway/CHANGELOG.md
+++ b/addon-gsm-gateway/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## [2.20.0] - 2026-06-18
+
+### Added
+
+- **`multipart_timeout_seconds` option** (default: 30, range: 0–300)
+  - Publishes partial multipart SMS with `[partial X/Y]` prefix after timeout
+  - Auto-deletes timed-out parts from modem (if auto_delete_read_sms enabled)
+  - Unblocks modems that stop accepting new SMS while incomplete parts sit on the SIM
+  - Set to `0` to wait forever (previous behavior)
+
 ## [2.19.1] - 2026-06-18
 
 ### Fixed

--- a/addon-gsm-gateway/DOCS.md
+++ b/addon-gsm-gateway/DOCS.md
@@ -129,32 +129,33 @@ curl -X POST http://192.168.1.x:5000/sms \
 
 ### MQTT Settings
 
-| Parameter                | Default                            | Description                                                                    |
-| ------------------------ | ---------------------------------- | ------------------------------------------------------------------------------ |
-| `mqtt_enabled`           | `true`                             | Enable MQTT integration                                                        |
-| `mqtt_host`              | `core-mosquitto`                   | MQTT broker hostname                                                           |
-| `mqtt_port`              | `1883`                             | MQTT broker port                                                               |
-| `mqtt_username`          | `""`                               | MQTT username (empty for no auth)                                              |
-| `mqtt_password`          | `""`                               | MQTT password (empty for no auth)                                              |
-| `mqtt_topic_prefix`      | `homeassistant/sensor/sms_gateway` | MQTT topic prefix                                                              |
+| Parameter                | Default                            | Description                                                                                 |
+| ------------------------ | ---------------------------------- | ------------------------------------------------------------------------------------------- |
+| `mqtt_enabled`           | `true`                             | Enable MQTT integration                                                                     |
+| `mqtt_host`              | `core-mosquitto`                   | MQTT broker hostname                                                                        |
+| `mqtt_port`              | `1883`                             | MQTT broker port                                                                            |
+| `mqtt_username`          | `""`                               | MQTT username (empty for no auth)                                                           |
+| `mqtt_password`          | `""`                               | MQTT password (empty for no auth)                                                           |
+| `mqtt_topic_prefix`      | `homeassistant/sensor/sms_gateway` | MQTT topic prefix                                                                           |
 | `mqtt_device_id`         | `sms_gateway`                      | Device identifier for multi-instance support (lowercase, numbers, underscores) (🆕 v2.19.0) |
-| `sms_monitoring_enabled` | `true`                             | Detect incoming SMS automatically                                              |
-| `sms_check_interval`     | `5`                                | SMS check interval (5-300 seconds) (🆕 v2.1.8: min reduced to 5s)              |
-| `status_update_interval` | `300`                              | Status update interval (30-3600 seconds) - signal & network (🆕 v2.1.8)        |
+| `sms_monitoring_enabled` | `true`                             | Detect incoming SMS automatically                                                           |
+| `sms_check_interval`     | `5`                                | SMS check interval (5-300 seconds) (🆕 v2.1.8: min reduced to 5s)                           |
+| `status_update_interval` | `300`                              | Status update interval (30-3600 seconds) - signal & network (🆕 v2.1.8)                     |
 
 ### SMS Management Settings
 
-| Parameter                  | Default | Description                                                         |
-| -------------------------- | ------- | ------------------------------------------------------------------- |
-| `sms_cost_per_message`     | `0.0`   | Price per SMS (0 = cost tracking disabled)                          |
-| `sms_cost_currency`        | `USD`   | Currency code (EUR, USD, CZK, GBP, etc.)                            |
-| `auto_delete_read_sms`     | `true`  | Auto-delete SMS after reading (frees SIM space)                     |
-| `sms_history_max_messages` | `10`    | Number of SMS to keep in history (1-100) (🆕 v2.1.0)                |
-| `sms_delivery_reports`     | `false` | Enable SMS delivery reports - may incur carrier charges (🆕 v2.1.0) |
-| `log_level`                | `info`  | Logging level: `warning`, `info`, or `debug` (🆕 v2.1.8)            |
-| `auto_recovery`            | `true`  | Automatically recover from modem failures (🆕 v2.4.0)               |
-| `auto_restart_on_failure`  | `true`  | Auto-restart addon after 2 min of persistent failure (🆕 v2.10.0)   |
-| `modem_operation_delay`    | `0.3`   | Delay between modem commands in seconds (0.1-5.0) (🆕 v2.12.0)      |
+| Parameter                   | Default | Description                                                                                                     |
+| --------------------------- | ------- | --------------------------------------------------------------------------------------------------------------- |
+| `sms_cost_per_message`      | `0.0`   | Price per SMS (0 = cost tracking disabled)                                                                      |
+| `sms_cost_currency`         | `USD`   | Currency code (EUR, USD, CZK, GBP, etc.)                                                                        |
+| `auto_delete_read_sms`      | `true`  | Auto-delete SMS after reading (frees SIM space)                                                                 |
+| `sms_history_max_messages`  | `10`    | Number of SMS to keep in history (1-100) (🆕 v2.1.0)                                                            |
+| `sms_delivery_reports`      | `false` | Enable SMS delivery reports - may incur carrier charges (🆕 v2.1.0)                                             |
+| `multipart_timeout_seconds` | `30`    | Seconds to wait for remaining multipart SMS parts before publishing partial text; 0 = wait forever (🆕 v2.20.0) |
+| `log_level`                 | `info`  | Logging level: `warning`, `info`, or `debug` (🆕 v2.1.8)                                                        |
+| `auto_recovery`             | `true`  | Automatically recover from modem failures (🆕 v2.4.0)                                                           |
+| `auto_restart_on_failure`   | `true`  | Auto-restart addon after 2 min of persistent failure (🆕 v2.10.0)                                               |
+| `modem_operation_delay`     | `0.3`   | Delay between modem commands in seconds (0.1-5.0) (🆕 v2.12.0)                                                  |
 
 ### Logging Levels (🆕 v2.1.8, Enhanced v2.2.1)
 

--- a/addon-gsm-gateway/README.md
+++ b/addon-gsm-gateway/README.md
@@ -141,27 +141,28 @@ This add-on provides an enhanced SMS gateway solution for Home Assistant with ad
 
 ### MQTT Settings
 
-| Option              | Default                            | Description                                                                    |
-| ------------------- | ---------------------------------- | ------------------------------------------------------------------------------ |
-| `mqtt_enabled`      | `true`                             | Enable MQTT integration                                                        |
-| `mqtt_host`         | `core-mosquitto`                   | MQTT broker hostname                                                           |
-| `mqtt_port`         | `1883`                             | MQTT broker port                                                               |
-| `mqtt_username`     | `""`                               | MQTT username (if required)                                                    |
-| `mqtt_password`     | `""`                               | MQTT password (if required)                                                    |
-| `mqtt_topic_prefix` | `homeassistant/sensor/sms_gateway` | MQTT topic prefix                                                              |
+| Option              | Default                            | Description                                                                                 |
+| ------------------- | ---------------------------------- | ------------------------------------------------------------------------------------------- |
+| `mqtt_enabled`      | `true`                             | Enable MQTT integration                                                                     |
+| `mqtt_host`         | `core-mosquitto`                   | MQTT broker hostname                                                                        |
+| `mqtt_port`         | `1883`                             | MQTT broker port                                                                            |
+| `mqtt_username`     | `""`                               | MQTT username (if required)                                                                 |
+| `mqtt_password`     | `""`                               | MQTT password (if required)                                                                 |
+| `mqtt_topic_prefix` | `homeassistant/sensor/sms_gateway` | MQTT topic prefix                                                                           |
 | `mqtt_device_id`    | `sms_gateway`                      | Device identifier for multi-instance support (lowercase, numbers, underscores) (🆕 v2.19.0) |
 
 ### SMS Settings
 
-| Option                     | Default | Description                                             |
-| -------------------------- | ------- | ------------------------------------------------------- |
-| `sms_monitoring_enabled`   | `true`  | Enable SMS monitoring                                   |
-| `sms_check_interval`       | `10`    | Check for new SMS every X seconds                       |
-| `auto_delete_read_sms`     | `true`  | Auto-delete SMS after reading                           |
-| `sms_history_max_messages` | `10`    | Number of SMS to keep in history (1-100)                |
-| `sms_delivery_reports`     | `false` | Enable SMS delivery reports (may incur carrier charges) |
-| `sms_cost_per_message`     | `0.0`   | Cost per SMS (0 = disabled)                             |
-| `sms_cost_currency`        | `USD`   | Currency for cost tracking                              |
+| Option                      | Default | Description                                             |
+| --------------------------- | ------- | ------------------------------------------------------- |
+| `sms_monitoring_enabled`    | `true`  | Enable SMS monitoring                                   |
+| `sms_check_interval`        | `10`    | Check for new SMS every X seconds                       |
+| `auto_delete_read_sms`      | `true`  | Auto-delete SMS after reading                           |
+| `sms_history_max_messages`  | `10`    | Number of SMS to keep in history (1-100)                |
+| `sms_delivery_reports`      | `false` | Enable SMS delivery reports (may incur carrier charges) |
+| `multipart_timeout_seconds` | `30`    | Timeout for incomplete multipart SMS (0 = wait forever) |
+| `sms_cost_per_message`      | `0.0`   | Cost per SMS (0 = disabled)                             |
+| `sms_cost_currency`         | `USD`   | Currency for cost tracking                              |
 
 ### Device Path Options
 

--- a/addon-gsm-gateway/config.yaml
+++ b/addon-gsm-gateway/config.yaml
@@ -1,5 +1,5 @@
 name: "GSM SMS Gateway Enhanced"
-version: 2.19.1
+version: 2.20.0
 slug: "gsm_sms_gateway_enhanced"
 description: |
   Enhanced SMS Gammu Gateway with network provider lookup, comprehensive diagnostics, and SMS-based balance tracking. 

--- a/addon-gsm-gateway/config.yaml
+++ b/addon-gsm-gateway/config.yaml
@@ -76,6 +76,7 @@ options:
   auto_delete_read_sms: true
   sms_history_max_messages: 10
   sms_delivery_reports: false
+  multipart_timeout_seconds: 30
   log_level: "info"
   auto_recovery: true
   auto_restart_on_failure: true
@@ -121,6 +122,7 @@ schema:
   auto_delete_read_sms: bool
   sms_history_max_messages: int(1,100)
   sms_delivery_reports: bool
+  multipart_timeout_seconds: int(0,300)
   log_level: list(warning|info|debug)
   auto_recovery: bool
   auto_restart_on_failure: bool

--- a/addon-gsm-gateway/mqtt_publisher.py
+++ b/addon-gsm-gateway/mqtt_publisher.py
@@ -4090,8 +4090,10 @@ class MQTTPublisher:
             last_sms_count = 0
             first_run = True
             # Track incomplete multipart SMS waiting for remaining parts.
-            # Key: (Number, Date) tuple, Value: parts seen so far.
+            # Key: (Number, Date) tuple
+            # Value: {"parts": count, "first_seen": time.time()}
             pending_incomplete = {}
+            multipart_timeout = int(self.config.get("multipart_timeout_seconds", 30))
 
             while self.connected and not self.disconnecting:
                 from support import deleteSms, retrieveAllSms
@@ -4211,25 +4213,50 @@ class MQTTPublisher:
                     continue
 
                 try:
-                    # Re-check previously incomplete multipart SMS for completeness.
-                    # Parts may arrive between polls without changing len(all_sms).
+                    # Re-check previously incomplete multipart SMS for completeness
+                    # or timeout. Parts may arrive between polls without changing
+                    # len(all_sms).
                     just_completed_keys = set()
                     recheck_deleted = 0
                     if pending_incomplete and all_sms:
                         for sms in all_sms:
                             key = (sms.get("Number"), sms.get("Date"))
-                            if key in pending_incomplete and sms.get("Complete", True):
-                                # Previously incomplete, now all parts arrived
+                            if key not in pending_incomplete:
+                                continue
+
+                            now_complete = sms.get("Complete", True)
+                            elapsed = (
+                                time.time() - pending_incomplete[key]["first_seen"]
+                            )
+                            timed_out = (
+                                multipart_timeout > 0 and elapsed >= multipart_timeout
+                            )
+
+                            if now_complete or timed_out:
+                                # Publish: either all parts arrived, or timeout
                                 pending_incomplete.pop(key, None)
                                 just_completed_keys.add(key)
                                 sms_copy = sms.copy()
                                 sms_copy.pop("Locations", None)
+                                if timed_out and not now_complete:
+                                    sms_copy["Text"] = (
+                                        f"[partial {sms.get('PartsReceived', '?')}"
+                                        f"/{sms.get('PartsExpected', '?')}] "
+                                        + sms_copy.get("Text", "")
+                                    )
+                                    logger.warning(
+                                        f"⏰ Multipart SMS from {sms.get('Number', 'Unknown')} "
+                                        f"timed out after {int(elapsed)}s "
+                                        f"({sms.get('PartsReceived')}/{sms.get('PartsExpected')} parts) "
+                                        f"- publishing partial text"
+                                    )
+                                else:
+                                    logger.info(
+                                        f"✅ Multipart SMS from {sms.get('Number', 'Unknown')} "
+                                        f"now complete ({sms.get('PartsExpected', '?')} parts), published"
+                                    )
                                 self.publish_sms_received(sms_copy)
-                                logger.info(
-                                    f"✅ Multipart SMS from {sms.get('Number', 'Unknown')} "
-                                    f"now complete ({sms.get('PartsExpected', '?')} parts), published"
-                                )
-                                # Auto-delete if enabled
+                                # Auto-delete if enabled (frees modem for next delivery)
                                 if self.config.get("auto_delete_read_sms", False):
                                     try:
                                         self.track_gammu_operation(
@@ -4240,11 +4267,12 @@ class MQTTPublisher:
                                         )
                                         recheck_deleted += 1
                                         logger.info(
-                                            f"🗑️ Auto-deleted completed multipart SMS from {sms.get('Number', 'Unknown')}"
+                                            f"🗑️ Auto-deleted {'partial' if timed_out else 'completed'} "
+                                            f"multipart SMS from {sms.get('Number', 'Unknown')}"
                                         )
                                     except Exception as e:
                                         logger.error(
-                                            f"Error auto-deleting completed multipart SMS: {e}"
+                                            f"Error auto-deleting multipart SMS: {e}"
                                         )
 
                     # After re-check deletes, current_count is stale (based on
@@ -4341,9 +4369,10 @@ class MQTTPublisher:
                                 # Skip incomplete multipart SMS — track and wait
                                 if not sms.get("Complete", True):
                                     key = (sms.get("Number"), sms.get("Date"))
-                                    pending_incomplete[key] = sms.get(
-                                        "PartsReceived", 1
-                                    )
+                                    pending_incomplete[key] = {
+                                        "parts": sms.get("PartsReceived", 1),
+                                        "first_seen": time.time(),
+                                    }
                                     logger.info(
                                         f"⏳ Incomplete multipart SMS from "
                                         f"{sms.get('Number', 'Unknown')} "
@@ -4457,9 +4486,10 @@ class MQTTPublisher:
                                         all_sms[i].get("Date"),
                                     )
                                     if key not in just_completed_keys:
-                                        pending_incomplete[key] = all_sms[i].get(
-                                            "PartsReceived", 1
-                                        )
+                                        pending_incomplete[key] = {
+                                            "parts": all_sms[i].get("PartsReceived", 1),
+                                            "first_seen": time.time(),
+                                        }
                                         logger.info(
                                             f"⏳ Incomplete multipart SMS from "
                                             f"{all_sms[i].get('Number', 'Unknown')} "

--- a/addon-gsm-gateway/translations/cs.yaml
+++ b/addon-gsm-gateway/translations/cs.yaml
@@ -74,6 +74,9 @@ configuration:
   sms_delivery_reports:
     name: Povolit potvrzení o doručení
     description: Požadovat potvrzení o doručení pro odeslané SMS (může způsobit poplatky operátora)
+  multipart_timeout_seconds:
+    name: Multipart SMS Timeout
+    description: Seconds to wait for remaining parts of a multipart SMS before publishing partial text (0 = wait forever).
   balance_sms_enabled:
     name: Povolit analýzu SMS zůstatku
     description: Automaticky analyzovat informace o zůstatku účtu ze SMS poskytovatele

--- a/addon-gsm-gateway/translations/de.yaml
+++ b/addon-gsm-gateway/translations/de.yaml
@@ -74,6 +74,9 @@ configuration:
   sms_delivery_reports:
     name: SMS-Zustellberichte aktivieren
     description: Zustellberichte für gesendete SMS anfordern (kann Gebühren verursachen)
+  multipart_timeout_seconds:
+    name: Multipart SMS Timeout
+    description: Seconds to wait for remaining parts of a multipart SMS before publishing partial text (0 = wait forever).
   balance_sms_enabled:
     name: Balance SMS-Analyse aktivieren
     description: Kontoguthaben-Informationen aus Provider-SMS automatisch analysieren

--- a/addon-gsm-gateway/translations/en.yaml
+++ b/addon-gsm-gateway/translations/en.yaml
@@ -80,6 +80,9 @@ configuration:
   sms_delivery_reports:
     name: Enable SMS Delivery Reports
     description: Request delivery reports for sent SMS (may incur carrier charges)
+  multipart_timeout_seconds:
+    name: Multipart SMS Timeout
+    description: Seconds to wait for remaining parts of a multipart SMS before publishing partial text (0 = wait forever). Helps with modems that stop delivering parts when unread SMS sit on the SIM.
   balance_sms_enabled:
     name: Enable Balance SMS Parsing
     description: Automatically parse account balance information from provider SMS messages

--- a/addon-gsm-gateway/translations/es.yaml
+++ b/addon-gsm-gateway/translations/es.yaml
@@ -74,6 +74,9 @@ configuration:
   sms_delivery_reports:
     name: Habilitar informes de entrega
     description: Solicitar informes de entrega para SMS enviados (puede generar cargos del operador)
+  multipart_timeout_seconds:
+    name: Multipart SMS Timeout
+    description: Seconds to wait for remaining parts of a multipart SMS before publishing partial text (0 = wait forever).
   balance_sms_enabled:
     name: Habilitar análisis de SMS de saldo
     description: Analizar automáticamente información de saldo de cuenta desde SMS del proveedor

--- a/addon-gsm-gateway/translations/fr.yaml
+++ b/addon-gsm-gateway/translations/fr.yaml
@@ -74,6 +74,9 @@ configuration:
   sms_delivery_reports:
     name: Activer les rapports de livraison
     description: Demander des rapports de livraison pour les SMS envoyés (peut entraîner des frais)
+  multipart_timeout_seconds:
+    name: Multipart SMS Timeout
+    description: Seconds to wait for remaining parts of a multipart SMS before publishing partial text (0 = wait forever).
   balance_sms_enabled:
     name: Activer l'analyse des SMS de solde
     description: Analyser automatiquement les informations de solde de compte depuis les SMS du fournisseur

--- a/addon-gsm-gateway/translations/it.yaml
+++ b/addon-gsm-gateway/translations/it.yaml
@@ -74,6 +74,9 @@ configuration:
   sms_delivery_reports:
     name: Abilita rapporti di consegna
     description: Richiedi rapporti di consegna per SMS inviati (può comportare costi dell'operatore)
+  multipart_timeout_seconds:
+    name: Multipart SMS Timeout
+    description: Seconds to wait for remaining parts of a multipart SMS before publishing partial text (0 = wait forever).
   balance_sms_enabled:
     name: Abilita analisi SMS saldo
     description: Analizza automaticamente le informazioni sul saldo dell'account dagli SMS del provider

--- a/addon-gsm-gateway/translations/nl.yaml
+++ b/addon-gsm-gateway/translations/nl.yaml
@@ -74,6 +74,9 @@ configuration:
   sms_delivery_reports:
     name: Bezorgingsrapporten inschakelen
     description: Bezorgingsrapporten aanvragen voor verzonden SMS (kan kosten met zich meebrengen)
+  multipart_timeout_seconds:
+    name: Multipart SMS Timeout
+    description: Seconds to wait for remaining parts of a multipart SMS before publishing partial text (0 = wait forever).
   balance_sms_enabled:
     name: Saldo SMS-analyse inschakelen
     description: Rekeningsaldo-informatie automatisch analyseren uit provider SMS-berichten

--- a/addon-gsm-gateway/translations/pl.yaml
+++ b/addon-gsm-gateway/translations/pl.yaml
@@ -74,6 +74,9 @@ configuration:
   sms_delivery_reports:
     name: Włącz raporty dostarczenia
     description: Żądaj raportów dostarczenia dla wysłanych SMS (może generować opłaty operatora)
+  multipart_timeout_seconds:
+    name: Multipart SMS Timeout
+    description: Seconds to wait for remaining parts of a multipart SMS before publishing partial text (0 = wait forever).
   balance_sms_enabled:
     name: Włącz analizę SMS salda
     description: Automatyczna analiza informacji o saldzie konta z SMS dostawcy

--- a/addon-gsm-gateway/translations/pt.yaml
+++ b/addon-gsm-gateway/translations/pt.yaml
@@ -74,6 +74,9 @@ configuration:
   sms_delivery_reports:
     name: Ativar relatórios de entrega
     description: Solicitar relatórios de entrega para SMS enviados (pode gerar cobranças da operadora)
+  multipart_timeout_seconds:
+    name: Multipart SMS Timeout
+    description: Seconds to wait for remaining parts of a multipart SMS before publishing partial text (0 = wait forever).
   balance_sms_enabled:
     name: Ativar análise de SMS de saldo
     description: Analisar automaticamente informações de saldo da conta a partir de SMS do provedor

--- a/addon-gsm-gateway/translations/sk.yaml
+++ b/addon-gsm-gateway/translations/sk.yaml
@@ -74,6 +74,9 @@ configuration:
   sms_delivery_reports:
     name: Povoliť potvrdenia o doručení
     description: Požadovať potvrdenia o doručení pre odoslané SMS (môže spôsobiť poplatky operátora)
+  multipart_timeout_seconds:
+    name: Multipart SMS Timeout
+    description: Seconds to wait for remaining parts of a multipart SMS before publishing partial text (0 = wait forever).
   balance_sms_enabled:
     name: Povoliť analýzu SMS zostatku
     description: Automaticky analyzovať informácie o zostatku účtu zo SMS poskytovateľa

--- a/addon-test-current/CHANGELOG.md
+++ b/addon-test-current/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## [2.20.0-test] - 2026-06-18
+
+### Added
+
+- **`multipart_timeout_seconds` option** (default: 30, range: 0–300)
+  - Publishes partial multipart SMS with `[partial X/Y]` prefix after timeout
+  - Auto-deletes timed-out parts from modem (if auto_delete_read_sms enabled)
+  - Unblocks modems that stop accepting new SMS while incomplete parts sit on the SIM
+  - Set to `0` to wait forever (previous behavior)
+
 ## [2.19.1-test] - 2026-06-18
 
 ### Fixed

--- a/addon-test-current/DOCS.md
+++ b/addon-test-current/DOCS.md
@@ -129,32 +129,33 @@ curl -X POST http://192.168.1.x:5000/sms \
 
 ### MQTT Settings
 
-| Parameter                | Default                            | Description                                                                    |
-| ------------------------ | ---------------------------------- | ------------------------------------------------------------------------------ |
-| `mqtt_enabled`           | `true`                             | Enable MQTT integration                                                        |
-| `mqtt_host`              | `core-mosquitto`                   | MQTT broker hostname                                                           |
-| `mqtt_port`              | `1883`                             | MQTT broker port                                                               |
-| `mqtt_username`          | `""`                               | MQTT username (empty for no auth)                                              |
-| `mqtt_password`          | `""`                               | MQTT password (empty for no auth)                                              |
-| `mqtt_topic_prefix`      | `homeassistant/sensor/sms_gateway` | MQTT topic prefix                                                              |
+| Parameter                | Default                            | Description                                                                                 |
+| ------------------------ | ---------------------------------- | ------------------------------------------------------------------------------------------- |
+| `mqtt_enabled`           | `true`                             | Enable MQTT integration                                                                     |
+| `mqtt_host`              | `core-mosquitto`                   | MQTT broker hostname                                                                        |
+| `mqtt_port`              | `1883`                             | MQTT broker port                                                                            |
+| `mqtt_username`          | `""`                               | MQTT username (empty for no auth)                                                           |
+| `mqtt_password`          | `""`                               | MQTT password (empty for no auth)                                                           |
+| `mqtt_topic_prefix`      | `homeassistant/sensor/sms_gateway` | MQTT topic prefix                                                                           |
 | `mqtt_device_id`         | `sms_gateway`                      | Device identifier for multi-instance support (lowercase, numbers, underscores) (🆕 v2.19.0) |
-| `sms_monitoring_enabled` | `true`                             | Detect incoming SMS automatically                                              |
-| `sms_check_interval`     | `5`                                | SMS check interval (5-300 seconds) (🆕 v2.1.8: min reduced to 5s)              |
-| `status_update_interval` | `300`                              | Status update interval (30-3600 seconds) - signal & network (🆕 v2.1.8)        |
+| `sms_monitoring_enabled` | `true`                             | Detect incoming SMS automatically                                                           |
+| `sms_check_interval`     | `5`                                | SMS check interval (5-300 seconds) (🆕 v2.1.8: min reduced to 5s)                           |
+| `status_update_interval` | `300`                              | Status update interval (30-3600 seconds) - signal & network (🆕 v2.1.8)                     |
 
 ### SMS Management Settings
 
-| Parameter                  | Default | Description                                                         |
-| -------------------------- | ------- | ------------------------------------------------------------------- |
-| `sms_cost_per_message`     | `0.0`   | Price per SMS (0 = cost tracking disabled)                          |
-| `sms_cost_currency`        | `USD`   | Currency code (EUR, USD, CZK, GBP, etc.)                            |
-| `auto_delete_read_sms`     | `true`  | Auto-delete SMS after reading (frees SIM space)                     |
-| `sms_history_max_messages` | `10`    | Number of SMS to keep in history (1-100) (🆕 v2.1.0)                |
-| `sms_delivery_reports`     | `false` | Enable SMS delivery reports - may incur carrier charges (🆕 v2.1.0) |
-| `log_level`                | `info`  | Logging level: `warning`, `info`, or `debug` (🆕 v2.1.8)            |
-| `auto_recovery`            | `true`  | Automatically recover from modem failures (🆕 v2.4.0)               |
-| `auto_restart_on_failure`  | `true`  | Auto-restart addon after 2 min of persistent failure (🆕 v2.10.0)   |
-| `modem_operation_delay`    | `0.3`   | Delay between modem commands in seconds (0.1-5.0) (🆕 v2.12.0)      |
+| Parameter                   | Default | Description                                                                                                     |
+| --------------------------- | ------- | --------------------------------------------------------------------------------------------------------------- |
+| `sms_cost_per_message`      | `0.0`   | Price per SMS (0 = cost tracking disabled)                                                                      |
+| `sms_cost_currency`         | `USD`   | Currency code (EUR, USD, CZK, GBP, etc.)                                                                        |
+| `auto_delete_read_sms`      | `true`  | Auto-delete SMS after reading (frees SIM space)                                                                 |
+| `sms_history_max_messages`  | `10`    | Number of SMS to keep in history (1-100) (🆕 v2.1.0)                                                            |
+| `sms_delivery_reports`      | `false` | Enable SMS delivery reports - may incur carrier charges (🆕 v2.1.0)                                             |
+| `multipart_timeout_seconds` | `30`    | Seconds to wait for remaining multipart SMS parts before publishing partial text; 0 = wait forever (🆕 v2.20.0) |
+| `log_level`                 | `info`  | Logging level: `warning`, `info`, or `debug` (🆕 v2.1.8)                                                        |
+| `auto_recovery`             | `true`  | Automatically recover from modem failures (🆕 v2.4.0)                                                           |
+| `auto_restart_on_failure`   | `true`  | Auto-restart addon after 2 min of persistent failure (🆕 v2.10.0)                                               |
+| `modem_operation_delay`     | `0.3`   | Delay between modem commands in seconds (0.1-5.0) (🆕 v2.12.0)                                                  |
 
 ### Logging Levels (🆕 v2.1.8, Enhanced v2.2.1)
 

--- a/addon-test-current/README.md
+++ b/addon-test-current/README.md
@@ -141,27 +141,28 @@ This add-on provides an enhanced SMS gateway solution for Home Assistant with ad
 
 ### MQTT Settings
 
-| Option              | Default                            | Description                                                                    |
-| ------------------- | ---------------------------------- | ------------------------------------------------------------------------------ |
-| `mqtt_enabled`      | `true`                             | Enable MQTT integration                                                        |
-| `mqtt_host`         | `core-mosquitto`                   | MQTT broker hostname                                                           |
-| `mqtt_port`         | `1883`                             | MQTT broker port                                                               |
-| `mqtt_username`     | `""`                               | MQTT username (if required)                                                    |
-| `mqtt_password`     | `""`                               | MQTT password (if required)                                                    |
-| `mqtt_topic_prefix` | `homeassistant/sensor/sms_gateway` | MQTT topic prefix                                                              |
+| Option              | Default                            | Description                                                                                 |
+| ------------------- | ---------------------------------- | ------------------------------------------------------------------------------------------- |
+| `mqtt_enabled`      | `true`                             | Enable MQTT integration                                                                     |
+| `mqtt_host`         | `core-mosquitto`                   | MQTT broker hostname                                                                        |
+| `mqtt_port`         | `1883`                             | MQTT broker port                                                                            |
+| `mqtt_username`     | `""`                               | MQTT username (if required)                                                                 |
+| `mqtt_password`     | `""`                               | MQTT password (if required)                                                                 |
+| `mqtt_topic_prefix` | `homeassistant/sensor/sms_gateway` | MQTT topic prefix                                                                           |
 | `mqtt_device_id`    | `sms_gateway`                      | Device identifier for multi-instance support (lowercase, numbers, underscores) (🆕 v2.19.0) |
 
 ### SMS Settings
 
-| Option                     | Default | Description                                             |
-| -------------------------- | ------- | ------------------------------------------------------- |
-| `sms_monitoring_enabled`   | `true`  | Enable SMS monitoring                                   |
-| `sms_check_interval`       | `10`    | Check for new SMS every X seconds                       |
-| `auto_delete_read_sms`     | `true`  | Auto-delete SMS after reading                           |
-| `sms_history_max_messages` | `10`    | Number of SMS to keep in history (1-100)                |
-| `sms_delivery_reports`     | `false` | Enable SMS delivery reports (may incur carrier charges) |
-| `sms_cost_per_message`     | `0.0`   | Cost per SMS (0 = disabled)                             |
-| `sms_cost_currency`        | `USD`   | Currency for cost tracking                              |
+| Option                      | Default | Description                                             |
+| --------------------------- | ------- | ------------------------------------------------------- |
+| `sms_monitoring_enabled`    | `true`  | Enable SMS monitoring                                   |
+| `sms_check_interval`        | `10`    | Check for new SMS every X seconds                       |
+| `auto_delete_read_sms`      | `true`  | Auto-delete SMS after reading                           |
+| `sms_history_max_messages`  | `10`    | Number of SMS to keep in history (1-100)                |
+| `sms_delivery_reports`      | `false` | Enable SMS delivery reports (may incur carrier charges) |
+| `multipart_timeout_seconds` | `30`    | Timeout for incomplete multipart SMS (0 = wait forever) |
+| `sms_cost_per_message`      | `0.0`   | Cost per SMS (0 = disabled)                             |
+| `sms_cost_currency`         | `USD`   | Currency for cost tracking                              |
 
 ### Device Path Options
 

--- a/addon-test-current/config.yaml
+++ b/addon-test-current/config.yaml
@@ -1,5 +1,5 @@
 name: "TEST - GSM SMS Gateway (Current Development)"
-version: 2.19.1-test
+version: 2.20.0-test
 slug: "gsm_sms_gateway_test_current"
 description: |
   🧪 TEST VERSION - Current development build for experimentation (v2.15.0-test)

--- a/addon-test-current/config.yaml
+++ b/addon-test-current/config.yaml
@@ -80,6 +80,7 @@ options:
   auto_delete_read_sms: true
   sms_history_max_messages: 10
   sms_delivery_reports: false
+  multipart_timeout_seconds: 30
   log_level: "info"
   auto_recovery: true
   auto_restart_on_failure: true
@@ -125,6 +126,7 @@ schema:
   auto_delete_read_sms: bool
   sms_history_max_messages: int(1,100)
   sms_delivery_reports: bool
+  multipart_timeout_seconds: int(0,300)
   log_level: list(warning|info|debug)
   auto_recovery: bool
   auto_restart_on_failure: bool

--- a/addon-test-current/mqtt_publisher.py
+++ b/addon-test-current/mqtt_publisher.py
@@ -3722,8 +3722,10 @@ class MQTTPublisher:
             last_sms_count = 0
             first_run = True
             # Track incomplete multipart SMS waiting for remaining parts.
-            # Key: (Number, Date) tuple, Value: parts seen so far.
+            # Key: (Number, Date) tuple
+            # Value: {"parts": count, "first_seen": time.time()}
             pending_incomplete = {}
+            multipart_timeout = int(self.config.get("multipart_timeout_seconds", 30))
 
             while self.connected and not self.disconnecting:
                 from support import deleteSms, retrieveAllSms
@@ -3843,25 +3845,50 @@ class MQTTPublisher:
                     continue
 
                 try:
-                    # Re-check previously incomplete multipart SMS for completeness.
-                    # Parts may arrive between polls without changing len(all_sms).
+                    # Re-check previously incomplete multipart SMS for completeness
+                    # or timeout. Parts may arrive between polls without changing
+                    # len(all_sms).
                     just_completed_keys = set()
                     recheck_deleted = 0
                     if pending_incomplete and all_sms:
                         for sms in all_sms:
                             key = (sms.get("Number"), sms.get("Date"))
-                            if key in pending_incomplete and sms.get("Complete", True):
-                                # Previously incomplete, now all parts arrived
+                            if key not in pending_incomplete:
+                                continue
+
+                            now_complete = sms.get("Complete", True)
+                            elapsed = (
+                                time.time() - pending_incomplete[key]["first_seen"]
+                            )
+                            timed_out = (
+                                multipart_timeout > 0 and elapsed >= multipart_timeout
+                            )
+
+                            if now_complete or timed_out:
+                                # Publish: either all parts arrived, or timeout
                                 pending_incomplete.pop(key, None)
                                 just_completed_keys.add(key)
                                 sms_copy = sms.copy()
                                 sms_copy.pop("Locations", None)
+                                if timed_out and not now_complete:
+                                    sms_copy["Text"] = (
+                                        f"[partial {sms.get('PartsReceived', '?')}"
+                                        f"/{sms.get('PartsExpected', '?')}] "
+                                        + sms_copy.get("Text", "")
+                                    )
+                                    logger.warning(
+                                        f"⏰ Multipart SMS from {sms.get('Number', 'Unknown')} "
+                                        f"timed out after {int(elapsed)}s "
+                                        f"({sms.get('PartsReceived')}/{sms.get('PartsExpected')} parts) "
+                                        f"- publishing partial text"
+                                    )
+                                else:
+                                    logger.info(
+                                        f"✅ Multipart SMS from {sms.get('Number', 'Unknown')} "
+                                        f"now complete ({sms.get('PartsExpected', '?')} parts), published"
+                                    )
                                 self.publish_sms_received(sms_copy)
-                                logger.info(
-                                    f"✅ Multipart SMS from {sms.get('Number', 'Unknown')} "
-                                    f"now complete ({sms.get('PartsExpected', '?')} parts), published"
-                                )
-                                # Auto-delete if enabled
+                                # Auto-delete if enabled (frees modem for next delivery)
                                 if self.config.get("auto_delete_read_sms", False):
                                     try:
                                         self.track_gammu_operation(
@@ -3872,11 +3899,12 @@ class MQTTPublisher:
                                         )
                                         recheck_deleted += 1
                                         logger.info(
-                                            f"🗑️ Auto-deleted completed multipart SMS from {sms.get('Number', 'Unknown')}"
+                                            f"🗑️ Auto-deleted {'partial' if timed_out else 'completed'} "
+                                            f"multipart SMS from {sms.get('Number', 'Unknown')}"
                                         )
                                     except Exception as e:
                                         logger.error(
-                                            f"Error auto-deleting completed multipart SMS: {e}"
+                                            f"Error auto-deleting multipart SMS: {e}"
                                         )
 
                     # After re-check deletes, current_count is stale (based on
@@ -3973,9 +4001,10 @@ class MQTTPublisher:
                                 # Skip incomplete multipart SMS — track and wait
                                 if not sms.get("Complete", True):
                                     key = (sms.get("Number"), sms.get("Date"))
-                                    pending_incomplete[key] = sms.get(
-                                        "PartsReceived", 1
-                                    )
+                                    pending_incomplete[key] = {
+                                        "parts": sms.get("PartsReceived", 1),
+                                        "first_seen": time.time(),
+                                    }
                                     logger.info(
                                         f"⏳ Incomplete multipart SMS from "
                                         f"{sms.get('Number', 'Unknown')} "
@@ -4089,9 +4118,10 @@ class MQTTPublisher:
                                         all_sms[i].get("Date"),
                                     )
                                     if key not in just_completed_keys:
-                                        pending_incomplete[key] = all_sms[i].get(
-                                            "PartsReceived", 1
-                                        )
+                                        pending_incomplete[key] = {
+                                            "parts": all_sms[i].get("PartsReceived", 1),
+                                            "first_seen": time.time(),
+                                        }
                                         logger.info(
                                             f"⏳ Incomplete multipart SMS from "
                                             f"{all_sms[i].get('Number', 'Unknown')} "

--- a/addon-test-current/translations/cs.yaml
+++ b/addon-test-current/translations/cs.yaml
@@ -74,6 +74,9 @@ configuration:
   sms_delivery_reports:
     name: Povolit potvrzení o doručení
     description: Požadovat potvrzení o doručení pro odeslané SMS (může způsobit poplatky operátora)
+  multipart_timeout_seconds:
+    name: Multipart SMS Timeout
+    description: Seconds to wait for remaining parts of a multipart SMS before publishing partial text (0 = wait forever).
   balance_sms_enabled:
     name: Povolit analýzu SMS zůstatku
     description: Automaticky analyzovat informace o zůstatku účtu ze SMS poskytovatele

--- a/addon-test-current/translations/de.yaml
+++ b/addon-test-current/translations/de.yaml
@@ -74,6 +74,9 @@ configuration:
   sms_delivery_reports:
     name: SMS-Zustellberichte aktivieren
     description: Zustellberichte für gesendete SMS anfordern (kann Gebühren verursachen)
+  multipart_timeout_seconds:
+    name: Multipart SMS Timeout
+    description: Seconds to wait for remaining parts of a multipart SMS before publishing partial text (0 = wait forever).
   balance_sms_enabled:
     name: Balance SMS-Analyse aktivieren
     description: Kontoguthaben-Informationen aus Provider-SMS automatisch analysieren

--- a/addon-test-current/translations/en.yaml
+++ b/addon-test-current/translations/en.yaml
@@ -80,6 +80,9 @@ configuration:
   sms_delivery_reports:
     name: Enable SMS Delivery Reports
     description: Request delivery reports for sent SMS (may incur carrier charges)
+  multipart_timeout_seconds:
+    name: Multipart SMS Timeout
+    description: Seconds to wait for remaining parts of a multipart SMS before publishing partial text (0 = wait forever). Helps with modems that stop delivering parts when unread SMS sit on the SIM.
   balance_sms_enabled:
     name: Enable Balance SMS Parsing
     description: Automatically parse account balance information from provider SMS messages

--- a/addon-test-current/translations/es.yaml
+++ b/addon-test-current/translations/es.yaml
@@ -74,6 +74,9 @@ configuration:
   sms_delivery_reports:
     name: Habilitar informes de entrega
     description: Solicitar informes de entrega para SMS enviados (puede generar cargos del operador)
+  multipart_timeout_seconds:
+    name: Multipart SMS Timeout
+    description: Seconds to wait for remaining parts of a multipart SMS before publishing partial text (0 = wait forever).
   balance_sms_enabled:
     name: Habilitar análisis de SMS de saldo
     description: Analizar automáticamente información de saldo de cuenta desde SMS del proveedor

--- a/addon-test-current/translations/fr.yaml
+++ b/addon-test-current/translations/fr.yaml
@@ -74,6 +74,9 @@ configuration:
   sms_delivery_reports:
     name: Activer les rapports de livraison
     description: Demander des rapports de livraison pour les SMS envoyés (peut entraîner des frais)
+  multipart_timeout_seconds:
+    name: Multipart SMS Timeout
+    description: Seconds to wait for remaining parts of a multipart SMS before publishing partial text (0 = wait forever).
   balance_sms_enabled:
     name: Activer l'analyse des SMS de solde
     description: Analyser automatiquement les informations de solde de compte depuis les SMS du fournisseur

--- a/addon-test-current/translations/it.yaml
+++ b/addon-test-current/translations/it.yaml
@@ -74,6 +74,9 @@ configuration:
   sms_delivery_reports:
     name: Abilita rapporti di consegna
     description: Richiedi rapporti di consegna per SMS inviati (può comportare costi dell'operatore)
+  multipart_timeout_seconds:
+    name: Multipart SMS Timeout
+    description: Seconds to wait for remaining parts of a multipart SMS before publishing partial text (0 = wait forever).
   balance_sms_enabled:
     name: Abilita analisi SMS saldo
     description: Analizza automaticamente le informazioni sul saldo dell'account dagli SMS del provider

--- a/addon-test-current/translations/nl.yaml
+++ b/addon-test-current/translations/nl.yaml
@@ -74,6 +74,9 @@ configuration:
   sms_delivery_reports:
     name: Bezorgingsrapporten inschakelen
     description: Bezorgingsrapporten aanvragen voor verzonden SMS (kan kosten met zich meebrengen)
+  multipart_timeout_seconds:
+    name: Multipart SMS Timeout
+    description: Seconds to wait for remaining parts of a multipart SMS before publishing partial text (0 = wait forever).
   balance_sms_enabled:
     name: Saldo SMS-analyse inschakelen
     description: Rekeningsaldo-informatie automatisch analyseren uit provider SMS-berichten

--- a/addon-test-current/translations/pl.yaml
+++ b/addon-test-current/translations/pl.yaml
@@ -74,6 +74,9 @@ configuration:
   sms_delivery_reports:
     name: Włącz raporty dostarczenia
     description: Żądaj raportów dostarczenia dla wysłanych SMS (może generować opłaty operatora)
+  multipart_timeout_seconds:
+    name: Multipart SMS Timeout
+    description: Seconds to wait for remaining parts of a multipart SMS before publishing partial text (0 = wait forever).
   balance_sms_enabled:
     name: Włącz analizę SMS salda
     description: Automatyczna analiza informacji o saldzie konta z SMS dostawcy

--- a/addon-test-current/translations/pt.yaml
+++ b/addon-test-current/translations/pt.yaml
@@ -74,6 +74,9 @@ configuration:
   sms_delivery_reports:
     name: Ativar relatórios de entrega
     description: Solicitar relatórios de entrega para SMS enviados (pode gerar cobranças da operadora)
+  multipart_timeout_seconds:
+    name: Multipart SMS Timeout
+    description: Seconds to wait for remaining parts of a multipart SMS before publishing partial text (0 = wait forever).
   balance_sms_enabled:
     name: Ativar análise de SMS de saldo
     description: Analisar automaticamente informações de saldo da conta a partir de SMS do provedor

--- a/addon-test-current/translations/sk.yaml
+++ b/addon-test-current/translations/sk.yaml
@@ -74,6 +74,9 @@ configuration:
   sms_delivery_reports:
     name: Povoliť potvrdenia o doručení
     description: Požadovať potvrdenia o doručení pre odoslané SMS (môže spôsobiť poplatky operátora)
+  multipart_timeout_seconds:
+    name: Multipart SMS Timeout
+    description: Seconds to wait for remaining parts of a multipart SMS before publishing partial text (0 = wait forever).
   balance_sms_enabled:
     name: Povoliť analýzu SMS zostatku
     description: Automaticky analyzovať informácie o zostatku účtu zo SMS poskytovateľa


### PR DESCRIPTION
## Summary

Related to #111 — adds a configurable timeout for incomplete multipart SMS.

### Problem

When a modem/carrier fails to deliver all parts of a multipart SMS, the incomplete message sits on the SIM indefinitely. Some modems (SIM7600G-H, Huawei E1550) stop accepting new multipart SMS deliveries while unread parts occupy SIM slots.

### Solution

New config option: `multipart_timeout_seconds` (default: 30, range: 0-300)

After the timeout expires with no new parts arriving:
1. Publishes the partial message with a `[partial X/Y]` prefix
2. Auto-deletes from modem (if auto_delete_read_sms enabled)
3. Frees the modem to accept new SMS deliveries

Set to `0` to wait forever (previous behavior).

### Changes

- `mqtt_publisher.py`: `pending_incomplete` value now stores `{parts, first_seen}` timestamp; re-check block handles timeout alongside completion
- `config.yaml`: New `multipart_timeout_seconds` option + schema
- `translations/en.yaml`: Label and description for new option

Both addons updated.